### PR TITLE
pp-1696 - Fix healthcheck to only only read config data at startup time

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/app/healthchecks/DatabaseHealthCheck.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/healthchecks/DatabaseHealthCheck.java
@@ -9,21 +9,22 @@ import java.sql.DriverManager;
 
 public class DatabaseHealthCheck extends HealthCheck {
 
-    private AdminUsersConfig configuration;
+    private final String dbUrl;
+    private final String dbUser;
+    private final String dbPassword;
 
     @Inject
     public DatabaseHealthCheck(AdminUsersConfig configuration) {
-        this.configuration = configuration;
+        this.dbUrl = configuration.getDataSourceFactory().getUrl();
+        this.dbUser = configuration.getDataSourceFactory().getUser();
+        this.dbPassword = configuration.getDataSourceFactory().getPassword();
     }
 
     @Override
     protected Result check() throws Exception {
         Connection connection = null;
         try {
-            connection = DriverManager.getConnection(
-                configuration.getDataSourceFactory().getUrl(),
-                configuration.getDataSourceFactory().getUser(),
-                configuration.getDataSourceFactory().getPassword());
+            connection = DriverManager.getConnection(dbUrl, dbUser, dbPassword);
             connection.setReadOnly(true);
             return connection.isValid(2) ? Result.healthy() : Result.unhealthy("Could not validate the DB connection.");
         } catch (Exception e) {


### PR DESCRIPTION
 This is probably the correct way, to avoid any configuration updates at runtime.

Given that app resources only reads the connection details at the startup time and then keeping stored, we should do the same in healthcheck resource as well.
Otherwise any configuration update at runtime will give a false positive for healthcheck