### PR TITLE
pp-1600 - user migration pre tasks

### DIFF
--- a/src/main/resources/migrations/00011_add_user_migration_column.sql
+++ b/src/main/resources/migrations/00011_add_user_migration_column.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table-users-add-is_new
+
+ALTER TABLE users ADD COLUMN is_new INTEGER NOT NULL DEFAULT 0;
+
+--rollback alter table users drop column is_new;

--- a/src/main/resources/migrations/00012_add_column_service_name.sql
+++ b/src/main/resources/migrations/00012_add_column_service_name.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table-service-add-name
+
+ALTER TABLE services ADD COLUMN name VARCHAR(255) NOT NULL DEFAULT 'System Generated';
+
+--rollback alter table services drop column name;

--- a/src/main/resources/migrations/00013_drop_constraint_service_gateway_accounts_gateway_account_id.sql
+++ b/src/main/resources/migrations/00013_drop_constraint_service_gateway_accounts_gateway_account_id.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table-service_gateway_accounts-drop-constraint
+
+ALTER TABLE service_gateway_accounts DROP CONSTRAINT service_gateway_accounts_gateway_account_id_key;
+
+--rollback ALTER TABLE service_gateway_accounts ADD CONSTRAINT service_gateway_accounts_gateway_account_id_key UNIQUE (gateway_account_id);


### PR DESCRIPTION
As per https://docs.google.com/document/d/1b8OklH_H_oL2gyG-i1icMGOU2_aYiQm9B5dv_B1g53k this PR includes the 3 preliminary tasks prior to migration

 - Adding `is_new` column -> purely for migration (drop later on)
 - Adding `name` column -> permanent change
 - Dropping unique constraint on `service_gateway_accounts` table -> purely for migration (add back later on)

Plus a small fix on test which was relying on ordering.