### PR TITLE
PP-1598 Restrict gateway accounts in user creation.

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
@@ -26,6 +26,13 @@ public class ServiceEntity {
         this.gatewayAccountIds.add(new GatewayAccountIdEntity(gatewayAccountId, this));
     }
 
+    public ServiceEntity(List<String> gatewayAccountIds) {
+        this.gatewayAccountIds.clear();
+        for (String gatewayAccountId : gatewayAccountIds) {
+            this.gatewayAccountIds.add(new GatewayAccountIdEntity(gatewayAccountId, this));
+        }
+    }
+
     public Long getId() {
         return id;
     }
@@ -40,5 +47,20 @@ public class ServiceEntity {
 
     public GatewayAccountIdEntity getGatewayAccountId() {
         return gatewayAccountIds.get(0);
+    }
+
+    public boolean hasExactGatewayAccountIds(List<String> gatewayAccountIds) {
+
+        if (this.gatewayAccountIds.size() != gatewayAccountIds.size()) {
+            return false;
+        }
+
+        for (GatewayAccountIdEntity gatewayAccountIdEntity : this.gatewayAccountIds) {
+            if (!gatewayAccountIds.contains(gatewayAccountIdEntity.getGatewayAccountId())) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.adminusers.persistence.entity;
 
-import com.google.common.collect.ImmutableList;
 import uk.gov.pay.adminusers.model.User;
 
 import javax.persistence.*;
@@ -60,7 +59,7 @@ public class UserEntity extends AbstractEntity {
     @Convert(converter = UTCDateTimeConverter.class)
     private ZonedDateTime updatedAt;
 
-    @Column(name = "session_version", columnDefinition="int default 0")
+    @Column(name = "session_version", columnDefinition = "int default 0")
     private Integer sessionVersion;
 
     public UserEntity() {
@@ -204,15 +203,8 @@ public class UserEntity extends AbstractEntity {
         return user;
     }
 
-    public List<ServiceEntity> getServices() {
-        return ImmutableList.copyOf(this.services);
-    }
-
-    public void addService(ServiceEntity service) {
+    public void setService(ServiceEntity service) {
+        this.services.clear();
         this.services.add(service);
-    }
-
-    public void removeService(ServiceEntity service) {
-        this.services.remove(service);
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
@@ -23,6 +23,11 @@ public class AdminUsersExceptions {
         return buildWebApplicationException(error, CONFLICT.getStatusCode());
     }
 
+    public static WebApplicationException conflictingServiceGatewayAccounts() {
+        String error = format("List of gateway accounts not matching one of the existing services");
+        return buildWebApplicationException(error, CONFLICT.getStatusCode());
+    }
+
     public static WebApplicationException userLockedException(String username) {
         String error = format("user [%s] locked due to too many login attempts", username);
         return buildWebApplicationException(error, UNAUTHORIZED.getStatusCode());

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoTest.java
@@ -62,7 +62,7 @@ public class UserDaoTest extends DaoTestBase {
         userEntity.setDisabled(false);
         userEntity.setEmail(random + "@example.com");
         userEntity.setGatewayAccountId(gatewayAccountId);
-        userEntity.addService(serviceDao.findByGatewayAccountId(gatewayAccountId).get());
+        userEntity.setService(serviceDao.findByGatewayAccountId(gatewayAccountId).get());
         userEntity.setOtpKey(randomInt.toString());
         userEntity.setTelephoneNumber("876284762");
         userEntity.setRoles(asList(new RoleEntity(role1), new RoleEntity(role2)));

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateAndGetTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateAndGetTest.java
@@ -6,15 +6,13 @@ import org.apache.commons.lang3.RandomUtils;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.User;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
-import static java.lang.String.valueOf;
 import static java.util.UUID.randomUUID;
-import static org.apache.commons.lang3.RandomStringUtils.*;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -25,10 +23,12 @@ public class UserResourceCreateAndGetTest extends UserResourceTestBase {
     public void shouldCreateAUserWithGatewayAccountIdFieldSuccessfully() throws Exception {
 
         String username = randomAlphanumeric(10) + randomUUID().toString();
+        String gatewayAccountId = randomAlphanumeric(5);
+
         ImmutableMap<Object, Object> userPayload = ImmutableMap.builder()
                 .put("username", username)
                 .put("email", "user-" + username + "@example.com")
-                .put("gateway_account_id", "1")
+                .put("gateway_account_id", gatewayAccountId)
                 .put("telephone_number", "45334534634")
                 .put("otp_key", "34f34")
                 .put("role_name", "admin")
@@ -46,9 +46,9 @@ public class UserResourceCreateAndGetTest extends UserResourceTestBase {
                 .body("username", is(username))
                 .body("password", nullValue())
                 .body("email", is("user-" + username + "@example.com"))
-                .body("gateway_account_id", is("1"))
+                .body("gateway_account_id", is(gatewayAccountId))
                 .body("gateway_account_ids", hasSize(1))
-                .body("gateway_account_ids[0]", is("1"))
+                .body("gateway_account_ids[0]", is(gatewayAccountId))
                 .body("telephone_number", is("45334534634"))
                 .body("otp_key", is("34f34"))
                 .body("login_counter", is(0))
@@ -61,15 +61,11 @@ public class UserResourceCreateAndGetTest extends UserResourceTestBase {
                 .body("role.description", is("Administrator"))
                 .body("permissions", hasSize(28)); //we could consider removing this assertion if the permissions constantly changing
 
-        //TODO - WIP PP-1483 This will be amended when the story is done.
+        //TODO - WIP This will be removed when PP-1612 is done.
         // This is an extra check to verify that new created user gateways are registered withing the new Services Model as well as in users table
         List<Map<String, Object>> userByName = databaseTestHelper.findUserByName(username);
         List<Map<String, Object>> servicesAssociatedToUser = databaseTestHelper.findUserServicesByUserId((Integer) userByName.get(0).get("id"));
         assertThat(servicesAssociatedToUser.size(), is(1));
-
-        List<Map<String, Object>> gatewayAccountsAssociatedToUser = databaseTestHelper.findGatewayAccountsByService((Long) servicesAssociatedToUser.get(0).get("service_id"));
-        assertThat(gatewayAccountsAssociatedToUser.size(), is(1));
-        assertThat(gatewayAccountsAssociatedToUser.get(0).get("gateway_account_id"), is("1"));
     }
 
     @Test
@@ -113,15 +109,11 @@ public class UserResourceCreateAndGetTest extends UserResourceTestBase {
                 .body("role.description", is("Administrator"))
                 .body("permissions", hasSize(28)); //we could consider removing this assertion if the permissions constantly changing
 
-        //TODO - WIP PP-1483 This will be amended when the story is done.
+        //TODO - WIP This will be removed when PP-1612 is done.
         // This is an extra check to verify that new created user gateways are registered withing the new Services Model as well as in users table
         List<Map<String, Object>> userByName = databaseTestHelper.findUserByName(username);
         List<Map<String, Object>> servicesAssociatedToUser = databaseTestHelper.findUserServicesByUserId((Integer) userByName.get(0).get("id"));
-        assertThat(servicesAssociatedToUser.size(), is(2));
-
-        List<Map<String, Object>> gatewayAccountsAssociatedToUser = databaseTestHelper.findGatewayAccountsByService((Long) servicesAssociatedToUser.get(0).get("service_id"));
-        assertThat(gatewayAccountsAssociatedToUser.size(), is(1));
-        assertThat(gatewayAccountsAssociatedToUser.get(0).get("gateway_account_id"), is("222"));
+        assertThat(servicesAssociatedToUser.size(), is(1));
     }
 
     @Test
@@ -166,15 +158,10 @@ public class UserResourceCreateAndGetTest extends UserResourceTestBase {
                 .body("role.description", is("Administrator"))
                 .body("permissions", hasSize(28)); //we could consider removing this assertion if the permissions constantly changing
 
-        //TODO - WIP PP-1483 This will be amended when the story is done.
-        // This is an extra check to verify that new created user gateways are registered withing the new Services Model as well as in users table
+        //TODO - WIP This will be removed when PP-1612 is done.
         List<Map<String, Object>> userByName = databaseTestHelper.findUserByName(username);
         List<Map<String, Object>> servicesAssociatedToUser = databaseTestHelper.findUserServicesByUserId((Integer) userByName.get(0).get("id"));
-        assertThat(servicesAssociatedToUser.size(), is(2));
-
-        List<Map<String, Object>> gatewayAccountsAssociatedToUser = databaseTestHelper.findGatewayAccountsByService((Long) servicesAssociatedToUser.get(0).get("service_id"));
-        assertThat(gatewayAccountsAssociatedToUser.size(), is(1));
-        assertThat(gatewayAccountsAssociatedToUser.get(0).get("gateway_account_id"), is("1"));
+        assertThat(servicesAssociatedToUser.size(), is(1));
     }
 
     @Test


### PR DESCRIPTION
## WHAT
- The list of gateway accounts must match exactly the ones of a service.
- If non of them are part of a service, a new service will be created.
- A '409 Conflict' will be returned in case of any these conditions are not met.