### PR TITLE
PP-1469 Consolidate tokens permissions

### DIFF
--- a/src/main/resources/migrations/00005_create_new_token_permission.sql
+++ b/src/main/resources/migrations/00005_create_new_token_permission.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:insert_tokens_read_permission
+INSERT INTO  permissions(id, name, description) VALUES (29, 'tokens:read', 'View keys');
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'super-admin'), (SELECT id FROM permissions  WHERE name = 'tokens:read'), NOW(), NOW());
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'admin'), (SELECT id FROM permissions  WHERE name = 'tokens:read'), NOW(), NOW());

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/RoleDaoTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/RoleDaoTest.java
@@ -59,7 +59,7 @@ public class RoleDaoTest extends DaoTestBase {
         assertTrue(adminRoleOptional.isPresent());
         RoleEntity adminRoleEntity = adminRoleOptional.get();
 
-        assertThat(adminRoleEntity.getPermissions().size(),is(27));
+        assertThat(adminRoleEntity.getPermissions().size(),is(28));
     }
 
 }

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationTest.java
@@ -38,7 +38,7 @@ public class UserResourceAuthenticationTest extends UserResourceTestBase {
                 .body("disabled", is(false))
                 .body("_links", hasSize(1))
                 .body("role.name", is("admin"))
-                .body("permissions", hasSize(27)); //we could consider removing this assertion if the permissions constantly changing
+                .body("permissions", hasSize(28)); //we could consider removing this assertion if the permissions constantly changing
 
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateAndGetTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateAndGetTest.java
@@ -53,7 +53,7 @@ public class UserResourceCreateAndGetTest extends UserResourceTestBase {
                 .body("_links[0].rel", is("self"))
                 .body("role.name", is("admin"))
                 .body("role.description", is("Administrator"))
-                .body("permissions", hasSize(27)); //we could consider removing this assertion if the permissions constantly changing
+                .body("permissions", hasSize(28)); //we could consider removing this assertion if the permissions constantly changing
 
         //TODO - WIP PP-1483 This will be amended when the story is done.
         // This is an extra check to verify that new created user gateways are registered withing the new Services Model as well as in users table
@@ -230,7 +230,7 @@ public class UserResourceCreateAndGetTest extends UserResourceTestBase {
                 .body("_links[0].rel", is("self"))
                 .body("role.name", is("admin"))
                 .body("role.description", is("Administrator"))
-                .body("permissions", hasSize(27)); //we could consider removing this assertion if the permissions constantly changing
+                .body("permissions", hasSize(28)); //we could consider removing this assertion if the permissions constantly changing
 
 
     }


### PR DESCRIPTION
We had two permissions around reading tokens:
`tokens-revoked:read` and `tokens-active:read`

We only really need `tokens:read`.

This does necessary migrations.