### PR TITLE
PP-1759 Add Adminusers Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,49 @@
+#!/usr/bin/env groovy
+
+pipeline {
+  agent any
+
+  options {
+    ansiColor('xterm')
+    timestamps()
+  }
+
+  libraries {
+    lib("pay-jenkins-library@master")
+  }
+
+  environment {
+    DOCKER_HOST = "unix:///var/run/docker.sock"
+  }
+
+  stages {
+    stage('Maven Build') {
+      steps {
+        sh 'docker pull govukpay/postgres:9.4.4'
+        sh 'mvn clean package'
+      }
+    }
+    stage('Docker Build') {
+      steps {
+        script {
+          buildApp{
+            app = "adminusers"
+          }
+        }
+      }
+    }
+    stage('Test') {
+      steps {
+        runEndToEnd("adminusers")
+      }
+    }
+    stage('Deploy') {
+      when {
+        branch 'master'
+      }
+      steps {
+        deploy("adminusers", "test")
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### What

Adds a Jenkinsfile for `pay-adminusers`.

![screen shot 2017-03-27 at 09 12 46](https://cloud.githubusercontent.com/assets/3025844/24346759/b170ec00-12cd-11e7-9521-d00c34ec4769.png)

When this is merged the following jobs need to be disabled + deleted:
- [ ] trigger-pay-adminusers-master
- [ ] trigger-pay-adminusers-pull-request
- [ ] build-pay-adminusers
- [ ] deploy-pay-adminusers

Depends on https://github.com/alphagov/pay-chef/pull/163 being merged + deployed.