### PR TITLE
PP-1717 username in api urls cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The GOV.UK Pay Admin Users Module in Java (Dropwizard)
 | [```/v1/api/users```](/docs/api_specification.md#post-v1apiusers)              | POST    |  Creates a new user            |
 | [```/v1/api/users/{externalId}```](/docs/api_specification.md#get-v1apiusersexternalid)              | GET    |  Gets a user with the associated external id            |
 | [```/v1/api/users/{externalId}```](/docs/api_specification.md#patch-v1apiusersexternalid)              | PATCH    |  amend a specific user attribute            |
-| [```/v1/api/users/{externalId}/services/{service-id}```](/docs/api_specification.md#put-v1apiusersexternalidservicesservice-id)  | PUT    |  update user's role for a service            |
+| [```/v1/api/users/{externalId}/services/{serviceId}```](/docs/api_specification.md#put-v1apiusersexternalidservicesserviceid)  | PUT    |  update user's role for a service            |
 | [```/v1/api/users/authenticate```](/docs/api_specification.md#post-v1apiusersauthenticate)              | POST    |  Authenticate a given username/password            |
 | [```/v1/api/forgotten-passwords```](/docs/api_specification.md#post-v1apiforgottenpasswords)              | POST    |  Create a new forgotten password request            |
 | [```/v1/api/forgotten-passwords/{code}```](/docs/api_specification.md#get-v1apiforgottenpasswordscode)              | GET    |  GETs a forgotten password record by code            |

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -47,7 +47,7 @@ Content-Type: application/json
     "role": {"admin","Administrator"},
     "permissions":["perm-1","perm-2","perm-3"], 
     "_links": [{
-        "href": "http://adminusers.service/v1/api/users/abcd1234",
+        "href": "http://adminusers.service/v1/api/users/7d19aff33f8948deb97ed16b2912dcd3",
         "rel" : "self",
         "method" : "GET"
     }]
@@ -97,7 +97,7 @@ Content-Type: application/json
     "sessionVersion": 0,
     "permissions":["perm-1","perm-2","perm-3"], 
     "_links": [{
-        "href": "http://adminusers.service/v1/api/users/abcd1234",
+        "href": "http://adminusers.service/v1/api/users/7d19aff33f8948deb97ed16b2912dcd3",
         "rel" : "self",
         "method" : "GET"
     }]
@@ -153,7 +153,7 @@ Content-Type: application/json
     "role": {"admin","Administrator"},
     "permissions":["perm-1","perm-2","perm-3"], 
     "_links": [{
-        "href": "http://adminusers.service/v1/api/users/abcd1234",
+        "href": "http://adminusers.service/v1/api/users/7d19aff33f8948deb97ed16b2912dcd3",
         "rel" : "self",
         "method" : "GET"
     }]
@@ -212,7 +212,7 @@ Content-Type: application/json
     "role": {"admin","Administrator"},
     "permissions":["perm-1","perm-2","perm-3"], 
     "_links": [{
-        "href": "http://adminusers.service/v1/api/users/abcd1234",
+        "href": "http://adminusers.service/v1/api/users/7d19aff33f8948deb97ed16b2912dcd3",
         "rel" : "self",
         "method" : "GET"
     }]
@@ -311,7 +311,7 @@ Content-Type: application/json
 
 -----------------------------------------------------------------------------------------------------------
 
-## PUT /v1/api/users/{externalId}/services/{service-id}
+## PUT /v1/api/users/{externalId}/services/{serviceId}
 
 This endpoint updates a service role of a perticular user.
 
@@ -341,7 +341,7 @@ Content-Type: application/json
     "role": {"view-and-refund","View and Refund"},
     "permissions":["perm-1","perm-2","perm-3"], 
     "_links": [{
-        "href": "http://adminusers.service/v1/api/users/abcd1234",
+        "href": "http://adminusers.service/v1/api/users/7d19aff33f8948deb97ed16b2912dcd3",
         "rel" : "self",
         "method" : "GET"
     }]

--- a/src/main/java/uk/gov/pay/adminusers/persistence/dao/UserDao.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/dao/UserDao.java
@@ -21,7 +21,7 @@ public class UserDao extends JpaDao<UserEntity> {
 
     public Optional<UserEntity> findByExternalId(String externalId) {
         String query = "SELECT u FROM UserEntity u " +
-                "WHERE u.externalId = :externalId";
+                "WHERE LOWER(u.externalId) = LOWER(:externalId)";
 
         return entityManager.get()
                 .createQuery(query, UserEntity.class)

--- a/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
@@ -37,21 +37,19 @@ public class UserResource {
     private static final String SECOND_FACTOR_RESOURCE = USER_RESOURCE + "/second-factor";
     private static final String SECOND_FACTOR_AUTHENTICATE_RESOURCE = SECOND_FACTOR_RESOURCE + "/authenticate";
     private static final String USER_SERVICES_RESOURCE = USER_RESOURCE + "/services";
-    private static final String USER_SERVICE_RESOURCE = USER_SERVICES_RESOURCE + "/{service-id}";
-
-    public static final String CONSTRAINT_VIOLATION_MESSAGE = "ERROR: duplicate key value violates unique constraint";
-
-
-    private final UserServices userServices;
-    private final UserServicesFactory userServicesFactory;
-
-    private final UserRequestValidator validator;
+    private static final String USER_SERVICE_RESOURCE = USER_SERVICES_RESOURCE + "/{serviceId}";
 
     private static final int USER_EXTERNAL_ID_LENGTH = 32;
     private static final int USER_USERNAME_MAX_LENGTH = 255;
 
     private static final String USERNAME_FILTER_PARAMETER_KEY = "username";
-    private static final String IS_NEW_API_REQUEST_PARAMETER_KEY = "is_new_api_request";
+
+    public static final String CONSTRAINT_VIOLATION_MESSAGE = "ERROR: duplicate key value violates unique constraint";
+
+    private final UserServices userServices;
+    private final UserServicesFactory userServicesFactory;
+
+    private final UserRequestValidator validator;
 
     @Inject
     public UserResource(UserServices userServices, UserRequestValidator validator, UserServicesFactory userServicesFactory) {
@@ -79,25 +77,15 @@ public class UserResource {
     @GET
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
-    public Response getUser(@PathParam("externalId") String externalId, @QueryParam(IS_NEW_API_REQUEST_PARAMETER_KEY) String isNewApiRequest) {
+    public Response getUser(@PathParam("externalId") String externalId) {
         logger.info("User GET request - [ {} ]", externalId);
-        if (isNotBlank(isNewApiRequest)) {
-            if (isNotBlank(externalId) && (externalId.length() != USER_EXTERNAL_ID_LENGTH)) {
-                return Response.status(NOT_FOUND).build();
-            }
-
-            return userServices.findUserByExternalId(externalId)
-                    .map(user -> Response.status(OK).type(APPLICATION_JSON).entity(user).build())
-                    .orElseGet(() -> Response.status(NOT_FOUND).build());
-        } else {
-            if (isNotBlank(externalId) && (externalId.length() > USER_USERNAME_MAX_LENGTH)) {
-                return Response.status(NOT_FOUND).build();
-            }
-
-            return userServices.findUserByUsername(externalId)
-                    .map(user -> Response.status(OK).type(APPLICATION_JSON).entity(user).build())
-                    .orElseGet(() -> Response.status(NOT_FOUND).build());
+        if (isNotBlank(externalId) && (externalId.length() != USER_EXTERNAL_ID_LENGTH)) {
+            return Response.status(NOT_FOUND).build();
         }
+
+        return userServices.findUserByExternalId(externalId)
+                .map(user -> Response.status(OK).type(APPLICATION_JSON).entity(user).build())
+                .orElseGet(() -> Response.status(NOT_FOUND).build());
     }
 
     @Path(USERS_RESOURCE)
@@ -187,7 +175,7 @@ public class UserResource {
     @Path(USER_SERVICE_RESOURCE)
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
-    public Response updateServiceRole(@PathParam("externalId") String externalId, @PathParam("service-id") Integer serviceId, JsonNode payload) {
+    public Response updateServiceRole(@PathParam("externalId") String externalId, @PathParam("serviceId") Integer serviceId, JsonNode payload) {
         logger.info("User update service role request");
         return validator.validateServiceRole(payload)
                 .map(errors -> Response.status(BAD_REQUEST).entity(errors).build())

--- a/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.*;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.conflictingUsername;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.internalServerError;
 
@@ -38,9 +37,6 @@ public class UserResource {
     private static final String SECOND_FACTOR_AUTHENTICATE_RESOURCE = SECOND_FACTOR_RESOURCE + "/authenticate";
     private static final String USER_SERVICES_RESOURCE = USER_RESOURCE + "/services";
     private static final String USER_SERVICE_RESOURCE = USER_SERVICES_RESOURCE + "/{serviceId}";
-
-    private static final int USER_EXTERNAL_ID_LENGTH = 32;
-    private static final int USER_USERNAME_MAX_LENGTH = 255;
 
     private static final String USERNAME_FILTER_PARAMETER_KEY = "username";
 
@@ -63,11 +59,7 @@ public class UserResource {
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
     public Response getUserByUsername(@QueryParam(USERNAME_FILTER_PARAMETER_KEY) String username) {
-        logger.info("User filter GET request - [ {} ]", username);
-        if (isNotBlank(username) && (username.length() > USER_USERNAME_MAX_LENGTH)) {
-            return Response.status(NOT_FOUND).build();
-        }
-
+        logger.info("User username filter GET request - [ {} ]", username);
         return userServices.findUserByUsername(username)
                 .map(user -> Response.status(OK).type(APPLICATION_JSON).entity(user).build())
                 .orElseGet(() -> Response.status(NOT_FOUND).build());
@@ -79,10 +71,6 @@ public class UserResource {
     @Consumes(APPLICATION_JSON)
     public Response getUser(@PathParam("externalId") String externalId) {
         logger.info("User GET request - [ {} ]", externalId);
-        if (isNotBlank(externalId) && (externalId.length() != USER_EXTERNAL_ID_LENGTH)) {
-            return Response.status(NOT_FOUND).build();
-        }
-
         return userServices.findUserByExternalId(externalId)
                 .map(user -> Response.status(OK).type(APPLICATION_JSON).entity(user).build())
                 .orElseGet(() -> Response.status(NOT_FOUND).build());

--- a/src/main/java/uk/gov/pay/adminusers/service/LinksBuilder.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/LinksBuilder.java
@@ -21,7 +21,7 @@ public class LinksBuilder {
     }
 
     public User decorate(User user) {
-        URI uri = fromUri(baseUrl).path(USERS_RESOURCE).path(user.getUsername())
+        URI uri = fromUri(baseUrl).path(USERS_RESOURCE).path(user.getExternalId())
                 .build();
         Link selfLink = Link.from(Rel.self, "GET", uri.toString());
         user.setLinks(ImmutableList.of(selfLink));

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceRoleUpdater.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceRoleUpdater.java
@@ -35,18 +35,15 @@ public class ServiceRoleUpdater {
     /**
      * updates user's service role.
      *
-     * @param usernameOrExternalId
+     * @param externalId
      * @param serviceId
      * @param roleName
      * @return Updated User if successful or Optional.empty() if user not found
      */
     @Transactional
-    public Optional<User> doUpdate(String usernameOrExternalId, Integer serviceId, String roleName){
-        Optional<UserEntity> userMaybe = userDao.findByUsername(usernameOrExternalId);
-        if (!userMaybe.isPresent()) {
-            userMaybe = userDao.findByExternalId(usernameOrExternalId);
-        }
-        if(!userMaybe.isPresent()){
+    public Optional<User> doUpdate(String externalId, Integer serviceId, String roleName) {
+        Optional<UserEntity> userMaybe = userDao.findByExternalId(externalId);
+        if(!userMaybe.isPresent()) {
             return Optional.empty();
         }
         UserEntity userEntity = userMaybe.get();

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/RoleDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/RoleDbFixture.java
@@ -37,7 +37,7 @@ public class RoleDbFixture {
         return insert(role(ADMIN.getId(), "admin", "Administrator"), aPermission(), aPermission());
     }
 
-    private Role insert(Role role, Permission... permissions) {
+    public Role insert(Role role, Permission... permissions) {
         for (Permission permission : permissions) {
             databaseHelper.add(permission);
         }

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
@@ -4,6 +4,8 @@ import org.apache.commons.lang3.RandomStringUtils;
 import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.utils.DatabaseTestHelper;
 
+import java.util.List;
+
 import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.String.valueOf;
 import static java.util.Arrays.asList;
@@ -15,12 +17,13 @@ public class UserDbFixture {
     private final DatabaseTestHelper databaseTestHelper;
     private Integer serviceId;
     private Integer roleId;
+    private String externalId = randomUuid();
     private String username = RandomStringUtils.randomAlphabetic(10);
     private String otpKey = RandomStringUtils.randomAlphabetic(10);
     private String password = "password-" + username;
     private String email = username + "@example.com";
     private String telephoneNumber = "374628482";
-    private String externalId = randomUuid();
+    private List<String> gatewayAccountIds = newArrayList();
 
     private UserDbFixture(DatabaseTestHelper databaseTestHelper) {
         this.databaseTestHelper = databaseTestHelper;
@@ -35,7 +38,7 @@ public class UserDbFixture {
             serviceId = ServiceDbFixture.serviceDbFixture(databaseTestHelper).insertService();
             roleId = RoleDbFixture.roleDbFixture(databaseTestHelper).insertRole().getId();
         }
-        User user = User.from(randomInt(), externalId, username, password, email, newArrayList(), asList(valueOf(serviceId)), otpKey, telephoneNumber);
+        User user = User.from(randomInt(), externalId, username, password, email, gatewayAccountIds, asList(valueOf(serviceId)), otpKey, telephoneNumber);
         databaseTestHelper.add(user, roleId);
         return user;
     }
@@ -46,13 +49,8 @@ public class UserDbFixture {
         return this;
     }
 
-    public UserDbFixture withPassword(String password) {
-        this.password = password;
-        return this;
-    }
-
-    public UserDbFixture withOtpKey(String otpKey) {
-        this.otpKey = otpKey;
+    public UserDbFixture withExternalId(String externalId) {
+        this.externalId = externalId;
         return this;
     }
 
@@ -61,8 +59,28 @@ public class UserDbFixture {
         return this;
     }
 
+    public UserDbFixture withPassword(String password) {
+        this.password = password;
+        return this;
+    }
+
     public UserDbFixture withEmail(String email) {
         this.email = email;
+        return this;
+    }
+
+    public UserDbFixture withGatewayAccountIds(List<String> gatewayAccountIds) {
+        this.gatewayAccountIds = gatewayAccountIds;
+        return this;
+    }
+
+    public UserDbFixture withTelephoneNumber(String telephoneNumber) {
+        this.telephoneNumber = telephoneNumber;
+        return this;
+    }
+
+    public UserDbFixture withOtpKey(String otpKey) {
+        this.otpKey = otpKey;
         return this;
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/pact/UsersApiTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/pact/UsersApiTest.java
@@ -7,23 +7,25 @@ import au.com.dius.pact.provider.junit.loader.PactFolder;
 import au.com.dius.pact.provider.junit.target.HttpTarget;
 import au.com.dius.pact.provider.junit.target.Target;
 import au.com.dius.pact.provider.junit.target.TestTarget;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
+import uk.gov.pay.adminusers.app.util.RandomIdGenerator;
+import uk.gov.pay.adminusers.fixtures.UserDbFixture;
 import uk.gov.pay.adminusers.infra.DropwizardAppWithPostgresRule;
 import uk.gov.pay.adminusers.model.ForgottenPassword;
+import uk.gov.pay.adminusers.model.Permission;
+import uk.gov.pay.adminusers.model.Role;
+import uk.gov.pay.adminusers.service.PasswordHasher;
 import uk.gov.pay.adminusers.utils.DatabaseTestHelper;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static com.jayway.restassured.RestAssured.given;
-import static com.jayway.restassured.http.ContentType.JSON;
 import static org.apache.commons.lang3.RandomStringUtils.*;
 import static org.apache.commons.lang3.RandomUtils.nextInt;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.adminusers.fixtures.RoleDbFixture.roleDbFixture;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 
@@ -35,7 +37,7 @@ public class UsersApiTest {
     @ClassRule
     public static DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule();
 
-    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final PasswordHasher passwordHasher = new PasswordHasher();
     private static DatabaseTestHelper dbHelper;
 
     @BeforeClass
@@ -43,7 +45,7 @@ public class UsersApiTest {
         target = new HttpTarget(app.getLocalPort());
         dbHelper = app.getDatabaseTestHelper();
         int serviceId = 12345;
-        createUserWithinAService("existing-user", serviceId, "password");
+        createUserWithinAService("7d19aff33f8948deb97ed16b2912dcd3", "existing-user", serviceId, "password");
     }
 
     @TestTarget
@@ -53,7 +55,7 @@ public class UsersApiTest {
     public void aUserExistsWithAForgottenPasswordRequest() throws Exception {
         String code = "avalidforgottenpasswordtoken";
         String username = randomAlphabetic(20);
-        createUserWithinAService(username, "password");
+        createUserWithinAService(RandomIdGenerator.randomUuid(), username, "password");
         List<Map<String, Object>> userByUsername = dbHelper.findUserByUsername(username);
         dbHelper.add(ForgottenPassword.forgottenPassword(code, username), (Integer) userByUsername.get(0).get("id"));
     }
@@ -61,7 +63,7 @@ public class UsersApiTest {
     @State("a user exists with max login attempts")
     public void aUserExistsWithMaxLoginAttempts() throws Exception {
         String username = "user-login-attempts-max";
-        createUserWithinAService(username, "password");
+        createUserWithinAService(RandomIdGenerator.randomUuid(), username, "password");
         dbHelper.updateLoginCount(username, 10);
     }
 
@@ -73,34 +75,29 @@ public class UsersApiTest {
         dbHelper.add(ForgottenPassword.forgottenPassword(code, username), (Integer) userByName.get(0).get("id"));
     }
 
-    private static void createUserWithinAService(String username, String password) throws Exception {
-        createUserWithinAService(username, nextInt(), password);
+    private static void createUserWithinAService(String externalId, String username, String password) throws Exception {
+        createUserWithinAService(externalId, username, nextInt(), password);
     }
 
-    private static void createUserWithinAService(String username, int serviceId, String password) throws Exception {
+    private static void createUserWithinAService(String externalId, String username, int serviceId, String password) throws Exception {
         String gatewayAccount1 = randomNumeric(5);
         String gatewayAccount2 = randomNumeric(5);
-        roleDbFixture(dbHelper).withName("admin").insertRole();
+        Role role = Role.role(randomInt(), "admin", "Administrator");
+        roleDbFixture(dbHelper).insert(role,
+                Permission.permission(randomInt(), "perm-1", "permission-1-description"),
+                Permission.permission(randomInt(), "perm-2", "permission-2-description"),
+                Permission.permission(randomInt(), "perm-3", "permission-3-description"));
         serviceDbFixture(dbHelper).withId(serviceId).withGatewayAccountIds(gatewayAccount1, gatewayAccount2).insertService();
 
-        ImmutableMap<Object, Object> userPayload = ImmutableMap.builder()
-                .put("username", username)
-                .put("password", password)
-                .put("email", "user-" + username + "@example.com")
-                .put("gateway_account_ids", new String[]{gatewayAccount1, gatewayAccount2})
-                .put("telephone_number", "45334534634")
-                .put("otp_key", "34f34")
-                .put("role_name", "admin")
-                .build();
-
-        given().port(app.getLocalPort())
-                .contentType(JSON)
-                .when()
-                .body(mapper.writeValueAsString(userPayload))
-                .contentType(JSON)
-                .accept(JSON)
-                .post("/v1/api/users")
-                .then()
-                .statusCode(201);
+        UserDbFixture.userDbFixture(dbHelper)
+                .withExternalId(externalId)
+                .withUsername(username)
+                .withPassword(passwordHasher.hash(password))
+                .withEmail("user-" + username + "@example.com")
+                .withGatewayAccountIds(Arrays.asList(gatewayAccount1, gatewayAccount2))
+                .withTelephoneNumber("45334534634")
+                .withOtpKey("34f34")
+                .withServiceRole(serviceId, role.getId())
+                .insertUser();
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceTest.java
@@ -2,6 +2,7 @@ package uk.gov.pay.adminusers.resources;
 
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.Role;
+import uk.gov.pay.adminusers.model.User;
 
 import static com.jayway.restassured.http.ContentType.JSON;
 import static org.hamcrest.Matchers.hasSize;
@@ -14,7 +15,6 @@ public class ServiceResourceTest extends IntegrationTest {
 
     @Test
     public void shouldReturnListOfAllUsersWithRolesForAGivenServiceOrderedByUsername() {
-
         Role role1 = roleDbFixture(databaseHelper)
                 .withName("roleB")
                 .insertRole();
@@ -25,15 +25,15 @@ public class ServiceResourceTest extends IntegrationTest {
         int serviceId1 = serviceDbFixture(databaseHelper).insertService();
         int serviceId2 = serviceDbFixture(databaseHelper).insertService();
 
-        String username1 = userDbFixture(databaseHelper)
+        User user1 = userDbFixture(databaseHelper)
                 .withUsername("zoe")
-                .withServiceRole(serviceId1, role1.getId()).insertUser().getUsername();
-        String username2 = userDbFixture(databaseHelper)
+                .withServiceRole(serviceId1, role1.getId()).insertUser();
+        User user2 = userDbFixture(databaseHelper)
                 .withUsername("tim")
-                .withServiceRole(serviceId1, role2.getId()).insertUser().getUsername();
-        String username3 = userDbFixture(databaseHelper)
+                .withServiceRole(serviceId1, role2.getId()).insertUser();
+        User user3 = userDbFixture(databaseHelper)
                 .withUsername("bob")
-                .withServiceRole(serviceId1, role2.getId()).insertUser().getUsername();
+                .withServiceRole(serviceId1, role2.getId()).insertUser();
 
         userDbFixture(databaseHelper)
                 .withServiceRole(serviceId2, role1.getId()).insertUser();
@@ -45,13 +45,21 @@ public class ServiceResourceTest extends IntegrationTest {
                 .then()
                 .statusCode(200)
                 .body("$", hasSize(3))
-                .body("[0].username", is(username3))
+                .body("[0].username", is(user3.getUsername()))
                 .body("[0]._links", hasSize(1))
-                .body("[0]._links[0].href", is("http://localhost:8080/v1/api/users/" + username3))
+                .body("[0]._links[0].href", is("http://localhost:8080/v1/api/users/" + user3.getExternalId()))
                 .body("[0]._links[0].method", is("GET"))
                 .body("[0]._links[0].rel", is("self"))
-                .body("[1].username", is(username2))
-                .body("[2].username", is(username1));
+                .body("[1].username", is(user2.getUsername()))
+                .body("[1]._links", hasSize(1))
+                .body("[1]._links[0].href", is("http://localhost:8080/v1/api/users/" + user2.getExternalId()))
+                .body("[1]._links[0].method", is("GET"))
+                .body("[1]._links[0].rel", is("self"))
+                .body("[2].username", is(user1.getUsername()))
+                .body("[2]._links", hasSize(1))
+                .body("[2]._links[0].href", is("http://localhost:8080/v1/api/users/" + user1.getExternalId()))
+                .body("[2]._links[0].method", is("GET"))
+                .body("[2]._links[0].rel", is("self"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateAndGetTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateAndGetTest.java
@@ -311,6 +311,16 @@ public class UserResourceCreateAndGetTest extends IntegrationTest {
     }
 
     @Test
+    public void shouldReturn404_whenGetUserByUsername_withEmptyUsername() throws Exception {
+        givenSetup()
+                .when()
+                .accept(JSON)
+                .get(USERS_RESOURCE_URL + "?username=")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
     public void shouldReturn404_whenGetUserByUsername_withNonExistentUsername() throws Exception {
         givenSetup()
                 .when()

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourcePatchTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourcePatchTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
+import uk.gov.pay.adminusers.model.User;
 
 import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
@@ -14,11 +15,13 @@ import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
 
 public class UserResourcePatchTest extends IntegrationTest {
 
-    private String username;
+    private String externalId;
 
     @Before
     public void createAUser() {
-        username = userDbFixture(databaseHelper).insertUser().getUsername();
+        User user = userDbFixture(databaseHelper).insertUser();
+
+        externalId = user.getExternalId();
     }
 
     @Test
@@ -30,7 +33,7 @@ public class UserResourcePatchTest extends IntegrationTest {
                 .when()
                 .contentType(JSON)
                 .body(payload)
-                .patch(format(USER_RESOURCE_URL, username))
+                .patch(format(USER_RESOURCE_URL, externalId))
                 .then()
                 .statusCode(200)
                 .body("session_version", is(2));
@@ -45,14 +48,14 @@ public class UserResourcePatchTest extends IntegrationTest {
                 .when()
                 .contentType(JSON)
                 .body(payload)
-                .patch(format(USER_RESOURCE_URL, username))
+                .patch(format(USER_RESOURCE_URL, externalId))
                 .then()
                 .statusCode(200)
                 .body("disabled", is(true));
     }
 
     @Test
-    public void shouldReturn404_whenUnknownUsernameIsSupplied() throws Exception {
+    public void shouldReturn404_whenUnknownExternalIdIsSupplied() throws Exception {
 
         JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("op", "append", "path", "sessionVersion", "value", 1));
 
@@ -75,7 +78,7 @@ public class UserResourcePatchTest extends IntegrationTest {
                 .contentType(JSON)
                 .accept(JSON)
                 .body(payload)
-                .patch(format(USER_RESOURCE_URL, username))
+                .patch(format(USER_RESOURCE_URL, externalId))
                 .then()
                 .statusCode(400)
                 .body("errors", hasSize(2))

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceSecondFactorAuthenticationTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceSecondFactorAuthenticationTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.warrenstrange.googleauth.GoogleAuthenticator;
 import org.junit.Before;
 import org.junit.Test;
+import uk.gov.pay.adminusers.model.User;
 
 import static com.google.common.io.BaseEncoding.base32;
 import static com.jayway.restassured.http.ContentType.JSON;
@@ -15,27 +16,30 @@ public class UserResourceSecondFactorAuthenticationTest extends IntegrationTest 
 
     private static final String USER_2FA_AUTHENTICATE_URL = USER_2FA_URL + "/authenticate";
     private static final String OTP_KEY = "34f34";
+
+    private String externalId;
     private String username;
 
     @Before
     public void createValidUser() throws Exception {
-        username = userDbFixture(databaseHelper).withOtpKey(OTP_KEY).insertUser().getUsername();
+        User user = userDbFixture(databaseHelper).withOtpKey(OTP_KEY).insertUser();
+
+        externalId = user.getExternalId();
+        username = user.getUsername();
     }
 
     @Test
     public void shouldCreate2FA_onForAValid2FAAuthRequest() throws Exception {
-
         givenSetup()
                 .when()
                 .accept(JSON)
-                .post(format(USER_2FA_URL, username))
+                .post(format(USER_2FA_URL, externalId))
                 .then()
                 .statusCode(200);
     }
 
     @Test
     public void shouldAuthenticate2FA_onForAValid2FAAuthRequest() throws Exception {
-
         GoogleAuthenticator testAuthenticator = new GoogleAuthenticator();
         int passcode = testAuthenticator.getTotpPassword(base32().encode(OTP_KEY.getBytes()));
         ImmutableMap<String, Integer> authBody = ImmutableMap.of("code", passcode);
@@ -44,7 +48,7 @@ public class UserResourceSecondFactorAuthenticationTest extends IntegrationTest 
                 .when()
                 .accept(JSON)
                 .body(mapper.writeValueAsString(authBody))
-                .post(format(USER_2FA_AUTHENTICATE_URL, username))
+                .post(format(USER_2FA_AUTHENTICATE_URL, externalId))
                 .then()
                 .statusCode(200)
                 .body("username", is(username))
@@ -54,18 +58,17 @@ public class UserResourceSecondFactorAuthenticationTest extends IntegrationTest 
 
     @Test
     public void shouldReturnNotFound_forNonExistentUser_when2FAAuthCreateRequest() throws Exception {
-        String username = "non-existent";
+        String nonExistingExternalId = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
         givenSetup()
                 .when()
                 .accept(JSON)
-                .post(format(USER_2FA_URL, username))
+                .post(format(USER_2FA_URL, nonExistingExternalId))
                 .then()
                 .statusCode(404);
     }
 
     @Test
     public void shouldReturnUnauthorized_onInvalid2FACode_during2FAAuth() throws Exception {
-
         int invalidPasscode = 111111;
         ImmutableMap<String, Integer> authBody = ImmutableMap.of("code", invalidPasscode);
 
@@ -73,15 +76,13 @@ public class UserResourceSecondFactorAuthenticationTest extends IntegrationTest 
                 .when()
                 .accept(JSON)
                 .body(mapper.writeValueAsString(authBody))
-                .post(format(USER_2FA_AUTHENTICATE_URL, username))
+                .post(format(USER_2FA_AUTHENTICATE_URL, externalId))
                 .then()
                 .statusCode(401);
-
     }
 
     @Test
     public void shouldReturnUnauthorizedAndAccountLocked_during2FAAuth_ifMaxRetryExceeded() throws Exception {
-
         databaseHelper.updateLoginCount(username, 10);
 
         int invalidPasscode = 111111;
@@ -91,7 +92,7 @@ public class UserResourceSecondFactorAuthenticationTest extends IntegrationTest 
                 .when()
                 .accept(JSON)
                 .body(mapper.writeValueAsString(authBody))
-                .post(format(USER_2FA_AUTHENTICATE_URL, username))
+                .post(format(USER_2FA_AUTHENTICATE_URL, externalId))
                 .then()
                 .statusCode(401);
 
@@ -99,7 +100,7 @@ public class UserResourceSecondFactorAuthenticationTest extends IntegrationTest 
                 .when()
                 .contentType(JSON)
                 .accept(JSON)
-                .get(format(USER_RESOURCE_URL, username))
+                .get(format(USER_RESOURCE_URL, externalId))
                 .then()
                 .statusCode(200)
                 .body("username", is(username))

--- a/src/test/java/uk/gov/pay/adminusers/service/ForgottenPasswordServicesTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ForgottenPasswordServicesTest.java
@@ -35,48 +35,47 @@ public class ForgottenPasswordServicesTest {
 
     @Test
     public void shouldReturnANewForgottenPassword_whenCreating_ifUserFound() throws Exception {
-        String existingUser = "existing-user";
+        String existingUsername = "existing-user";
         UserEntity mockUser = mock(UserEntity.class);
-        when(mockUser.getUsername()).thenReturn(existingUser);
+        when(mockUser.getUsername()).thenReturn(existingUsername);
 
-        when(userDao.findByUsername(existingUser)).thenReturn(Optional.of(mockUser));
-        Optional<ForgottenPassword> forgottenPasswordOptional = forgottenPasswordServices.create(existingUser);
+        when(userDao.findByUsername(existingUsername)).thenReturn(Optional.of(mockUser));
+        Optional<ForgottenPassword> forgottenPasswordOptional = forgottenPasswordServices.create(existingUsername);
 
         verify(forgottenPasswordDao, times(1)).persist(any(ForgottenPasswordEntity.class));
         assertTrue(forgottenPasswordOptional.isPresent());
-        assertThat(forgottenPasswordOptional.get().getUsername(), is(existingUser));
+        assertThat(forgottenPasswordOptional.get().getUsername(), is(existingUsername));
         assertThat(forgottenPasswordOptional.get().getCode(), is(notNullValue()));
         assertThat(forgottenPasswordOptional.get().getLinks().size(), is(1));
     }
 
     @Test
     public void shouldReturnEmpty_whenCreating_ifUserNotFound() throws Exception {
-        String nonExistingUser = "non-existent-user";
-        when(userDao.findByUsername(nonExistingUser)).thenReturn(Optional.empty());
-        when(userDao.findByExternalId(nonExistingUser)).thenReturn(Optional.empty());
+        String nonExistentUser = "non-existent-user";
+        when(userDao.findByUsername(nonExistentUser)).thenReturn(Optional.empty());
 
-        Optional<ForgottenPassword> forgottenPasswordOptional = forgottenPasswordServices.create(nonExistingUser);
+        Optional<ForgottenPassword> forgottenPasswordOptional = forgottenPasswordServices.create(nonExistentUser);
         assertFalse(forgottenPasswordOptional.isPresent());
     }
 
     @Test
     public void shouldFindForgottenPassword_whenFindByCode_ifFound() throws Exception {
-        String code = "an-existent-code";
-        ForgottenPasswordEntity forgottenPasswordEntity = mockForgottenPassword(code);
-        when(forgottenPasswordDao.findNonExpiredByCode(code)).thenReturn(Optional.of(forgottenPasswordEntity));
+        String existingCode = "existing-code";
+        ForgottenPasswordEntity forgottenPasswordEntity = mockForgottenPassword(existingCode);
+        when(forgottenPasswordDao.findNonExpiredByCode(existingCode)).thenReturn(Optional.of(forgottenPasswordEntity));
 
-        Optional<ForgottenPassword> forgottenPasswordOptional = forgottenPasswordServices.findNonExpired(code);
+        Optional<ForgottenPassword> forgottenPasswordOptional = forgottenPasswordServices.findNonExpired(existingCode);
         assertTrue(forgottenPasswordOptional.isPresent());
-        assertThat(forgottenPasswordOptional.get().getCode(), is(code));
+        assertThat(forgottenPasswordOptional.get().getCode(), is(existingCode));
         assertThat(forgottenPasswordOptional.get().getLinks(), hasSize(1));
     }
 
     @Test
     public void shouldReturnEmpty_whenFindByCode_ifNotFound() throws Exception {
-        String code = "non-existent-code";
-        when(forgottenPasswordDao.findNonExpiredByCode(code)).thenReturn(Optional.empty());
+        String nonExistentCode = "non-existent-code";
+        when(forgottenPasswordDao.findNonExpiredByCode(nonExistentCode)).thenReturn(Optional.empty());
 
-        Optional<ForgottenPassword> forgottenPasswordOptional = forgottenPasswordServices.findNonExpired(code);
+        Optional<ForgottenPassword> forgottenPasswordOptional = forgottenPasswordServices.findNonExpired(nonExistentCode);
         assertFalse(forgottenPasswordOptional.isPresent());
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/service/LinksBuilderTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/LinksBuilderTest.java
@@ -23,7 +23,7 @@ public class LinksBuilderTest {
         User decoratedUser = linksBuilder.decorate(user);
 
         String linkJson = new ObjectMapper().writeValueAsString(decoratedUser.getLinks().get(0));
-        assertThat(linkJson, is("{\"rel\":\"self\",\"method\":\"GET\",\"href\":\"http://localhost:8080/v1/api/users/a-username\"}"));
+        assertThat(linkJson, is("{\"rel\":\"self\",\"method\":\"GET\",\"href\":\"http://localhost:8080/v1/api/users/" + decoratedUser.getExternalId() + "\"}"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
@@ -22,6 +22,16 @@ public class DatabaseTestHelper {
         this.jdbi = jdbi;
     }
 
+    public List<Map<String, Object>> findUserByExternalId(String externalId) {
+        List<Map<String, Object>> ret = jdbi.withHandle(h ->
+                h.createQuery("SELECT id, external_id, username, password, email, otp_key, telephone_number, disabled, login_counter, \"createdAt\", \"updatedAt\", session_version " +
+                        "FROM users " +
+                        "WHERE external_id = :externalId")
+                        .bind("externalId", externalId)
+                        .list());
+        return ret;
+    }
+
     public List<Map<String, Object>> findUserByUsername(String username) {
         List<Map<String, Object>> ret = jdbi.withHandle(h ->
                 h.createQuery("SELECT id, external_id, username, password, email, otp_key, telephone_number, disabled, login_counter, \"createdAt\", \"updatedAt\", session_version " +
@@ -46,7 +56,7 @@ public class DatabaseTestHelper {
         List<Map<String, Object>> ret = jdbi.withHandle(h ->
                 h.createQuery("SELECT r.id, r.name, r.description, ur.service_id " +
                         "FROM roles r INNER JOIN user_services_roles ur " +
-                        "ON ur.user_id = :userId AND ur.role_id=r.id")
+                        "ON ur.user_id = :userId AND ur.role_id = r.id")
                         .bind("userId", userId)
                         .list());
         return ret;
@@ -56,7 +66,7 @@ public class DatabaseTestHelper {
         return jdbi.withHandle(h ->
                 h.createQuery("SELECT id, date, code, \"userId\" " +
                         "FROM forgotten_passwords " +
-                        "WHERE id=:id")
+                        "WHERE id = :id")
                         .bind("id", forgottenPasswordId)
                         .list());
     }
@@ -65,7 +75,7 @@ public class DatabaseTestHelper {
         return jdbi.withHandle(h ->
                 h.createQuery("SELECT id, sender_id, date, code, email, role_id, service_id, otp_key, telephone_number " +
                         "FROM invites " +
-                        "WHERE id=:id")
+                        "WHERE id = :id")
                         .bind("id", inviteId)
                         .list());
     }
@@ -73,8 +83,8 @@ public class DatabaseTestHelper {
     public DatabaseTestHelper updateLoginCount(String username, int loginCount) {
         jdbi.withHandle(handle ->
                 handle
-                        .createStatement("UPDATE users SET login_counter=:loginCount " +
-                                "WHERE username=:username")
+                        .createStatement("UPDATE users SET login_counter = :loginCount " +
+                                "WHERE username = :username")
                         .bind("loginCount", loginCount)
                         .bind("username", username)
                         .execute()
@@ -88,9 +98,9 @@ public class DatabaseTestHelper {
                 handle
                         .createStatement("INSERT INTO users(" +
                                 "id, external_id, username, password, email, otp_key, telephone_number, disabled, login_counter, version, \"createdAt\", \"updatedAt\", session_version) " +
-                                "VALUES (:id, :external_id, :username, :password, :email, :otpKey, :telephoneNumber, :disabled, :loginCounter, :version, :createdAt, :updatedAt, :session_version)")
+                                "VALUES (:id, :externalId, :username, :password, :email, :otpKey, :telephoneNumber, :disabled, :loginCounter, :version, :createdAt, :updatedAt, :session_version)")
                         .bind("id", user.getId())
-                        .bind("external_id", user.getExternalId())
+                        .bind("externalId", user.getExternalId())
                         .bind("username", user.getUsername())
                         .bind("password", user.getPassword())
                         .bind("email", user.getEmail())
@@ -121,7 +131,7 @@ public class DatabaseTestHelper {
                 handle
                         .createStatement("INSERT INTO roles(id, name, description) " +
                                 "SELECT :id, :name, :description " +
-                                "WHERE NOT EXISTS (SELECT id FROM roles WHERE id=:id) " +
+                                "WHERE NOT EXISTS (SELECT id FROM roles WHERE id = :id) " +
                                 "RETURNING id")
                         .bind("id", role.getId())
                         .bind("name", role.getName())

--- a/src/test/resources/pacts/selfservice-authenticate-adminusers.json
+++ b/src/test/resources/pacts/selfservice-authenticate-adminusers.json
@@ -26,10 +26,14 @@
           "Content-Type": "application/json"
         },
         "body": {
+          "external_id": "7d19aff33f8948deb97ed16b2912dcd3",
           "username": "existing-user",
           "email": "existing-user@example.com",
           "gateway_account_ids": [
-            "918"
+            "134"
+          ],
+          "service_ids": [
+            "258"
           ],
           "otp_key": "43c3c4t",
           "role": {
@@ -44,13 +48,16 @@
           ],
           "_links": [
             {
-              "href": "http://adminusers.service/v1/api/users/existing-user",
+              "href": "http://adminusers.service/v1/api/users/7d19aff33f8948deb97ed16b2912dcd3",
               "rel": "self",
               "method": "GET"
             }
           ]
         },
         "matchingRules": {
+          "$.body.external_id": {
+            "match": "type"
+          },
           "$.body.username": {
             "match": "type"
           },
@@ -64,6 +71,15 @@
             "match": "type"
           },
           "$.body.gateway_account_ids[*]": {
+            "match": "type"
+          },
+          "$.body.service_ids": {
+            "min": 1
+          },
+          "$.body.service_ids[*].*": {
+            "match": "type"
+          },
+          "$.body.service_ids[*]": {
             "match": "type"
           },
           "$.body.otp_key": {

--- a/src/test/resources/pacts/selfservice-create-user-adminusers.json
+++ b/src/test/resources/pacts/selfservice-create-user-adminusers.json
@@ -31,6 +31,7 @@
           "Content-Type": "application/json"
         },
         "body": {
+          "external_id": "72dadb5019f4447595f57643304b54a8",
           "username": "wjq68lqaz1in72pgb9",
           "email": "wjq68lqaz1in72pgb9@example.com",
           "gateway_account_ids": [
@@ -49,13 +50,16 @@
           ],
           "_links": [
             {
-              "href": "http://adminusers.service/v1/api/users/wjq68lqaz1in72pgb9",
+              "href": "http://adminusers.service/v1/api/users/72dadb5019f4447595f57643304b54a8",
               "rel": "self",
               "method": "GET"
             }
           ]
         },
         "matchingRules": {
+          "$.body.external_id": {
+            "match": "type"
+          },
           "$.body.username": {
             "match": "type"
           },

--- a/src/test/resources/pacts/selfservice-get-user-adminusers.json
+++ b/src/test/resources/pacts/selfservice-get-user-adminusers.json
@@ -8,10 +8,10 @@
   "interactions": [
     {
       "description": "a valid get user request",
-      "provider_state": "a user exits with the given name",
+      "provider_state": "a user exits with the given external id",
       "request": {
         "method": "GET",
-        "path": "/v1/api/users/existing-user",
+        "path": "/v1/api/users/7d19aff33f8948deb97ed16b2912dcd3",
         "headers": {
           "Accept": "application/json"
         }
@@ -22,11 +22,15 @@
           "Content-Type": "application/json"
         },
         "body": {
+          "external_id": "7d19aff33f8948deb97ed16b2912dcd3",
           "username": "existing-user",
           "email": "existing-user@example.com",
           "gateway_account_ids": [
             "666",
             "666"
+          ],
+          "service_ids": [
+            "665"
           ],
           "otp_key": "43c3c4t",
           "role": {
@@ -41,13 +45,16 @@
           ],
           "_links": [
             {
-              "href": "http://adminusers.service/v1/api/users/existing-user",
+              "href": "http://adminusers.service/v1/api/users/7d19aff33f8948deb97ed16b2912dcd3",
               "rel": "self",
               "method": "GET"
             }
           ]
         },
         "matchingRules": {
+          "$.body.external_id": {
+            "match": "type"
+          },
           "$.body.username": {
             "match": "type"
           },
@@ -61,6 +68,15 @@
             "match": "type"
           },
           "$.body.gateway_account_ids[*]": {
+            "match": "type"
+          },
+          "$.body.service_ids": {
+            "min": 1
+          },
+          "$.body.service_ids[*].*": {
+            "match": "type"
+          },
+          "$.body.service_ids[*]": {
             "match": "type"
           },
           "$.body.otp_key": {
@@ -98,10 +114,10 @@
     },
     {
       "description": "a valid get user request of an non existing user",
-      "provider_state": "no user exits with the given name",
+      "provider_state": "no user exits with the given external id",
       "request": {
         "method": "GET",
-        "path": "/v1/api/users/non-existent-user",
+        "path": "/v1/api/users/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
         "headers": {
           "Accept": "application/json"
         }

--- a/src/test/resources/pacts/selfservice-session-adminusers.json
+++ b/src/test/resources/pacts/selfservice-session-adminusers.json
@@ -11,7 +11,7 @@
       "provider_state": "a user exists",
       "request": {
         "method": "PATCH",
-        "path": "/v1/api/users/existing-user",
+        "path": "/v1/api/users/7d19aff33f8948deb97ed16b2912dcd3",
         "headers": {
           "Accept": "application/json"
         },
@@ -33,7 +33,7 @@
       "provider_state": "a user does not exist",
       "request": {
         "method": "PATCH",
-        "path": "/v1/api/users/non-existent-username",
+        "path": "/v1/api/users/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
         "headers": {
           "Accept": "application/json"
         },


### PR DESCRIPTION
## WHAT

Modifies pay-adminusers service to use only `external id` in api endpoints.
Before that we were querying for `username` and `externalId` in api endpoints.
This PR replaces `username` with `externalId` from the endpoints and services (removes the `username` condition)

## HOW

- Modified `UserResource` and removed `is_new_api_request ` GET parameter
- Modified service and dao layers and removed the `username` condition
- Modified tests and documentation