### PR TITLE
pp-1675 - Notify integration via proxy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         <dependency>
             <groupId>uk.gov.service.notify</groupId>
             <artifactId>notifications-java-client</artifactId>
-            <version>2.0.0-RELEASE</version>
+            <version>2.2.1-RELEASE</version>
         </dependency>
 
         <!-- testing -->

--- a/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersConfig.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersConfig.java
@@ -46,6 +46,14 @@ public class AdminUsersConfig extends Configuration {
     @NotNull
     private Integer timeStepsInSeconds;
 
+    @NotNull
+    private  ProxyConfiguration proxyConfiguration;
+
+    @JsonProperty("proxy")
+    public ProxyConfiguration getProxyConfiguration() {
+        return proxyConfiguration;
+    }
+
     public DataSourceFactory getDataSourceFactory() {
         //temporary switch to check if adminusers database exists and can be used
         if (shouldUseAdminUsersDatasource(getNewDataSourceFactory())) {

--- a/src/main/java/uk/gov/pay/adminusers/app/config/ProxyConfiguration.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/ProxyConfiguration.java
@@ -1,0 +1,22 @@
+package uk.gov.pay.adminusers.app.config;
+
+import io.dropwizard.Configuration;
+
+import javax.validation.constraints.NotNull;
+
+public class ProxyConfiguration extends Configuration{
+
+    @NotNull
+    private String host;
+
+    @NotNull
+    private Integer port;
+
+    public String getHost() {
+        return host;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -88,6 +88,10 @@ jpa:
   queryResultsCache: false
   cacheSharedDefault: false
 
+proxy:
+  host: ${HTTP_PROXY_HOST}
+  port: ${HTTP_PROXY_PORT}
+
 notify:
   secret: ${NOTIFY_SECRET:-pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs}
   serviceId: ${NOTIFY_SERVICE_ID:-pay-notify-service-id}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -89,6 +89,10 @@ jpa:
   queryResultsCache: false
   cacheSharedDefault: false
 
+proxy:
+  host: localhost
+  port: 1234
+
 notify:
   secret: ${NOTIFY_SECRET:-pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs}
   serviceId: ${NOTIFY_SERVICE_ID:-pay-notify-service-id}


### PR DESCRIPTION
 Using global proxy configuration. (This is similar to connector as of now)

Notify has release a 3.0.0 SDK which supports java.net.Proxy support. This however requires a `apiKey` instead of secret and serviceId. That might require addtional setup, so leaving this compliant for 2.2.1 level.

We should consider upgrading both connector and adminusers with version 3.0.0 (hopefully soon)

