### PR TITLE
PP-1479 fix login attempt behaviour difference in second factor login

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
@@ -135,7 +135,11 @@ public class UserServices {
         return userDao.findByUsername(username)
                 .map(userEntity -> {
                     userEntity.setLoginCounter(userEntity.getLoginCounter() + 1);
-                    userEntity.setDisabled(userEntity.getLoginCounter() >= loginAttemptCap);
+                    //NOTE: the reason for this check is different to authenticate method above, is due to the way selfservice
+                    // is wired up. Currently increment login count is called before the second factor check,
+                    // whereas on username/password (first factor) it the increment happens afterwards.
+                    // FIXME: when we migrate the ToTp login to adminusers
+                    userEntity.setDisabled(userEntity.getLoginCounter() > loginAttemptCap);
                     userEntity.setUpdatedAt(ZonedDateTime.now(ZoneId.of("UTC")));
                     userDao.merge(userEntity);
                     return Optional.of(linksBuilder.decorate(userEntity.toUser()));

--- a/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
@@ -143,7 +143,7 @@ public class UserServicesTest {
     @Test
     public void shouldLockUser_onTooManyAuthFailures() throws Exception {
         User user = aUser();
-        user.setLoginCounter(3);
+        user.setLoginCounter(2);
         UserEntity userEntity = UserEntity.from(user);
         userEntity.setPassword("hashed-password");
 
@@ -155,7 +155,7 @@ public class UserServicesTest {
         userServices.authenticate("random-name", "random-password");
         UserEntity savedUser = argumentCaptor.getValue();
         assertTrue(within(3, SECONDS, savedUser.getCreatedAt()).matches(savedUser.getUpdatedAt()));
-        assertThat(savedUser.getLoginCounter(), is(4));
+        assertThat(savedUser.getLoginCounter(), is(3));
         assertThat(savedUser.isDisabled(), is(true));
 
     }
@@ -215,6 +215,7 @@ public class UserServicesTest {
         UserEntity savedUser = argumentCaptor.getValue();
         assertTrue(within(3, SECONDS, savedUser.getCreatedAt()).matches(savedUser.getUpdatedAt()));
         assertThat(savedUser.getLoginCounter(), is(4));
+        assertThat(savedUser.isDisabled(), is(true));
 
     }
 


### PR DESCRIPTION
Changed the way how the no of attempts limit is checked in the 2 factors.

The reason for this check is different to authenticate method, is due to the way selfservice is wired up. Currently increment login count is called before the second factor check, whereas on username/password (first factor) it the increment happens afterwards.

We need to fix this when we migrate the ToTp login to adminusers