### PR TITLE
PP-1857 Upgrade Notify client to version 3.1.1-RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
         <dependency>
             <groupId>uk.gov.service.notify</groupId>
             <artifactId>notifications-java-client</artifactId>
-            <version>2.0.0-RELEASE</version>
+            <version>3.1.2-RELEASE</version>
         </dependency>
 
         <!-- testing -->

--- a/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersModule.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersModule.java
@@ -15,11 +15,13 @@ import uk.gov.pay.adminusers.resources.ResetPasswordValidator;
 import uk.gov.pay.adminusers.resources.UserRequestValidator;
 import uk.gov.pay.adminusers.service.*;
 import uk.gov.pay.adminusers.validations.RequestValidations;
-import uk.gov.service.notify.NotificationClient;
 
 import java.util.Properties;
 
+import static uk.gov.pay.adminusers.app.util.TrustStoreLoader.*;
+
 public class AdminUsersModule extends AbstractModule {
+
     final AdminUsersConfig configuration;
     final Environment environment;
 
@@ -32,7 +34,6 @@ public class AdminUsersModule extends AbstractModule {
     protected void configure() {
         bind(AdminUsersConfig.class).toInstance(configuration);
         bind(Environment.class).toInstance(environment);
-        bind(NotificationClient.class).toProvider(NotifyClientProvider.class);
         bind(LinksBuilder.class).toInstance(new LinksBuilder(configuration.getBaseUrl()));
 
         bind(PasswordHasher.class).in(Singleton.class);
@@ -77,7 +78,7 @@ public class AdminUsersModule extends AbstractModule {
     private UserNotificationService provideUserNotificationService() {
         return new UserNotificationService(
                 environment.lifecycle().executorService("2fa-sms-%d").build(),
-                new NotifyClientProvider(configuration.getNotifyConfiguration()),
+                new NotifyClientProvider(configuration.getNotifyConfiguration(), getSSLContext()),
                 configuration.getNotifyConfiguration().getSecondFactorSmsTemplateId(),
                 environment.metrics());
     }

--- a/src/main/java/uk/gov/pay/adminusers/app/config/NotifyConfiguration.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/NotifyConfiguration.java
@@ -9,11 +9,7 @@ public class NotifyConfiguration extends Configuration {
 
     @Valid
     @NotNull
-    private String secret;
-
-    @Valid
-    @NotNull
-    private String serviceId;
+    private String apiKey;
 
     @Valid
     @NotNull
@@ -23,12 +19,8 @@ public class NotifyConfiguration extends Configuration {
     @NotNull
     private String secondFactorSmsTemplateId;
 
-    public String getSecret() {
-        return secret;
-    }
-
-    public String getServiceId() {
-        return serviceId;
+    public String getApiKey() {
+        return apiKey;
     }
 
     public String getNotificationBaseURL() {

--- a/src/main/java/uk/gov/pay/adminusers/service/NotifyClientProvider.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NotifyClientProvider.java
@@ -1,25 +1,23 @@
 package uk.gov.pay.adminusers.service;
 
-import com.google.inject.Inject;
 import com.google.inject.Provider;
 import uk.gov.pay.adminusers.app.config.NotifyConfiguration;
 import uk.gov.service.notify.NotificationClient;
 
+import javax.net.ssl.SSLContext;
+
 public class NotifyClientProvider implements Provider<NotificationClient> {
 
     private NotifyConfiguration configuration;
+    private final SSLContext sslContext;
 
-    @Inject
-    public NotifyClientProvider(NotifyConfiguration configuration) {
+    public NotifyClientProvider(NotifyConfiguration configuration, SSLContext sslContext) {
         this.configuration = configuration;
+        this.sslContext = sslContext;
     }
 
     @Override
     public NotificationClient get() {
-        return new NotificationClient(configuration.getSecret(),
-                configuration.getServiceId(),
-                configuration.getNotificationBaseURL()
-        );
+        return new NotificationClient(configuration.getApiKey(), configuration.getNotificationBaseURL(), null, sslContext);
     }
-
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/UserNotificationService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserNotificationService.java
@@ -3,7 +3,7 @@ package uk.gov.pay.adminusers.service;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Stopwatch;
-import uk.gov.service.notify.NotificationResponse;
+import uk.gov.service.notify.SendSmsResponse;
 
 import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
@@ -32,8 +32,8 @@ public class UserNotificationService {
             personalisation.put("code", passcode);
             Stopwatch responseTimeStopwatch = Stopwatch.createStarted();
             try {
-                NotificationResponse notificationResponse = notifyClientProvider.get().sendSms(secondFactorSmsTemplateId, phoneNumber, personalisation);
-                return notificationResponse.getNotificationId();
+                SendSmsResponse response = notifyClientProvider.get().sendSms(secondFactorSmsTemplateId, phoneNumber, personalisation, null);
+                return response.getNotificationId().toString();
             } catch (Exception e) {
                 metricRegistry.counter("notify-operations.sms.failures").inc();
                 throw AdminUsersExceptions.userNotificationError(e);

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -60,8 +60,7 @@ proxy:
   port: ${HTTP_PROXY_PORT}
 
 notify:
-  secret: ${NOTIFY_SECRET:-pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs}
-  serviceId: ${NOTIFY_SERVICE_ID:-pay-notify-service-id}
+  apiKey: ${NOTIFY_API_KEY:-api_key-pay-notify-service-id-pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs}
   notificationBaseURL: ${NOTIFY_BASE_URL:-https://stubs.pymnt.localdomain/notify}
   secondFactorSmsTemplateId: ${NOTIFY_2FA_TEMPLATE_ID:-pay-notify-two-factor-template-id}
 

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -60,8 +60,7 @@ proxy:
   port: 1234
 
 notify:
-  secret: ${NOTIFY_SECRET:-pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs}
-  serviceId: ${NOTIFY_SERVICE_ID:-pay-notify-service-id}
+  apiKey: ${NOTIFY_API_KEY:-pay-notify-api-key}
   notificationBaseURL: ${NOTIFY_BASE_URL:-https://stubs.pymnt.localdomain/notify}
   secondFactorSmsTemplateId: ${NOTIFY_2FA_TEMPLATE_ID:-pay-notify-two-factor-template-id}
 


### PR DESCRIPTION
- We are running an old version of Notify client, this upgrade will allow us to send emails in _adminusers_ therefore we can implement Forgotten Password and Invite email notifications.