### PR TITLE
PP-1651 remove check during initial db migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ The GOV.UK Pay Admin Users Module in Java (Dropwizard)
 
 `BASE_URL`:  This is the publicly visible URL for the pay admin users root. Defaults to http://localhost:8080 if not set.
 
-`INITIAL_MIGRATION_REQUIRED`: Defaults to false. Must set to `true` for an environment where you bring up adminusers connecting to a empty database. 
-
 `DB_USER`: database username for adminusers DB. 
 `DB_PASSWORD`: database password for adminusers DB.
  

--- a/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersConfig.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersConfig.java
@@ -25,9 +25,6 @@ public class AdminUsersConfig extends Configuration{
     private String baseUrl;
 
     @NotNull
-    private String initialMigrationRequired;
-
-    @NotNull
     private Integer loginAttemptCap;
 
     @JsonProperty("database")
@@ -50,10 +47,6 @@ public class AdminUsersConfig extends Configuration{
 
     public String getBaseUrl() {
         return baseUrl;
-    }
-
-    public boolean getInitialMigrationRequired() {
-        return initialMigrationRequired.equalsIgnoreCase("true") ;
     }
 
     public Integer getLoginAttemptCap() {

--- a/src/main/java/uk/gov/pay/adminusers/app/healthchecks/MigrateToInitialDbState.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/healthchecks/MigrateToInitialDbState.java
@@ -23,12 +23,6 @@ public class MigrateToInitialDbState extends ConfiguredCommand<AdminUsersConfig>
 
     @Override
     protected void run(Bootstrap<AdminUsersConfig> bootstrap, Namespace namespace, AdminUsersConfig configuration) throws Exception {
-        if (!configuration.getInitialMigrationRequired()) {
-            logger.info("Environment specified as not required for the initial database migration");
-            return;
-        }
-
-        logger.info("Environment specified as required for the initial database migration. Checking if migration is required");
         Connection connection = null;
         try {
             connection = getDatabaseConnection(configuration);

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -61,7 +61,3 @@ graphitePort: ${METRICS_PORT:-8092}
 baseUrl: ${BASE_URL:-http://localhost:8080}
 
 loginAttemptCap: ${LOGIN_ATTEMPT_CAP:-10}
-
-# Keep this property to default false. If you need to perform the initial migration, override through ENV variable or pay-scripts/services/adminusers.env
-# This is because in production/AWS environments this migration is not required, the only use cases required are DEV environments and any new AWS environment
-initialMigrationRequired: ${INITIAL_MIGRATION_REQUIRED:-false}

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/RoleDaoTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/RoleDaoTest.java
@@ -47,19 +47,4 @@ public class RoleDaoTest extends DaoTestBase {
 
     }
 
-    /**
-     * This is just to confirm the initial data migrations have happened.
-     * perhaps we can consider to remove this if its doesn't serve a purpose.
-     * @throws Exception
-     */
-    @Test
-    public void shouldFindAnExistingRole() throws Exception {
-        Optional<RoleEntity> adminRoleOptional = roleDao.findByRoleName("admin");
-
-        assertTrue(adminRoleOptional.isPresent());
-        RoleEntity adminRoleEntity = adminRoleOptional.get();
-
-        assertThat(adminRoleEntity.getPermissions().size(),is(28));
-    }
-
 }

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -60,4 +60,3 @@ graphitePort: ${METRICS_PORT:-8092}
 
 baseUrl: ${BASE_URL:-http://localhost:8080}
 loginAttemptCap: ${LOGIN_ATTEMPT_CAP:-10}
-initialMigrationRequired: ${INITIAL_MIGRATION_REQUIRED:-true}


### PR DESCRIPTION
This check was in place as a safety net for dev environments. No longer needs this check as the secondary check is now intelligent enough to perform initial migration safely in all environments. (by checking if USER table exists)