### PR TITLE
PP-1717 Genarate externalId only when needed

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/app/util/RandomIdGenerator.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/util/RandomIdGenerator.java
@@ -25,15 +25,11 @@ public class RandomIdGenerator {
         return new BigInteger(130, SECURE_RANDOM).toString(32);
     }
 
-    public static Long newLongId() {
-        return (long) Math.floor(Math.random() * 9000000000L) + 1000000000L;
-    }
-
     public static Integer randomInt() {
         return RANDOM.nextInt(Integer.MAX_VALUE);
     }
 
     public static String randomUuid() {
-        return UUID.randomUUID().toString().replace("-", "");
+        return UUID.randomUUID().toString().replace("-", "").toLowerCase();
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/model/CreateUserRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/CreateUserRequest.java
@@ -1,0 +1,114 @@
+package uk.gov.pay.adminusers.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.google.common.collect.ImmutableList;
+import uk.gov.pay.adminusers.utils.Comparators;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.newId;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class CreateUserRequest {
+
+    public static final String FIELD_USERNAME = "username";
+    public static final String FIELD_PASSWORD = "password";
+    public static final String FIELD_EMAIL = "email";
+    public static final String FIELD_SERVICE_IDS = "service_ids";
+    public static final String FIELD_GATEWAY_ACCOUNT_IDS = "gateway_account_ids";
+    public static final String FIELD_TELEPHONE_NUMBER = "telephone_number";
+    public static final String FIELD_OTP_KEY = "otp_key";
+    public static final String FIELD_ROLE_NAME = "role_name";
+
+    private String username;
+    private String password;
+    private String email;
+    private List<String> gatewayAccountIds = new ArrayList<>();
+    private String telephoneNumber;
+    private List<String> serviceIds = new ArrayList<>();
+    private String otpKey;
+
+    public static CreateUserRequest from(String username, String password, String email,
+                                         List<String> gatewayAccountIds, List<String> serviceIds, String otpKey, String telephoneNumber) {
+        return new CreateUserRequest(username, password, email, gatewayAccountIds, serviceIds, otpKey, telephoneNumber);
+    }
+
+    public static CreateUserRequest from(JsonNode node) {
+        List<String> serviceIds = new ArrayList<>();
+        try {
+            List<String> gatewayAccountIds =
+                    ImmutableList.copyOf(node.get(FIELD_GATEWAY_ACCOUNT_IDS).iterator())
+                            .stream().map(JsonNode::asText)
+                            .sorted(Comparators.usingNumericComparator())
+                            .collect(Collectors.toList());
+            JsonNode serviceIdsNode = node.get(FIELD_SERVICE_IDS);
+            if (serviceIdsNode != null) {
+               serviceIds =
+                        ImmutableList.copyOf(serviceIdsNode.iterator())
+                                .stream().map(JsonNode::asText)
+                                .sorted(Comparators.usingNumericComparator())
+                                .collect(Collectors.toList());
+            }
+            String username = node.get(FIELD_USERNAME).asText();
+            String password = getOrElseRandom(node.get(FIELD_PASSWORD), newId());
+            String email = node.get(FIELD_EMAIL).asText();
+            String telephoneNumber = node.get(FIELD_TELEPHONE_NUMBER).asText();
+            String otpKey = getOrElseRandom(node.get(FIELD_OTP_KEY), newId());
+            return from(username, password, email, gatewayAccountIds, serviceIds, otpKey, telephoneNumber);
+        } catch (NullPointerException e) {
+            throw new RuntimeException("Error retrieving required fields for creating a user", e);
+        }
+    }
+
+    private static String getOrElseRandom(JsonNode elementNode, String randomValue) {
+        return elementNode == null || isBlank(elementNode.asText()) ? randomValue : elementNode.asText();
+    }
+
+    private CreateUserRequest(@JsonProperty("username") String username, @JsonProperty("password") String password,
+                              @JsonProperty("email") String email, @JsonProperty("gateway_account_ids") List<String> gatewayAccountIds,
+                              List<String> serviceIds, @JsonProperty("otp_key") String otpKey, @JsonProperty("telephone_number") String telephoneNumber) {
+        this.username = username;
+        this.password = password;
+        this.email = email;
+        this.gatewayAccountIds = gatewayAccountIds;
+        this.serviceIds = serviceIds;
+        this.otpKey = otpKey;
+        this.telephoneNumber = telephoneNumber;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    @JsonIgnore
+    public String getPassword() {
+        return password;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public List<String> getGatewayAccountIds() {
+        return gatewayAccountIds;
+    }
+
+    public List<String> getServiceIds() {
+        return serviceIds;
+    }
+
+    public String getOtpKey() {
+        return otpKey;
+    }
+
+    public String getTelephoneNumber() {
+        return telephoneNumber;
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/model/User.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/User.java
@@ -17,13 +17,10 @@ import static java.lang.Boolean.FALSE;
 import static java.util.Collections.emptyList;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.newId;
-import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
-import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class User {
 
-    public static final String FIELD_EXTERNAL_ID = "external_id";
     public static final String FIELD_USERNAME = "username";
     public static final String FIELD_PASSWORD = "password";
     public static final String FIELD_EMAIL = "email";
@@ -69,13 +66,12 @@ public class User {
                                 .sorted(Comparators.usingNumericComparator())
                                 .collect(Collectors.toList());
             }
-            String externalId = getOrElseRandom(node.get(FIELD_EXTERNAL_ID), randomUuid());
             String username = node.get(FIELD_USERNAME).asText();
             String password = getOrElseRandom(node.get(FIELD_PASSWORD), newId());
             String email = node.get(FIELD_EMAIL).asText();
             String telephoneNumber = node.get(FIELD_TELEPHONE_NUMBER).asText();
             String otpKey = getOrElseRandom(node.get(FIELD_OTP_KEY), newId());
-            return from(randomInt(), externalId, username, password, email, gatewayAccountIds, serviceIds, otpKey, telephoneNumber);
+            return from(null, null, username, password, email, gatewayAccountIds, serviceIds, otpKey, telephoneNumber);
         } catch (NullPointerException e) {
             throw new RuntimeException("Error retrieving required fields for creating a user", e);
         }
@@ -85,21 +81,9 @@ public class User {
         return elementNode == null || isBlank(elementNode.asText()) ? randomValue : elementNode.asText();
     }
 
-    private User(Integer id, @JsonProperty("external_id") String externalId, @JsonProperty("username") String username, @JsonProperty("password") String password,
+    private User(Integer id, String externalId, @JsonProperty("username") String username, @JsonProperty("password") String password,
                  @JsonProperty("email") String email, @JsonProperty("gateway_account_ids") List<String> gatewayAccountIds,
-                 @JsonProperty("otp_key") String otpKey, @JsonProperty("telephone_number") String telephoneNumber) {
-        this.id = id;
-        this.externalId = externalId;
-        this.username = username;
-        this.password = password;
-        this.email = email;
-        this.gatewayAccountIds = gatewayAccountIds;
-        this.otpKey = otpKey;
-        this.telephoneNumber = telephoneNumber;
-    }
-
-    private User(Integer id, String externalId, String username, String password, String email, List<String> gatewayAccountIds,
-                 List<String> serviceIds, String otpKey, String telephoneNumber) {
+                 List<String> serviceIds, @JsonProperty("otp_key") String otpKey, @JsonProperty("telephone_number") String telephoneNumber) {
         this.id = id;
         this.externalId = externalId;
         this.username = username;

--- a/src/main/java/uk/gov/pay/adminusers/model/User.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/User.java
@@ -3,20 +3,14 @@ package uk.gov.pay.adminusers.model;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.google.common.collect.ImmutableList;
-import uk.gov.pay.adminusers.utils.Comparators;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static java.lang.Boolean.FALSE;
 import static java.util.Collections.emptyList;
-import static org.apache.commons.lang3.StringUtils.isBlank;
-import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.newId;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class User {
@@ -39,7 +33,7 @@ public class User {
     private String telephoneNumber;
     private List<String> serviceIds = new ArrayList<>();
     private String otpKey;
-    private Boolean disabled = FALSE;
+    private Boolean disabled = Boolean.FALSE;
     private Integer loginCounter = 0;
     private List<Role> roles = new ArrayList<>();
     private List<Link> links = new ArrayList<>();
@@ -50,38 +44,7 @@ public class User {
         return new User(id, externalId, username, password, email, gatewayAccountIds, serviceIds, otpKey, telephoneNumber);
     }
 
-    public static User from(JsonNode node) {
-        List<String> serviceIds = new ArrayList<>();
-        try {
-            List<String> gatewayAccountIds =
-                    ImmutableList.copyOf(node.get(FIELD_GATEWAY_ACCOUNT_IDS).iterator())
-                            .stream().map(JsonNode::asText)
-                            .sorted(Comparators.usingNumericComparator())
-                            .collect(Collectors.toList());
-            JsonNode serviceIdsNode = node.get(FIELD_SERVICE_IDS);
-            if (serviceIdsNode != null) {
-               serviceIds =
-                        ImmutableList.copyOf(serviceIdsNode.iterator())
-                                .stream().map(JsonNode::asText)
-                                .sorted(Comparators.usingNumericComparator())
-                                .collect(Collectors.toList());
-            }
-            String username = node.get(FIELD_USERNAME).asText();
-            String password = getOrElseRandom(node.get(FIELD_PASSWORD), newId());
-            String email = node.get(FIELD_EMAIL).asText();
-            String telephoneNumber = node.get(FIELD_TELEPHONE_NUMBER).asText();
-            String otpKey = getOrElseRandom(node.get(FIELD_OTP_KEY), newId());
-            return from(null, null, username, password, email, gatewayAccountIds, serviceIds, otpKey, telephoneNumber);
-        } catch (NullPointerException e) {
-            throw new RuntimeException("Error retrieving required fields for creating a user", e);
-        }
-    }
-
-    private static String getOrElseRandom(JsonNode elementNode, String randomValue) {
-        return elementNode == null || isBlank(elementNode.asText()) ? randomValue : elementNode.asText();
-    }
-
-    private User(Integer id, String externalId, @JsonProperty("username") String username, @JsonProperty("password") String password,
+    private User(Integer id, @JsonProperty("external_id") String externalId, @JsonProperty("username") String username, @JsonProperty("password") String password,
                  @JsonProperty("email") String email, @JsonProperty("gateway_account_ids") List<String> gatewayAccountIds,
                  List<String> serviceIds, @JsonProperty("otp_key") String otpKey, @JsonProperty("telephone_number") String telephoneNumber) {
         this.id = id;
@@ -93,6 +56,11 @@ public class User {
         this.serviceIds = serviceIds;
         this.otpKey = otpKey;
         this.telephoneNumber = telephoneNumber;
+    }
+
+    @JsonIgnore
+    public Integer getId() {
+        return id;
     }
 
     public String getExternalId() {
@@ -187,11 +155,6 @@ public class User {
 
     public void setRoles(List<Role> roles) {
         this.roles = roles;
-    }
-
-    @JsonIgnore
-    public Integer getId() {
-        return id;
     }
 
     @JsonProperty("_links")

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.adminusers.persistence.entity;
 
+import uk.gov.pay.adminusers.app.util.RandomIdGenerator;
+import uk.gov.pay.adminusers.model.CreateUserRequest;
 import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.utils.Comparators;
 
@@ -13,7 +15,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static java.lang.Boolean.FALSE;
 import static java.lang.String.valueOf;
 
 @Entity
@@ -40,7 +41,7 @@ public class UserEntity extends AbstractEntity {
     private String telephoneNumber;
 
     @Column(name = "disabled")
-    private Boolean disabled = FALSE;
+    private Boolean disabled = Boolean.FALSE;
 
     @Column(name = "login_counter")
     private Integer loginCounter = 0;
@@ -177,6 +178,29 @@ public class UserEntity extends AbstractEntity {
         userEntity.setLoginCounter(user.getLoginCounter());
         userEntity.setDisabled(user.isDisabled());
         userEntity.setSessionVersion(user.getSessionVersion());
+        ZonedDateTime timeNow = ZonedDateTime.now(ZoneId.of("UTC"));
+        userEntity.setCreatedAt(timeNow);
+        userEntity.setUpdatedAt(timeNow);
+        return userEntity;
+    }
+
+    /**
+     * Creates UserEntity object from CreateUserRequest object
+     *
+     * @param createUserRequest
+     * @return persistable UserEntity object not bounded to entity manager
+     */
+    public static UserEntity from(CreateUserRequest createUserRequest) {
+        UserEntity userEntity = new UserEntity();
+        userEntity.setExternalId(RandomIdGenerator.randomUuid());
+        userEntity.setUsername(createUserRequest.getUsername());
+        userEntity.setPassword(createUserRequest.getPassword());
+        userEntity.setEmail(createUserRequest.getEmail());
+        userEntity.setOtpKey(createUserRequest.getOtpKey());
+        userEntity.setTelephoneNumber(createUserRequest.getTelephoneNumber());
+        userEntity.setLoginCounter(0);
+        userEntity.setDisabled(Boolean.FALSE);
+        userEntity.setSessionVersion(0);
         ZonedDateTime timeNow = ZonedDateTime.now(ZoneId.of("UTC"));
         userEntity.setCreatedAt(timeNow);
         userEntity.setUpdatedAt(timeNow);

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
@@ -21,7 +21,7 @@ import static java.lang.String.valueOf;
 @SequenceGenerator(name = "users_id_seq", sequenceName = "users_id_seq", allocationSize = 1)
 public class UserEntity extends AbstractEntity {
 
-    @Column(name = "external_id", insertable = false, updatable = false)
+    @Column(name = "external_id")
     private String externalId;
 
     @Column(name = "username")

--- a/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
@@ -8,6 +8,7 @@ import com.google.inject.Inject;
 import io.dropwizard.jersey.PATCH;
 import org.slf4j.Logger;
 import uk.gov.pay.adminusers.logger.PayLoggerFactory;
+import uk.gov.pay.adminusers.model.CreateUserRequest;
 import uk.gov.pay.adminusers.model.PatchRequest;
 import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.service.UserServices;
@@ -93,10 +94,10 @@ public class UserResource {
         return validator.validateCreateRequest(node)
                 .map(errors -> Response.status(BAD_REQUEST).entity(errors).build())
                 .orElseGet(() -> {
-                    String roleName = node.get(User.FIELD_ROLE_NAME).asText();
-                    String userName = node.get(User.FIELD_USERNAME).asText();
+                    String roleName = node.get(CreateUserRequest.FIELD_ROLE_NAME).asText();
+                    String userName = node.get(CreateUserRequest.FIELD_USERNAME).asText();
                     try {
-                        User newUser = userServices.createUser(User.from(node), roleName);
+                        User newUser = userServices.createUser(CreateUserRequest.from(node), roleName);
                         logger.info("User created successfully [{}] for gateway accounts [{}]", newUser.getExternalId(), String.join(", ", newUser.getGatewayAccountIds()));
                         return Response.status(CREATED).type(APPLICATION_JSON)
                                 .entity(newUser).build();

--- a/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
@@ -5,6 +5,7 @@ import com.google.inject.Provider;
 import com.google.inject.name.Named;
 import com.google.inject.persist.Transactional;
 import org.slf4j.Logger;
+import uk.gov.pay.adminusers.app.util.RandomIdGenerator;
 import uk.gov.pay.adminusers.logger.PayLoggerFactory;
 import uk.gov.pay.adminusers.model.PatchRequest;
 import uk.gov.pay.adminusers.model.SecondFactorToken;
@@ -74,6 +75,7 @@ public class UserServices {
                 .map(roleEntity -> {
                     UserEntity userEntity = UserEntity.from(user);
                     userEntity.setPassword(passwordHasher.hash(user.getPassword()));
+                    userEntity.setExternalId(RandomIdGenerator.randomUuid());
                     if(user.getServiceIds().isEmpty()) {
                         addServiceRoleToUser(userEntity, roleEntity, user.getGatewayAccountIds());
                     } else {

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
@@ -15,7 +15,6 @@ public class UserDbFixture {
     private final DatabaseTestHelper databaseTestHelper;
     private Integer serviceId;
     private Integer roleId;
-    private String externalId = randomUuid();
     private String username = RandomStringUtils.randomAlphabetic(10);
     private String otpKey = RandomStringUtils.randomAlphabetic(10);
     private String password = "password-" + username;
@@ -35,14 +34,9 @@ public class UserDbFixture {
             serviceId = ServiceDbFixture.serviceDbFixture(databaseTestHelper).insertService();
             roleId = RoleDbFixture.roleDbFixture(databaseTestHelper).insertRole().getId();
         }
-        User user = User.from(randomInt(), externalId, username, password, email, newArrayList(), asList(valueOf(serviceId)), otpKey, telephoneNumber);
+        User user = User.from(randomInt(), randomUuid(), username, password, email, newArrayList(), asList(valueOf(serviceId)), otpKey, telephoneNumber);
         databaseTestHelper.add(user, roleId);
         return user;
-    }
-
-    public UserDbFixture withExternalId(String externalId) {
-        this.externalId = externalId;
-        return this;
     }
 
     public UserDbFixture withServiceRole(int serviceId, int roleId) {

--- a/src/test/java/uk/gov/pay/adminusers/model/CreateUserRequestTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/CreateUserRequestTest.java
@@ -1,0 +1,58 @@
+package uk.gov.pay.adminusers.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+
+public class CreateUserRequestTest {
+
+    @Test
+    public void shouldConstructAUser_fromMinimalValidUserJson() throws Exception {
+        String minimumUserJson = "{" +
+                "\"username\": \"a-username\"," +
+                "\"telephone_number\": \"2123524\"," +
+                "\"gateway_account_ids\": [\"1\", \"2\"]," +
+                "\"email\": \"email@example.com\"" +
+                "}";
+
+        JsonNode jsonNode = new ObjectMapper().readTree(minimumUserJson);
+        CreateUserRequest createUserRequest = CreateUserRequest.from(jsonNode);
+
+        assertThat(createUserRequest.getUsername(), is("a-username"));
+        assertThat(createUserRequest.getPassword(), notNullValue());
+        assertThat(createUserRequest.getOtpKey(), notNullValue());
+        assertThat(createUserRequest.getGatewayAccountIds().size(), is(2));
+        assertThat(createUserRequest.getGatewayAccountIds().get(0), is("1"));
+        assertThat(createUserRequest.getGatewayAccountIds().get(1), is("2"));
+        assertThat(createUserRequest.getTelephoneNumber(), is("2123524"));
+        assertThat(createUserRequest.getEmail(), is("email@example.com"));
+    }
+
+    @Test
+    public void shouldConstructAUser_fromCompleteValidUserJson() throws Exception {
+        String minimunUserJson = "{" +
+                "\"username\": \"a-username\"," +
+                "\"password\": \"a-password\"," +
+                "\"telephone_number\": \"2123524\"," +
+                "\"gateway_account_ids\": [\"1\", \"2\"]," +
+                "\"otp_key\": \"fr6ysdf\"," +
+                "\"email\": \"email@example.com\"" +
+                "}";
+
+        JsonNode jsonNode = new ObjectMapper().readTree(minimunUserJson);
+        CreateUserRequest createUserRequest = CreateUserRequest.from(jsonNode);
+
+        assertThat(createUserRequest.getUsername(), is("a-username"));
+        assertThat(createUserRequest.getPassword(), is("a-password"));
+        assertThat(createUserRequest.getGatewayAccountIds().size(), is(2));
+        assertThat(createUserRequest.getGatewayAccountIds().get(0), is("1"));
+        assertThat(createUserRequest.getGatewayAccountIds().get(1), is("2"));
+        assertThat(createUserRequest.getTelephoneNumber(), is("2123524"));
+        assertThat(createUserRequest.getOtpKey(), is("fr6ysdf"));
+        assertThat(createUserRequest.getEmail(), is("email@example.com"));
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/model/UserEntityTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/UserEntityTest.java
@@ -21,7 +21,6 @@ public class UserEntityTest {
     @Test
     public void shouldConstructAUser_fromMinimalValidUserJson() throws Exception {
         String minimumUserJson = "{" +
-                "\"external_id\": \"7d19aff33f8948deb97ed16b2912dcd3\"," +
                 "\"username\": \"a-username\"," +
                 "\"telephone_number\": \"2123524\"," +
                 "\"gateway_account_ids\": [\"1\", \"2\"]," +
@@ -33,7 +32,6 @@ public class UserEntityTest {
 
         UserEntity userEntity = UserEntity.from(user);
 
-        assertEquals(user.getExternalId(), userEntity.getExternalId());
         assertEquals(user.getUsername(), userEntity.getUsername());
         assertEquals(user.getPassword(), userEntity.getPassword());
         assertEquals(user.getOtpKey(), userEntity.getOtpKey());

--- a/src/test/java/uk/gov/pay/adminusers/model/UserEntityTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/UserEntityTest.java
@@ -28,15 +28,15 @@ public class UserEntityTest {
                 "}";
 
         JsonNode jsonNode = new ObjectMapper().readTree(minimumUserJson);
-        User user = User.from(jsonNode);
+        CreateUserRequest createUserRequest = CreateUserRequest.from(jsonNode);
 
-        UserEntity userEntity = UserEntity.from(user);
+        UserEntity userEntity = UserEntity.from(createUserRequest);
 
-        assertEquals(user.getUsername(), userEntity.getUsername());
-        assertEquals(user.getPassword(), userEntity.getPassword());
-        assertEquals(user.getOtpKey(), userEntity.getOtpKey());
-        assertEquals(user.getTelephoneNumber(), userEntity.getTelephoneNumber());
-        assertEquals(user.getEmail(), userEntity.getEmail());
+        assertEquals(createUserRequest.getUsername(), userEntity.getUsername());
+        assertEquals(createUserRequest.getPassword(), userEntity.getPassword());
+        assertEquals(createUserRequest.getOtpKey(), userEntity.getOtpKey());
+        assertEquals(createUserRequest.getTelephoneNumber(), userEntity.getTelephoneNumber());
+        assertEquals(createUserRequest.getEmail(), userEntity.getEmail());
         assertThat(userEntity.getCreatedAt(), is(notNullValue()));
         assertThat(userEntity.getUpdatedAt(), is(notNullValue()));
         // Since role and gatewayAccountId will be set up after won't be unit-testing from JSON to entity.

--- a/src/test/java/uk/gov/pay/adminusers/model/UserTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/UserTest.java
@@ -1,7 +1,5 @@
 package uk.gov.pay.adminusers.model;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 
@@ -10,57 +8,10 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.notNullValue;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 
 public class UserTest {
-
-    @Test
-    public void shouldConstructAUser_fromMinimalValidUserJson() throws Exception {
-        String minimumUserJson = "{" +
-                "\"username\": \"a-username\"," +
-                "\"telephone_number\": \"2123524\"," +
-                "\"gateway_account_ids\": [\"1\", \"2\"]," +
-                "\"email\": \"email@example.com\"" +
-                "}";
-
-        JsonNode jsonNode = new ObjectMapper().readTree(minimumUserJson);
-        User user = User.from(jsonNode);
-
-        assertThat(user.getUsername(), is("a-username"));
-        assertThat(user.getPassword(), notNullValue());
-        assertThat(user.getOtpKey(), notNullValue());
-        assertThat(user.getGatewayAccountIds().size(), is(2));
-        assertThat(user.getGatewayAccountIds().get(0), is("1"));
-        assertThat(user.getGatewayAccountIds().get(1), is("2"));
-        assertThat(user.getTelephoneNumber(), is("2123524"));
-        assertThat(user.getEmail(), is("email@example.com"));
-    }
-
-    @Test
-    public void shouldConstructAUser_fromCompleteValidUserJson() throws Exception {
-        String minimunUserJson = "{" +
-                "\"username\": \"a-username\"," +
-                "\"password\": \"a-password\"," +
-                "\"telephone_number\": \"2123524\"," +
-                "\"gateway_account_ids\": [\"1\", \"2\"]," +
-                "\"otp_key\": \"fr6ysdf\"," +
-                "\"email\": \"email@example.com\"" +
-                "}";
-
-        JsonNode jsonNode = new ObjectMapper().readTree(minimunUserJson);
-        User user = User.from(jsonNode);
-
-        assertThat(user.getUsername(), is("a-username"));
-        assertThat(user.getPassword(), is("a-password"));
-        assertThat(user.getGatewayAccountIds().size(), is(2));
-        assertThat(user.getGatewayAccountIds().get(0), is("1"));
-        assertThat(user.getGatewayAccountIds().get(1), is("2"));
-        assertThat(user.getTelephoneNumber(), is("2123524"));
-        assertThat(user.getOtpKey(), is("fr6ysdf"));
-        assertThat(user.getEmail(), is("email@example.com"));
-    }
 
     @Test
     public void shouldFlatten_permissionsOfAUser() throws Exception {

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoTest.java
@@ -2,6 +2,7 @@ package uk.gov.pay.adminusers.persistence.dao;
 
 import org.junit.Before;
 import org.junit.Test;
+import uk.gov.pay.adminusers.app.util.RandomIdGenerator;
 import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
@@ -52,6 +53,7 @@ public class UserDaoTest extends DaoTestBase {
         String username = valueOf(nextInt());
 
         UserEntity userEntity = new UserEntity();
+        userEntity.setExternalId(RandomIdGenerator.randomUuid());
         userEntity.setUsername(username);
         userEntity.setPassword("password-" + username);
         userEntity.setDisabled(false);

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceTest.java
@@ -6,7 +6,7 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import uk.gov.pay.adminusers.model.User;
+import uk.gov.pay.adminusers.model.CreateUserRequest;
 import uk.gov.pay.adminusers.service.UserServices;
 import uk.gov.pay.adminusers.service.UserServicesFactory;
 
@@ -41,7 +41,7 @@ public class UserResourceTest {
     public void shouldThrowConflictExceptionIfUserNameExists() throws Exception {
 
         when(validator.validateCreateRequest(validUserNode)).thenReturn(Optional.empty());
-        when(userService.createUser(any(User.class), eq("admin"))).thenThrow(new RuntimeException(CONSTRAINT_VIOLATION_MESSAGE));
+        when(userService.createUser(any(CreateUserRequest.class), eq("admin"))).thenThrow(new RuntimeException(CONSTRAINT_VIOLATION_MESSAGE));
         thrown.expect(WebApplicationException.class);
         thrown.expectMessage("HTTP 409 Conflict");
         userResource.createUser(validUserNode);
@@ -52,7 +52,7 @@ public class UserResourceTest {
     public void shouldThrowUnknownErrorForAnyOtherReason() throws Exception {
 
         when(validator.validateCreateRequest(validUserNode)).thenReturn(Optional.empty());
-        when(userService.createUser(any(User.class), eq("admin"))).thenThrow(new RuntimeException("Unexpected Error"));
+        when(userService.createUser(any(CreateUserRequest.class), eq("admin"))).thenThrow(new RuntimeException("Unexpected Error"));
         thrown.expect(WebApplicationException.class);
         thrown.expectMessage("HTTP 500");
         userResource.createUser(validUserNode);
@@ -63,7 +63,7 @@ public class UserResourceTest {
     public void shouldThrowWebApplicationExceptionIfRoleNameDoesNotExist() throws Exception {
 
         when(validator.validateCreateRequest(validUserNode)).thenReturn(Optional.empty());
-        when(userService.createUser(any(User.class), eq("admin"))).thenThrow(new WebApplicationException("Expected Error"));
+        when(userService.createUser(any(CreateUserRequest.class), eq("admin"))).thenThrow(new WebApplicationException("Expected Error"));
         thrown.expect(WebApplicationException.class);
         thrown.expectMessage("Expected Error");
         userResource.createUser(validUserNode);

--- a/src/test/java/uk/gov/pay/adminusers/service/LinksBuilderTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/LinksBuilderTest.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 
 public class LinksBuilderTest {
 
@@ -18,7 +19,7 @@ public class LinksBuilderTest {
 
     @Test
     public void shouldConstruct_userSelfLinkCorrectly() throws Exception {
-        User user = User.from(randomInt(), "7d19aff33f8948deb97ed16b2912dcd3", "a-username", "a-password", "email@example.com", Arrays.asList("1"), Arrays.asList("2"), "4wrwef", "123435");
+        User user = User.from(randomInt(), randomUuid(), "a-username", "a-password", "email@example.com", Arrays.asList("1"), Arrays.asList("2"), "4wrwef", "123435");
         User decoratedUser = linksBuilder.decorate(user);
 
         String linkJson = new ObjectMapper().writeValueAsString(decoratedUser.getLinks().get(0));


### PR DESCRIPTION
- Removed random exteranlId generation from JsonNode: we must ignore JsonNode externalIds (coming from clients) when creating User object
- Generate externalIds using Java