### PR TITLE
PP-1584 Add toggle-3ds:read and toggle-3ds:update permissions

### DIFF
--- a/src/main/resources/migrations/00007_add_toggle_3ds_read_and_toggle_3ds_update_permissions.sql
+++ b/src/main/resources/migrations/00007_add_toggle_3ds_read_and_toggle_3ds_update_permissions.sql
@@ -1,0 +1,12 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:insert_toggle_3ds_read_permission
+INSERT INTO  permissions(id, name, description) VALUES (30, 'toggle-3ds:read', 'View 3D Secure setting');
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'super-admin'), (SELECT id FROM permissions WHERE name = 'toggle-3ds:read'), NOW(), NOW());
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'admin'), (SELECT id FROM permissions WHERE name = 'toggle-3ds:read'), NOW(), NOW());
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'view-and-refund'), (SELECT id FROM permissions WHERE name = 'toggle-3ds:read'), NOW(), NOW());
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'view-only'), (SELECT id FROM permissions WHERE name = 'toggle-3ds:read'), NOW(), NOW());
+
+--changeset uk.gov.pay:insert_toggle_3ds_update_permission
+INSERT INTO  permissions(id, name, description) VALUES (31, 'toggle-3ds:update', 'Edit 3D Secure setting');
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'admin'), (SELECT id FROM permissions WHERE name = 'toggle-3ds:update'), NOW(), NOW());

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationTest.java
@@ -39,7 +39,7 @@ public class UserResourceAuthenticationTest extends UserResourceTestBase {
                 .body("disabled", is(false))
                 .body("_links", hasSize(1))
                 .body("role.name", is("admin"))
-                .body("permissions", hasSize(28)); //we could consider removing this assertion if the permissions constantly changing
+                .body("permissions", hasSize(30)); //we could consider removing this assertion if the permissions constantly changing
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateAndGetTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateAndGetTest.java
@@ -6,15 +6,13 @@ import org.apache.commons.lang3.RandomUtils;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.User;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
-import static java.lang.String.valueOf;
 import static java.util.UUID.randomUUID;
-import static org.apache.commons.lang3.RandomStringUtils.*;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -59,7 +57,7 @@ public class UserResourceCreateAndGetTest extends UserResourceTestBase {
                 .body("_links[0].rel", is("self"))
                 .body("role.name", is("admin"))
                 .body("role.description", is("Administrator"))
-                .body("permissions", hasSize(28)); //we could consider removing this assertion if the permissions constantly changing
+                .body("permissions", hasSize(30)); //we could consider removing this assertion if the permissions constantly changing
 
         //TODO - WIP PP-1483 This will be amended when the story is done.
         // This is an extra check to verify that new created user gateways are registered withing the new Services Model as well as in users table
@@ -111,7 +109,7 @@ public class UserResourceCreateAndGetTest extends UserResourceTestBase {
                 .body("_links[0].rel", is("self"))
                 .body("role.name", is("admin"))
                 .body("role.description", is("Administrator"))
-                .body("permissions", hasSize(28)); //we could consider removing this assertion if the permissions constantly changing
+                .body("permissions", hasSize(30)); //we could consider removing this assertion if the permissions constantly changing
 
         //TODO - WIP PP-1483 This will be amended when the story is done.
         // This is an extra check to verify that new created user gateways are registered withing the new Services Model as well as in users table
@@ -164,7 +162,7 @@ public class UserResourceCreateAndGetTest extends UserResourceTestBase {
                 .body("_links[0].rel", is("self"))
                 .body("role.name", is("admin"))
                 .body("role.description", is("Administrator"))
-                .body("permissions", hasSize(28)); //we could consider removing this assertion if the permissions constantly changing
+                .body("permissions", hasSize(30)); //we could consider removing this assertion if the permissions constantly changing
 
         //TODO - WIP PP-1483 This will be amended when the story is done.
         // This is an extra check to verify that new created user gateways are registered withing the new Services Model as well as in users table
@@ -349,6 +347,6 @@ public class UserResourceCreateAndGetTest extends UserResourceTestBase {
                 .body("_links[0].rel", is("self"))
                 .body("role.name", is("admin"))
                 .body("role.description", is("Administrator"))
-                .body("permissions", hasSize(28)); //we could consider removing this assertion if the permissions constantly changing
+                .body("permissions", hasSize(30)); //we could consider removing this assertion if the permissions constantly changing
     }
 }


### PR DESCRIPTION
* `toggle-3ds:read` means user can see if 3D Secure is enabled for the service — all roles have this
* `toggle-3ds:update` means user can enable or disable 3D Secure for the service — only users with the `admin` role have this