### PR TITLE
PP-1753 Upgraded project dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,11 +7,10 @@
 
     <properties>
         <dropwizard.version>1.0.6</dropwizard.version>
-        <mockserver.version>3.10.4</mockserver.version>
-        <jersey2.version>2.24.1</jersey2.version>
         <hamcrest.version>1.3</hamcrest.version>
         <eclipselink.version>2.6.4</eclipselink.version>
         <guice.version>4.1.0</guice.version>
+        <jersey2.version>2.25.1</jersey2.version>
     </properties>
     <repositories>
         <repository>
@@ -32,7 +31,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.22</version>
+            <version>1.7.24</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -58,12 +57,12 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>3.1.2</version>
+            <version>3.2.0</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-graphite</artifactId>
-            <version>3.1.2</version>
+            <version>3.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.liquibase</groupId>
@@ -78,12 +77,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.8.6</version>
+            <version>2.8.7</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.8.6</version>
+            <version>2.8.7</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -124,12 +123,27 @@
         <dependency>
             <groupId>org.mindrot</groupId>
             <artifactId>jbcrypt</artifactId>
-            <version>0.3m</version>
+            <version>0.4</version>
         </dependency>
         <dependency>
             <groupId>com.warrenstrange</groupId>
             <artifactId>googleauth</artifactId>
             <version>1.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+            <version>${jersey2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-jaxb</artifactId>
+            <version>${jersey2.version}</version>
         </dependency>
         <dependency>
             <groupId>uk.gov.service.notify</groupId>
@@ -165,7 +179,7 @@
         <dependency>
             <groupId>com.spotify</groupId>
             <artifactId>docker-client</artifactId>
-            <version>6.0.0</version>
+            <version>8.1.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- Upgraded the following libraries:
  - `slf4j-api` from version `1.7.22` to `1.7.24`
  - `metrics-core` from version `3.1.2` to `3.2.0`
  - `metrics-graphite` from version `3.1.2` to `3.2.0`
  - `jackson-annotations` from version `2.8.6` to `2.8.7`
  - `jackson-datatype-jsr310` from version `2.8.6` to `2.8.7`
  - `docker-client` from version `6.0.0` to `8.1.1`
  - `jbcrypt` from version `0.3m` to `0.4`
  - `httpclient` from version `4.5.2` to `4.5.3`
  - `jersey-common` from version `2.23.2` to `2.25.1`
  - `jersey-media-jaxb` from version `2.23.2` to `2.25.1`

 NOTE: `liquibase-core` couldn't not be upgraded to its latest version due to a weird issue that fails importing data from a CSV file into an existing table during the migration. Since this is only used for  testing, there is no vulnerability risk.