### PR TITLE
PP-1483 Migration to populate new model

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/persistence/dao/ServiceDao.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/dao/ServiceDao.java
@@ -1,0 +1,35 @@
+package uk.gov.pay.adminusers.persistence.dao;
+
+import com.google.inject.Provider;
+import com.google.inject.persist.Transactional;
+import uk.gov.pay.adminusers.persistence.entity.GatewayAccountEntity;
+import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import java.util.Optional;
+
+@Transactional
+public class ServiceDao extends JpaDao<ServiceEntity> {
+
+    @Inject
+    public ServiceDao(Provider<EntityManager> entityManager) {
+        super(entityManager, ServiceEntity.class);
+    }
+
+    public Optional<ServiceEntity> findByGatewayAccountId(String gatewayAccountId) {
+
+        String query = "SELECT ga FROM GatewayAccountEntity ga " +
+                "WHERE ga.gatewayAccountId = :gatewayAccountId";
+
+        Optional<GatewayAccountEntity> gatewayAccount = entityManager.get()
+                .createQuery(query, GatewayAccountEntity.class)
+                .setParameter("gatewayAccountId", gatewayAccountId)
+                .getResultList().stream().findFirst();
+
+        if (gatewayAccount.isPresent()) {
+            return Optional.of(gatewayAccount.get().getService());
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/GatewayAccountEntity.java
@@ -1,0 +1,52 @@
+package uk.gov.pay.adminusers.persistence.entity;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "service_gateway_accounts")
+@SequenceGenerator(name = "service_gatewayAccounts_seq_gen", sequenceName = "service_gateway_accounts_id_seq", allocationSize = 1)
+public class GatewayAccountEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "service_gatewayAccounts_seq_gen")
+    private Long id;
+
+    @Column(name = "gateway_account_id")
+    private String gatewayAccountId;
+
+    @ManyToOne(fetch= FetchType.LAZY)
+    @JoinColumn(name = "service_id")
+    private ServiceEntity service;
+
+    public GatewayAccountEntity() {
+    }
+
+    public GatewayAccountEntity(String gatewayAccountId, ServiceEntity service) {
+        this.gatewayAccountId = gatewayAccountId;
+        this.service = service;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getGatewayAccountId() {
+        return gatewayAccountId;
+    }
+
+    public void setGatewayAccountId(String gatewayAccountId) {
+        this.gatewayAccountId = gatewayAccountId;
+    }
+
+    public ServiceEntity getService() {
+        return service;
+    }
+
+    public void setService(ServiceEntity service) {
+        this.service = service;
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
@@ -1,0 +1,38 @@
+package uk.gov.pay.adminusers.persistence.entity;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "services")
+@SequenceGenerator(name = "services_seq_gen", sequenceName = "services_id_seq", allocationSize = 1)
+public class ServiceEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "services_seq_gen")
+    private Long id;
+
+    @OneToMany(mappedBy = "service", targetEntity = GatewayAccountEntity.class, fetch = FetchType.EAGER, cascade = CascadeType.PERSIST)
+    private List<GatewayAccountEntity> gatewayAccounts = new ArrayList<>();
+
+    public ServiceEntity() {
+    }
+
+    public ServiceEntity(String gatewayAccountId) {
+        this.gatewayAccounts.clear();
+        this.gatewayAccounts.add(new GatewayAccountEntity(gatewayAccountId, this));
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public GatewayAccountEntity getGatewayAccount() {
+        return gatewayAccounts.get(0);
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
@@ -45,6 +45,11 @@ public class UserEntity extends AbstractEntity {
             inverseJoinColumns = @JoinColumn(name = "role_id", referencedColumnName = "id"))
     private List<RoleEntity> roles = new ArrayList<>();
 
+    @ManyToMany(fetch = FetchType.LAZY, targetEntity = ServiceEntity.class)
+    @JoinTable(name = "users_services", joinColumns = @JoinColumn(name = "user_id", referencedColumnName = "id"),
+            inverseJoinColumns = @JoinColumn(name = "service_id", referencedColumnName = "id"))
+    private List<ServiceEntity> services = new ArrayList<>();
+
     // TODO: Change column from 'camelCase' to 'snake_case'. These columns were created through Sequelize.
     @Column(name = "\"createdAt\"")
     @Convert(converter = UTCDateTimeConverter.class)
@@ -188,5 +193,14 @@ public class UserEntity extends AbstractEntity {
         user.setSessionVersion(sessionVersion);
         user.setRoles(roles.stream().map(roleEntity -> roleEntity.toRole()).collect(Collectors.toList()));
         return user;
+    }
+
+    public void setService(ServiceEntity service) {
+        this.services.clear();
+        this.services.add(service);
+    }
+
+    public ServiceEntity getService(){
+        return services.get(0);
     }
 }

--- a/src/main/resources/migrations/00004_update_table_services.sql
+++ b/src/main/resources/migrations/00004_update_table_services.sql
@@ -16,7 +16,7 @@ BEGIN
         'WHERE gateway_account_id = $1') INTO serviceGatewayAccount USING gatewayAccountId;
       IF serviceGatewayAccount IS NULL
       THEN
-        EXECUTE format('INSERT INTO services values(default)');
+        EXECUTE 'INSERT INTO services values(default)';
         SELECT currval('services_id_seq') INTO service;
         INSERT INTO service_gateway_accounts (service_id, gateway_account_id) VALUES (service.currval, gatewayAccountId);
         INSERT INTO users_services (user_id, service_id) VALUES (userId, service.currval);

--- a/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
@@ -154,7 +154,7 @@ public class DatabaseTestHelper {
     }
 
     //TODO Remove - This is temporary - WIP PP-1483
-    public List<Map<String, Object>> findUserServicesByUserId(long userId) {
+    public List<Map<String, Object>> findUserServicesByUserId(Integer userId) {
         return jdbi.withHandle(h ->
                 h.createQuery("SELECT service_id FROM users_services " +
                         "WHERE user_id = :userId")
@@ -162,11 +162,31 @@ public class DatabaseTestHelper {
                         .list());
     }
 
-    public List<Map<String, Object>> findGatewayAccountsByService(long serviceId) {
+    public List<Map<String, Object>> findGatewayAccountsByService(Long serviceId) {
         return jdbi.withHandle(h ->
                 h.createQuery("SELECT gateway_account_id FROM service_gateway_accounts " +
                         "WHERE service_id = :serviceId")
                         .bind("serviceId", serviceId)
                         .list());
+    }
+
+    public DatabaseTestHelper addService(Long serviceId, String gatewayAccountId) {
+
+        jdbi.withHandle(handle ->
+                handle
+                        .createStatement("INSERT INTO services(id) " +
+                                "VALUES (:id)")
+                        .bind("id", serviceId)
+                        .execute()
+        );
+
+        jdbi.withHandle(handle ->
+                handle.createStatement("INSERT INTO service_gateway_accounts(service_id, gateway_account_id) VALUES (:serviceId, :gatewayAccountId)")
+                        .bind("serviceId", serviceId)
+                        .bind("gatewayAccountId", gatewayAccountId)
+                        .execute()
+        );
+
+        return this;
     }
 }


### PR DESCRIPTION
## WHAT
- **Users gateway accounts migration.** Create Postgres FUNCTION that does the following:
  1. Read from **users** table pairs (**id**, **gateway_account_id**).
  2. For each one of them, inspect **service_gateway_accounts** to see if that gateway account already exists associated to an user.
  3. Since a gateway account can only exist (if exist) for one service, then extract this service and associate this to the given user (**users_services** table).
  4. If the gateway account is not associated to a service then, create a new service and associate this to the gateway account and the given user.

- **After users migration** we need to save the new created users into the existing new model too.
  - Add the relevant mapping and force 'one to one' mapping in code at the moment (since currently user - gateway account is one to one).
  - Then user will be related to a single service therefore is related to a single gateway account, but two different users can be related to the same service (since two different users can be associated to the same gateway account).

## HOW
- Insert a random number of users, each one with a **gateway_account_id** that can be for several users.
- Log in into the _selfservice_ db with user _adminuser_.
- Run `select id as user_id, gateway_account_id from users order by id;`
- After the migration, running `select users_services.user_id, service_gateway_accounts.gateway_account_id from users_services, service_gateway_accounts where users_services.service_id = service_gateway_accounts.service_id order by users_services.user_id;` should return exactly the same results as the previous query. 
         