### PR TITLE
PP-1819 update user service role

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The GOV.UK Pay Admin Users Module in Java (Dropwizard)
 | [```/v1/api/users```](/docs/api_specification.md#post-v1apiusers)              | POST    |  Creates a new user            |
 | [```/v1/api/users/{username}```](/docs/api_specification.md#get-v1apiusersusername)              | GET    |  Gets a user with the associated username            |
 | [```/v1/api/users/{username}```](/docs/api_specification.md#patch-v1apiusersusername)              | PATCH    |  amend a specific user attribute            |
+| [```/v1/api/users/{username}/services/{service-id}```](/docs/api_specification.md#patch-v1apiusersusernameservicesserviceid)  | PUT    |  update user's role for a service            |
 | [```/v1/api/users/authenticate```](/docs/api_specification.md#post-v1apiusersauthenticate)              | POST    |  Authenticate a given username/password            |
 | [```/v1/api/forgotten-passwords```](/docs/api_specification.md#post-v1apiforgottenpasswords)              | POST    |  Create a new forgotten password request            |
 | [```/v1/api/forgotten-passwords/{code}```](/docs/api_specification.md#get-v1apiforgottenpasswordscode)              | GET    |  GETs a forgotten password record by code            |

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -302,3 +302,79 @@ Content-Type: application/json
           }]
 }
 ```
+
+-----------------------------------------------------------------------------------------------------------
+
+## PUT /v1/api/users/{username}/services/{service-id}
+
+This endpoint updates a service role of a perticular user.
+
+### Request example
+
+```
+PUT /v1/api/users/abcd1234/services/111
+Content-Type: application/json
+{
+    "role_name": "view-and-refund"
+}
+```
+
+### Response example
+
+```
+200 OK
+Content-Type: application/json
+{
+    "username": "abcd1234",
+    "email": "email@email.com",
+    "gateway_account_ids": ["1"],
+    "telephone_number": "49875792",
+    "otp_key": "43c3c4t",
+    "sessionVersion": 2,
+    "role": {"view-and-refund","View and Refund"},
+    "permissions":["perm-1","perm-2","perm-3"], 
+    "_links": [{
+        "href": "http://adminusers.service/v1/api/users/abcd1234",
+        "rel" : "self",
+        "method" : "GET"
+    }]
+    
+}
+```
+
+if user not found:
+```
+404 Not found
+```
+
+if provided role name not valid:
+```
+400 Bad request
+Content-Type: application/json
+{
+  "errors": "role [xyz] not recognised"
+}
+```
+
+if provided the user does not have access to the given service id:
+```
+409 Conflict
+Content-Type: application/json
+{
+  "errors": "user [abcd1234] does not belong to service [123]"
+}
+```
+
+if no of administrators for the given service is less than or equal to 1:
+```
+412 Precondition Failed
+Content-Type: application/json
+{
+  "errors": "Service admin limit reached. At least 1 admin(s) required"
+}
+```
+#### Request field description
+
+| Field                    | required | Description                                                | Supported Values     |
+| ------------------------ |:--------:| ---------------------------------------------------------- |----------------------|
+| `role_name`              |   X      | the name of an existing valid role                         | e.g. admin           |

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,11 @@
             <version>${guice.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-assistedinject</artifactId>
+            <version>${guice.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.5</version>

--- a/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersModule.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersModule.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.name.Names;
 import com.google.inject.persist.jpa.JpaPersistModule;
 import io.dropwizard.db.DataSourceFactory;
@@ -47,6 +48,7 @@ public class AdminUsersModule extends AbstractModule {
         bind(ResetPasswordService.class).in(Singleton.class);
 
         install(jpaModule(configuration));
+        install(new FactoryModuleBuilder().build(UserServicesFactory.class));
     }
 
     private JpaPersistModule jpaModule(AdminUsersConfig configuration) {

--- a/src/main/java/uk/gov/pay/adminusers/model/Role.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Role.java
@@ -13,6 +13,8 @@ import static org.apache.commons.collections.CollectionUtils.isEqualCollection;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class Role {
 
+    public static final Integer ROLE_ADMIN_ID = 2;
+
     @JsonIgnore
     private Integer id;
     private String name;

--- a/src/main/java/uk/gov/pay/adminusers/persistence/dao/ServiceDao.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/dao/ServiceDao.java
@@ -32,4 +32,13 @@ public class ServiceDao extends JpaDao<ServiceEntity> {
         }
         return Optional.empty();
     }
+
+    public Long countOfRolesForService(Integer serviceId, Integer roleId) {
+
+        String query = "SELECT count(*) FROM user_services_roles usr WHERE usr.service_id=? AND usr.role_id=?";
+        return (long) entityManager.get().createNativeQuery(query)
+                .setParameter(1, serviceId)
+                .setParameter(2, roleId)
+                .getSingleResult();
+    }
 }

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
@@ -9,11 +9,12 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.Boolean.FALSE;
-import static java.lang.String.*;
+import static java.lang.String.valueOf;
 
 @Entity
 @Table(name = "users")
@@ -192,5 +193,9 @@ public class UserEntity extends AbstractEntity {
         this.servicesRoles.clear();
         service.setUser(this);
         this.servicesRoles.add(service);
+    }
+
+    public Optional<ServiceRoleEntity> getServicesRole(Integer serviceId) {
+        return servicesRoles.stream().filter(serviceRoleEntity -> serviceId.equals(serviceRoleEntity.getService().getId())).findFirst();
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/resources/UserRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/UserRequestValidator.java
@@ -71,6 +71,14 @@ public class UserRequestValidator {
         return Optional.empty();
     }
 
+    public Optional<Errors> validateServiceRole(JsonNode payload) {
+        Optional<List<String>> missingMandatoryFields =  requestValidations.checkIfExists(payload, "role_name");
+        if (missingMandatoryFields.isPresent()) {
+            return Optional.of(Errors.from(missingMandatoryFields.get()));
+        }
+        return Optional.empty();
+    }
+
     public Optional<Errors> validatePatchRequest(JsonNode payload) {
         Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExists(payload, "op", "path", "value");
         if (missingMandatoryFields.isPresent()) {

--- a/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
@@ -28,6 +28,11 @@ public class AdminUsersExceptions {
         return buildWebApplicationException(error, CONFLICT.getStatusCode());
     }
 
+    public static WebApplicationException conflictingServiceForUser(Integer userId, Integer serviceId) {
+        String error = format("user [%d] does not belong to service [%d]", userId, serviceId);
+        return buildWebApplicationException(error, CONFLICT.getStatusCode());
+    }
+
     public static WebApplicationException notFoundServiceError(String serviceId) {
         String error = format("Service %s provided does not exist", serviceId);
         return buildWebApplicationException(error, BAD_REQUEST.getStatusCode());
@@ -40,6 +45,11 @@ public class AdminUsersExceptions {
 
     public static WebApplicationException internalServerError(String message) {
         return buildWebApplicationException(message, INTERNAL_SERVER_ERROR.getStatusCode());
+    }
+
+    public static WebApplicationException adminRoleLimitException(int adminLimit) {
+        String error = format("Service admin limit reached. At least %d admin(s) required", adminLimit);
+        return buildWebApplicationException(error, PRECONDITION_FAILED.getStatusCode());
     }
 
     public static RuntimeException userNotificationError(Exception e) {

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceRoleUpdater.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceRoleUpdater.java
@@ -1,0 +1,74 @@
+package uk.gov.pay.adminusers.service;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+import uk.gov.pay.adminusers.model.User;
+import uk.gov.pay.adminusers.persistence.dao.RoleDao;
+import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
+import uk.gov.pay.adminusers.persistence.dao.UserDao;
+import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
+import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
+import uk.gov.pay.adminusers.persistence.entity.UserEntity;
+
+import java.util.Optional;
+
+import static uk.gov.pay.adminusers.model.Role.ROLE_ADMIN_ID;
+import static uk.gov.pay.adminusers.service.AdminUsersExceptions.*;
+
+public class ServiceRoleUpdater {
+
+    private final UserDao userDao;
+    private final ServiceDao serviceDao;
+    private final RoleDao roleDao;
+    private final LinksBuilder linksBuilder;
+
+    private final Integer adminsPerServiceLimit = 1;
+
+    @Inject
+    public ServiceRoleUpdater(UserDao userDao, ServiceDao serviceDao, RoleDao roleDao, LinksBuilder linksBuilder) {
+        this.userDao = userDao;
+        this.serviceDao = serviceDao;
+        this.roleDao = roleDao;
+        this.linksBuilder = linksBuilder;
+    }
+
+    /**
+     * updates user's service role.
+     *
+     * @param username
+     * @param serviceId
+     * @param roleName
+     * @return Updated User if successful or Optional.empty() if user not found
+     */
+    @Transactional
+    public Optional<User> doUpdate(String username, Integer serviceId, String roleName){
+        Optional<UserEntity> userMaybe = userDao.findByUsername(username);
+        if(!userMaybe.isPresent()){
+            return Optional.empty();
+        }
+        UserEntity userEntity = userMaybe.get();
+
+        Optional<RoleEntity> roleMaybe = roleDao.findByRoleName(roleName);
+        if(!roleMaybe.isPresent()){
+            throw undefinedRoleException(roleName);
+        }
+        RoleEntity roleEntity = roleMaybe.get();
+
+        Optional<ServiceRoleEntity> servicesRoleMaybe = userEntity.getServicesRole(serviceId);
+        if(!servicesRoleMaybe.isPresent()) {
+            throw conflictingServiceForUser(userEntity.getId(), serviceId);
+        }
+
+        ServiceRoleEntity serviceRoleEntity = servicesRoleMaybe.get();
+
+        if (!roleEntity.getId().equals(ROLE_ADMIN_ID)) {
+            if (serviceDao.countOfRolesForService(serviceId, ROLE_ADMIN_ID) <= adminsPerServiceLimit) {
+                throw adminRoleLimitException(adminsPerServiceLimit);
+            }
+        }
+        serviceRoleEntity.setRole(roleEntity);
+        userEntity.setServiceRole(serviceRoleEntity);
+        userDao.persist(userEntity);
+        return Optional.of(linksBuilder.decorate(userEntity.toUser()));
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
@@ -74,7 +74,7 @@ public class UserServices {
                 .map(roleEntity -> {
                     UserEntity userEntity = UserEntity.from(user);
                     userEntity.setPassword(passwordHasher.hash(user.getPassword()));
-                    if(user.getServiceIds().isEmpty()){
+                    if (user.getServiceIds().isEmpty()) {
                         addServiceRoleToUser(userEntity, roleEntity, user.getGatewayAccountIds());
                     } else {
                         addServiceRoleToUser(userEntity, roleEntity, user.getServiceIds().get(0));
@@ -128,6 +128,7 @@ public class UserServices {
         }
     }
 
+
     /**
      * finds a user by username
      *
@@ -141,7 +142,6 @@ public class UserServices {
                         linksBuilder.decorate(userEntity.toUser())))
                 .orElse(Optional.empty());
     }
-
 
     public Optional<SecondFactorToken> newSecondFactorPasscode(String username) {
         return userDao.findByUsername(username)

--- a/src/main/java/uk/gov/pay/adminusers/service/UserServicesFactory.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserServicesFactory.java
@@ -1,0 +1,13 @@
+package uk.gov.pay.adminusers.service;
+
+/**
+ * Factory for providing user services components
+ *
+ * instantiation facilitated by Guice assisted injects supported via FactoryModule
+ * @see uk.gov.pay.adminusers.app.config.AdminUsersModule
+ */
+public interface UserServicesFactory {
+
+    ServiceRoleUpdater serviceRoleUpdater();
+
+}

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/RoleDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/RoleDbFixture.java
@@ -29,14 +29,19 @@ public class RoleDbFixture {
     }
 
     public Role insertRole() {
-        Permission permission1 = aPermission();
-        Permission permission2 = aPermission();
-        databaseHelper.add(permission1).add(permission2);
+        return insert(role(randomInt(), name, "role-description" + newId()), aPermission(), aPermission());
+    }
 
-        Role role = role(randomInt(), name, "role-description" + newId());
-        role.setPermissions(newArrayList(permission1, permission2));
+    public Role insertAdmin() {
+        return insert(role(2, "Admin", "Administrator"), aPermission(), aPermission());
+    }
+
+    private Role insert(Role role, Permission... permissions) {
+        for (Permission permission : permissions) {
+            databaseHelper.add(permission);
+        }
+        role.setPermissions(newArrayList(permissions));
         databaseHelper.add(role);
-
         return role;
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoTest.java
@@ -1,0 +1,65 @@
+package uk.gov.pay.adminusers.persistence.dao;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.adminusers.fixtures.UserDbFixture;
+import uk.gov.pay.adminusers.model.Permission;
+import uk.gov.pay.adminusers.model.Role;
+import uk.gov.pay.adminusers.model.User;
+
+import static java.util.Arrays.asList;
+import static java.util.stream.IntStream.range;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
+import static uk.gov.pay.adminusers.model.Role.role;
+
+public class ServiceDaoTest extends DaoTestBase {
+
+    private ServiceDao serviceDao;
+
+    @Before
+    public void before() throws Exception {
+        serviceDao = env.getInstance(ServiceDao.class);
+    }
+
+    @Test
+    public void shouldGetRoleCountForAService() throws Exception {
+        Integer serviceId = randomInt();
+        Integer roleId = randomInt();
+        setupUsersForServiceAndRole(serviceId, roleId, 3);
+
+        Long count = serviceDao.countOfRolesForService(serviceId, roleId);
+
+        assertThat(count, is(3l));
+
+    }
+
+    private void setupUsersForServiceAndRole(int serviceId, int roleId, int noOfUsers) {
+        Permission perm1 = aPermission();
+        Permission perm2 = aPermission();
+        databaseHelper.add(perm1).add(perm2);
+
+        Role role = role(roleId, "role-" + roleId, "role-desc-" + roleId);
+        role.setPermissions(asList(perm1, perm2));
+        databaseHelper.add(role);
+
+        String gatewayAccountId1 = randomInt().toString();
+        databaseHelper.addService(serviceId, gatewayAccountId1);
+
+        range(0, noOfUsers - 1).forEach(i -> {
+            UserDbFixture.userDbFixture(databaseHelper).withServiceRole(serviceId, roleId).insertUser();
+        });
+
+        //unmatching service
+        String gatewayAccountId2 = randomInt().toString();
+        Integer serviceId2 = randomInt();
+        databaseHelper.addService(serviceId2, gatewayAccountId2);
+
+        //same user 2 diff services - should count only once
+        User user3 = UserDbFixture.userDbFixture(databaseHelper).withServiceRole(serviceId, roleId).insertUser();
+        databaseHelper.addUserServiceRole(user3.getId(),serviceId2, role.getId());
+    }
+
+
+}

--- a/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
@@ -16,7 +16,7 @@ public class IntegrationTest {
     static final String USER_RESOURCE_URL = "/v1/api/users/%s";
     static final String USERS_AUTHENTICATE_URL = "/v1/api/users/authenticate";
     static final String USER_2FA_URL = "/v1/api/users/%s/second-factor";
-
+    static final String USER_SERVICE_RESOURCE = USER_RESOURCE_URL + "/services/%d";
     @ClassRule
     public static DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule();
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.service.UserServices;
+import uk.gov.pay.adminusers.service.UserServicesFactory;
 
 import javax.ws.rs.WebApplicationException;
 import java.util.Optional;
@@ -22,7 +23,8 @@ public class UserResourceTest {
 
     private UserServices userService = mock(UserServices.class);
     private UserRequestValidator validator = mock(UserRequestValidator.class);
-    private UserResource userResource = new UserResource(userService, validator);
+    private UserServicesFactory userServiceFactory = mock(UserServicesFactory.class);
+    private UserResource userResource = new UserResource(userService, validator, userServiceFactory);
     private JsonNode validUserNode = new ObjectMapper().valueToTree(ImmutableMap.builder()
             .put("username", "fred")
             .put("email", "user-@example.com")

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceUpdateServiceRoleTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceUpdateServiceRoleTest.java
@@ -1,0 +1,76 @@
+package uk.gov.pay.adminusers.resources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import uk.gov.pay.adminusers.model.Role;
+
+import static com.jayway.restassured.http.ContentType.JSON;
+import static java.lang.String.format;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.adminusers.fixtures.RoleDbFixture.roleDbFixture;
+import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
+import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
+
+public class UserResourceUpdateServiceRoleTest extends IntegrationTest {
+
+    @Test
+    public void shouldUpdateUserServiceRole() throws Exception {
+
+        Role role = roleDbFixture(databaseHelper).insertAdmin();
+        int serviceId = serviceDbFixture(databaseHelper).insertService();
+        String username = userDbFixture(databaseHelper).withServiceRole(serviceId, role.getId()).insertUser().getUsername();
+        userDbFixture(databaseHelper).withServiceRole(serviceId, role.getId()).insertUser();
+
+        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("role_name", "view-and-refund"));
+
+        givenSetup()
+                .when()
+                .contentType(JSON)
+                .body(payload)
+                .put(format(USER_SERVICE_RESOURCE, username, serviceId))
+                .then()
+                .statusCode(200)
+                .body("username", is(username))
+                .body("role.name", is("view-and-refund"))
+                .body("role.description", is("View and Refund"));
+    }
+
+
+    @Test
+    public void shouldError404_ifUserNotFound_whenUpdatingServiceRole() throws Exception {
+
+        int serviceId = serviceDbFixture(databaseHelper).insertService();
+        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("role_name", "view-and-refund"));
+
+        givenSetup()
+                .when()
+                .contentType(JSON)
+                .body(payload)
+                .put(format(USER_SERVICE_RESOURCE, "non-existent", serviceId))
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void shouldError412_ifNoOfMinimumAdminsLimitReached_whenUpdatingServiceRole() throws Exception {
+
+        Role role = roleDbFixture(databaseHelper).insertAdmin();
+        int serviceId = serviceDbFixture(databaseHelper).insertService();
+        String username = userDbFixture(databaseHelper).withServiceRole(serviceId, role.getId()).insertUser().getUsername();
+
+        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("role_name", "view-and-refund"));
+
+        givenSetup()
+                .when()
+                .contentType(JSON)
+                .body(payload)
+                .put(format(USER_SERVICE_RESOURCE, username, serviceId))
+                .then()
+                .statusCode(412)
+                .body("errors", hasSize(1))
+                .body("errors[0]", is("Service admin limit reached. At least 1 admin(s) required"));
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceRoleUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceRoleUpdaterTest.java
@@ -1,0 +1,136 @@
+package uk.gov.pay.adminusers.service;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.pay.adminusers.model.Role;
+import uk.gov.pay.adminusers.model.User;
+import uk.gov.pay.adminusers.persistence.dao.RoleDao;
+import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
+import uk.gov.pay.adminusers.persistence.dao.UserDao;
+import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
+import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
+import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
+import uk.gov.pay.adminusers.persistence.entity.UserEntity;
+
+import javax.ws.rs.WebApplicationException;
+import java.util.Optional;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
+import static uk.gov.pay.adminusers.model.Role.ROLE_ADMIN_ID;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class ServiceRoleUpdaterTest {
+
+    @Mock
+    private UserDao userDao;
+    @Mock
+    private RoleDao roleDao;
+    @Mock
+    private ServiceDao serviceDao;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private ServiceRoleUpdater serviceRoleUpdater;
+
+    @Before
+    public void before() throws Exception {
+        serviceRoleUpdater = new ServiceRoleUpdater(userDao, serviceDao, roleDao, new LinksBuilder("http://localhost"));
+    }
+
+    @Test
+    public void shouldReturnEmpty_ifUserNotFound_whenUpdatingServiceRole() throws Exception {
+        String username = "non-existent";
+        when(userDao.findByUsername(username)).thenReturn(Optional.empty());
+
+        Optional<User> userOptional = serviceRoleUpdater.doUpdate(username, randomInt(), "randomRole");
+        assertFalse(userOptional.isPresent());
+    }
+
+    @Test
+    public void shouldError_ifRoleNotFound_whenUpdatingServiceRole() throws Exception {
+        String username = "existing-user";
+        String randomRole = "randomRole";
+        when(userDao.findByUsername(username)).thenReturn(Optional.of(UserEntity.from(aUser(username))));
+        when(roleDao.findByRoleName(randomRole)).thenReturn(Optional.empty());
+
+        thrown.expect(WebApplicationException.class);
+        thrown.expectMessage("HTTP 400 Bad Request");
+        serviceRoleUpdater.doUpdate(username, randomInt(), randomRole);
+    }
+
+    @Test
+    public void shouldError_ifServiceNotBelongToUser_whenUpdatingServiceRole() throws Exception {
+        String username = "existing-user";
+        String role = "a-role";
+        when(userDao.findByUsername(username)).thenReturn(Optional.of(UserEntity.from(aUser(username))));
+        when(roleDao.findByRoleName(role)).thenReturn(Optional.of(new RoleEntity(aRole(1, role))));
+
+        thrown.expect(WebApplicationException.class);
+        thrown.expectMessage("HTTP 409 Conflict");
+        serviceRoleUpdater.doUpdate(username, randomInt(), role);
+    }
+
+    @Test
+    public void shouldError_ifCountOfServiceAdminsLessThan1_whenUpdatingServiceRole() throws Exception {
+        String username = "existing-user";
+        String role = "a-role";
+        Integer serviceId = 1;
+
+        UserEntity userEntity = UserEntity.from(aUser(username));
+        RoleEntity roleEntity = new RoleEntity(aRole(10, role)); //non admin
+        ServiceEntity serviceEntity = new ServiceEntity(asList("1"));
+        serviceEntity.setId(serviceId);
+        userEntity.setServiceRole(new ServiceRoleEntity(serviceEntity, roleEntity));
+
+        when(userDao.findByUsername(username)).thenReturn(Optional.of(userEntity));
+        when(roleDao.findByRoleName(role)).thenReturn(Optional.of(roleEntity));
+        when(serviceDao.countOfRolesForService(serviceId,ROLE_ADMIN_ID)).thenReturn(1l);
+
+        thrown.expect(WebApplicationException.class);
+        thrown.expectMessage("HTTP 412 Precondition Failed");
+        serviceRoleUpdater.doUpdate(username, serviceId, role);
+    }
+
+    @Test
+    public void shouldReturnUpdatedUser_whenUpdatingServiceRoleSuccess() throws Exception {
+        String username = "existing-user";
+        String role = "a-role";
+        Integer serviceId = 1;
+
+        UserEntity userEntity = UserEntity.from(aUser(username));
+        RoleEntity roleEntity = new RoleEntity(aRole(10, role)); //non admin
+        ServiceEntity serviceEntity = new ServiceEntity(asList("1"));
+        serviceEntity.setId(serviceId);
+        userEntity.setServiceRole(new ServiceRoleEntity(serviceEntity, roleEntity));
+
+        when(userDao.findByUsername(username)).thenReturn(Optional.of(userEntity));
+        when(roleDao.findByRoleName(role)).thenReturn(Optional.of(roleEntity));
+        when(serviceDao.countOfRolesForService(serviceId,ROLE_ADMIN_ID)).thenReturn(2l);
+
+        Optional<User> userOptional = serviceRoleUpdater.doUpdate(username, serviceId, role);
+        assertTrue(userOptional.isPresent());
+        assertThat(userOptional.get().getRole().getId(),is(10));
+    }
+
+    private Role aRole(int roleId, String roleName) {
+        return Role.role(roleId, roleName, roleName + "-description");
+    }
+
+    private User aUser(String username) {
+        return User.from(randomInt(), username, "random-password", "random@email.com", asList("1"), newArrayList(), "784rh", "8948924");
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
@@ -128,11 +128,14 @@ public class DatabaseTestHelper {
         return this;
     }
 
+    //inserting if not exist, just to be safe for fixed value inserts like Admin role
     public DatabaseTestHelper add(Role role) {
         jdbi.withHandle(handle ->
                 handle
                         .createStatement("INSERT INTO roles(id, name, description) " +
-                                "VALUES (:id, :name, :description)")
+                                "SELECT :id, :name, :description " +
+                                "WHERE NOT EXISTS (SELECT id FROM roles WHERE id=:id) " +
+                                "RETURNING id")
                         .bind("id", role.getId())
                         .bind("name", role.getName())
                         .bind("description", role.getDescription())
@@ -211,6 +214,16 @@ public class DatabaseTestHelper {
                             .execute()
             );
         }
+        return this;
+    }
+
+    public DatabaseTestHelper addUserServiceRole(Integer userId, Integer serviceId, Integer roleId) {
+        jdbi.withHandle(handle -> handle
+                .createStatement("INSERT INTO user_services_roles(user_id, service_id, role_id) VALUES(:userId, :serviceId, :roleId)")
+                .bind("userId", userId)
+                .bind("serviceId", serviceId)
+                .bind("roleId", roleId)
+                .execute());
         return this;
     }
 }


### PR DESCRIPTION
Introduced `PUT  /v1/api/users/{username}/services/{service-id}`

Instead of adding business logic on to the existing UserService (which is already grown bit too much), have introduced a guice assisted factory pattern to obtain business service components that can be used by UserResource. The upside of this guice factory is that we can have @Transactional around the component method as usual.
And we can unit test each individual business service object separately without messing around other business services (unlike UserServicesTest.java)