### PR TITLE
PP-1716 adjust 2fa login counter check

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
@@ -183,7 +183,7 @@ public class UserServices {
                     } else {
                         userEntity.setLoginCounter(userEntity.getLoginCounter() + 1);
                         userEntity.setUpdatedAt(ZonedDateTime.now(ZoneId.of("UTC")));
-                        userEntity.setDisabled(userEntity.getLoginCounter() >= loginAttemptCap);
+                        userEntity.setDisabled(userEntity.getLoginCounter() > loginAttemptCap);
                         userDao.merge(userEntity);
                         if (userEntity.isDisabled()) {
                             logger.warn("User [{}] attempted a invalid second factor, and account currently locked", userEntity.getId());

--- a/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
@@ -477,7 +477,7 @@ public class UserServicesTest {
     @Test
     public void shouldReturnEmptyAndDisable_whenAuthenticate2FA_ifUnsuccessfulMaxRetry() throws Exception {
         User user = aUser();
-        user.setLoginCounter(2);
+        user.setLoginCounter(3);
         UserEntity userEntity = aUserEntityWithTrimmings(user);
         when(userDao.findByUsername(user.getUsername())).thenReturn(Optional.of(userEntity));
         when(secondFactorAuthenticator.authorize(user.getOtpKey(), 123456)).thenReturn(false);
@@ -489,7 +489,7 @@ public class UserServicesTest {
         assertFalse(tokenOptional.isPresent());
 
         UserEntity savedUser = argumentCaptor.getValue();
-        assertThat(savedUser.getLoginCounter(), is(3));
+        assertThat(savedUser.getLoginCounter(), is(4));
         assertThat(savedUser.isDisabled(), is(true));
     }
 


### PR DESCRIPTION
The way selfservice checks for user is disabled or not at first factor and second factor are slightly different. 
On first factor (username/password) it checks disability before authenticating username/password. On Second factor we check after 2fa verification. 
So, in order to have the same locking effect to user we need to adjust the 2fa locking set only after max_attempts exceeded.