### PR TITLE
PP-1896 Username and email case insensitive on findBy DAO methods

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/persistence/dao/UserDao.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/dao/UserDao.java
@@ -31,21 +31,21 @@ public class UserDao extends JpaDao<UserEntity> {
 
     public Optional<UserEntity> findByUsername(String username) {
         String query = "SELECT u FROM UserEntity u " +
-                "WHERE u.username = :username";
+                "WHERE LOWER(u.username) = :username";
 
         return entityManager.get()
                 .createQuery(query, UserEntity.class)
-                .setParameter("username", username)
+                .setParameter("username", username.toLowerCase())
                 .getResultList().stream().findFirst();
     }
 
     public Optional<UserEntity> findByEmail(String email) {
         String query = "SELECT u FROM UserEntity u " +
-                "WHERE u.email = :email";
+                "WHERE LOWER(u.email) = :email";
 
         return entityManager.get()
                 .createQuery(query, UserEntity.class)
-                .setParameter("email", email)
+                .setParameter("email", email.toLowerCase())
                 .getResultList().stream().findFirst();
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoTest.java
@@ -125,7 +125,7 @@ public class UserDaoTest extends DaoTestBase {
     }
 
     @Test
-    public void shouldFindUserBy_Username() throws Exception {
+    public void shouldFindUserBy_Username_caseInsensitive() throws Exception {
         Role role = roleDbFixture(databaseHelper).insertRole();
         int serviceId = serviceDbFixture(databaseHelper)
                 .insertService();
@@ -135,7 +135,7 @@ public class UserDaoTest extends DaoTestBase {
         String username = user.getUsername();
         String otpKey = user.getOtpKey();
 
-        Optional<UserEntity> userEntityMaybe = userDao.findByUsername(username);
+        Optional<UserEntity> userEntityMaybe = userDao.findByUsername(username.toUpperCase());
         assertTrue(userEntityMaybe.isPresent());
 
         UserEntity foundUser = userEntityMaybe.get();
@@ -151,7 +151,7 @@ public class UserDaoTest extends DaoTestBase {
     }
 
     @Test
-    public void shouldFindUser_ByEmail() throws Exception {
+    public void shouldFindUser_ByEmail_caseInsensitive() throws Exception {
         Role role = roleDbFixture(databaseHelper).insertRole();
         int serviceId = serviceDbFixture(databaseHelper).insertService();
         User user = userDbFixture(databaseHelper)
@@ -161,7 +161,7 @@ public class UserDaoTest extends DaoTestBase {
         String otpKey = user.getOtpKey();
         String email = user.getEmail();
 
-        Optional<UserEntity> userEntityMaybe = userDao.findByEmail(username + "@example.com");
+        Optional<UserEntity> userEntityMaybe = userDao.findByEmail(username + "@EXAMPLE.com");
         assertTrue(userEntityMaybe.isPresent());
 
         UserEntity foundUser = userEntityMaybe.get();


### PR DESCRIPTION
- We have an issue in forgotten passwords not resetting passwords when email does not match db case so making the find case insensitive for both username (is this what is being used) and email.