### PR TITLE
PP-1600 Update users resource to accept service ids.

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
@@ -28,6 +28,11 @@ public class AdminUsersExceptions {
         return buildWebApplicationException(error, CONFLICT.getStatusCode());
     }
 
+    public static WebApplicationException notFoundServiceError(String serviceId) {
+        String error = format("Service %s provided does not exist", serviceId);
+        return buildWebApplicationException(error, BAD_REQUEST.getStatusCode());
+    }
+
     public static WebApplicationException userLockedException(String username) {
         String error = format("user [%s] locked due to too many login attempts", username);
         return buildWebApplicationException(error, UNAUTHORIZED.getStatusCode());

--- a/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
@@ -196,7 +196,7 @@ public class DatabaseTestHelper {
                         .list());
     }
 
-    public DatabaseTestHelper addService(int serviceId, String gatewayAccountId) {
+    public DatabaseTestHelper addService(int serviceId, String... gatewayAccountIds) {
 
         jdbi.withHandle(handle ->
                 handle
@@ -206,13 +206,14 @@ public class DatabaseTestHelper {
                         .execute()
         );
 
-        jdbi.withHandle(handle ->
-                handle.createStatement("INSERT INTO service_gateway_accounts(service_id, gateway_account_id) VALUES (:serviceId, :gatewayAccountId)")
-                        .bind("serviceId", serviceId)
-                        .bind("gatewayAccountId", gatewayAccountId)
-                        .execute()
-        );
-
+        for (String gatewayAccountId : gatewayAccountIds) {
+            jdbi.withHandle(handle ->
+                    handle.createStatement("INSERT INTO service_gateway_accounts(service_id, gateway_account_id) VALUES (:serviceId, :gatewayAccountId)")
+                            .bind("serviceId", serviceId)
+                            .bind("gatewayAccountId", gatewayAccountId)
+                            .execute()
+            );
+        }
         return this;
     }
 }


### PR DESCRIPTION
## WHAT
- Since removing the gateway account ids constraint from the service_gateway_accounts table breaks the constraint on code about exactitude in gateway accounts passed when creating users, we need a way to add users to a Service so optionally service_ids can be passed into the payload (see IT tests) ignoring (but necessary for validation) gateway_account_ids.