### PR TITLE
PP-1866 Call deploy function with TAG_AFTER_DEPLOYMENT set to true

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
         branch 'master'
       }
       steps {
-        deploy("adminusers", "test")
+        deploy("adminusers", "test", null, true)
       }
     }
   }


### PR DESCRIPTION
Calls the `deploy` Jenkinsfile library function with `tagAfterDeployment` set to `true`, which means that the `TAG_AFTER_DEPLOYMENT` parameter passed to the invoked Jenkins job is also set to true

with @mrlumbu