### PR TITLE
PP-1771 Clean up after users migration (add constraints)

### DIFF
--- a/src/main/resources/migrations/00016_alter_table_users_unique_email.sql
+++ b/src/main/resources/migrations/00016_alter_table_users_unique_email.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter-table-users-update-column-email-unique-back
+ALTER TABLE users ADD CONSTRAINT users_email_unique UNIQUE (email);
+
+--rollback ALTER TABLE users DROP CONSTRAINT users_email_unique;

--- a/src/main/resources/migrations/00017_alter_table_users_unique_username.sql
+++ b/src/main/resources/migrations/00017_alter_table_users_unique_username.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter-table-users-update-column-username-unique-back
+ALTER TABLE users ADD CONSTRAINT users_username_unique UNIQUE (username);
+
+--rollback ALTER TABLE users DROP CONSTRAINT users_username_unique;

--- a/src/main/resources/migrations/00018_alter_table_users_drop_column_is_new.sql
+++ b/src/main/resources/migrations/00018_alter_table_users_drop_column_is_new.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter-table-users-drop-column-is_new
+ALTER TABLE users DROP COLUMN is_new;
+
+--rollback ALTER TABLE users ADD COLUMN is_new INTEGER NOT NULL DEFAULT 1;

--- a/src/main/resources/migrations/00019_add_constraint_service_gateway_accounts_gateway_account_id.sql
+++ b/src/main/resources/migrations/00019_add_constraint_service_gateway_accounts_gateway_account_id.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table-service_gateway_accounts-add-constraint-back
+ALTER TABLE service_gateway_accounts ADD CONSTRAINT service_gateway_accounts_gateway_account_id_key UNIQUE (gateway_account_id);
+
+--rollback ALTER TABLE service_gateway_accounts DROP CONSTRAINT service_gateway_accounts_gateway_account_id_key;

--- a/src/test/java/uk/gov/pay/adminusers/pact/UsersApiTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/pact/UsersApiTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.http.ContentType.JSON;
+import static org.apache.commons.lang3.RandomStringUtils.*;
 import static org.apache.commons.lang3.RandomUtils.nextInt;
 import static uk.gov.pay.adminusers.fixtures.RoleDbFixture.roleDbFixture;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
@@ -51,7 +52,7 @@ public class UsersApiTest {
     @State("a valid forgotten password entry and a related user exists")
     public void aUserExistsWithAForgottenPasswordRequest() throws Exception {
         String code = "avalidforgottenpasswordtoken";
-        String username = RandomStringUtils.randomAlphabetic(20);
+        String username = randomAlphabetic(20);
         createUserWithinAService(username, "password");
         List<Map<String, Object>> userByUsername = dbHelper.findUserByUsername(username);
         dbHelper.add(ForgottenPassword.forgottenPassword(code, username), (Integer) userByUsername.get(0).get("id"));
@@ -77,14 +78,16 @@ public class UsersApiTest {
     }
 
     private static void createUserWithinAService(String username, int serviceId, String password) throws Exception {
+        String gatewayAccount1 = randomNumeric(5);
+        String gatewayAccount2 = randomNumeric(5);
         roleDbFixture(dbHelper).withName("admin").insertRole();
-        serviceDbFixture(dbHelper).withId(serviceId).withGatewayAccountIds("1", "2").insertService();
+        serviceDbFixture(dbHelper).withId(serviceId).withGatewayAccountIds(gatewayAccount1, gatewayAccount2).insertService();
 
         ImmutableMap<Object, Object> userPayload = ImmutableMap.builder()
                 .put("username", username)
                 .put("password", password)
                 .put("email", "user-" + username + "@example.com")
-                .put("gateway_account_ids", new String[]{"1", "2"})
+                .put("gateway_account_ids", new String[]{gatewayAccount1, gatewayAccount2})
                 .put("telephone_number", "45334534634")
                 .put("otp_key", "34f34")
                 .put("role_name", "admin")

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateAndGetTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateAndGetTest.java
@@ -75,7 +75,9 @@ public class UserResourceCreateAndGetTest extends IntegrationTest {
 
     @Test
     public void shouldCreateAUserWithinAServiceIfServiceIdIsInPayloadIgnoringGatewayAccountIds() throws Exception {
-        int serviceId = serviceDbFixture(databaseHelper).withGatewayAccountIds("1", "2").insertService();
+        String gatewayAccount1 = valueOf(nextInt());
+        String gatewayAccount2 = valueOf(nextInt());
+        int serviceId = serviceDbFixture(databaseHelper).withGatewayAccountIds(gatewayAccount1, gatewayAccount2).insertService();
         String username = randomAlphanumeric(10) + randomUUID().toString();
 
         ImmutableMap<Object, Object> userPayload = ImmutableMap.builder()
@@ -101,8 +103,7 @@ public class UserResourceCreateAndGetTest extends IntegrationTest {
                 .body("password", nullValue())
                 .body("email", is("user-" + username + "@example.com"))
                 .body("gateway_account_ids", hasSize(2))
-                .body("gateway_account_ids[0]", is("1"))
-                .body("gateway_account_ids[1]", is("2"))
+                .body("gateway_account_ids", hasItems(gatewayAccount1,gatewayAccount2))
                 .body("service_ids", hasSize(1))
                 .body("service_ids[0]", is(valueOf(serviceId)))
                 .body("telephone_number", is("45334534634"))
@@ -281,7 +282,9 @@ public class UserResourceCreateAndGetTest extends IntegrationTest {
 
     @Test
     public void shouldReturnUser_whenGetUserWithUsername() throws Exception {
-        int serviceId = serviceDbFixture(databaseHelper).withGatewayAccountIds("1", "2").insertService();
+        String gatewayAccount1 = valueOf(nextInt());
+        String gatewayAccount2 = valueOf(nextInt());
+        int serviceId = serviceDbFixture(databaseHelper).withGatewayAccountIds(gatewayAccount1, gatewayAccount2).insertService();
         Role role = roleDbFixture(databaseHelper).insertRole();
         User user = userDbFixture(databaseHelper).withServiceRole(serviceId, role.getId()).insertUser();
 
@@ -297,8 +300,7 @@ public class UserResourceCreateAndGetTest extends IntegrationTest {
                 .body("password", nullValue())
                 .body("email", is(user.getEmail()))
                 .body("gateway_account_ids", hasSize(2))
-                .body("gateway_account_ids[0]", is("1"))
-                .body("gateway_account_ids[1]", is("2"))
+                .body("gateway_account_ids", hasItems(gatewayAccount1, gatewayAccount2))
                 .body("service_ids", hasSize(1))
                 .body("service_ids[0]", is(valueOf(serviceId)))
                 .body("telephone_number", is(user.getTelephoneNumber()))


### PR DESCRIPTION
## WHAT    
-  unique email / username.
-  unique gateway accounts in service_gateway_accounts.
- Drop temporary column 'is_new'