### PR TITLE
PP-1805 Upgraded logback-classic dependency which contains vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,11 @@
             <version>${jersey2.version}</version>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.2</version>
+        </dependency>
+        <dependency>
             <groupId>uk.gov.service.notify</groupId>
             <artifactId>notifications-java-client</artifactId>
             <version>2.0.0-RELEASE</version>


### PR DESCRIPTION
`logback-classic` dependency has an "arbitrary code execution via serialization" vulnerability which has been addressed in the latest version.

https://app.sourceclear.com/teams/100t11M/issues/vulnerabilities/1093372/196795

Upgraded the dependency to version `1.2.2`.