### PR TITLE
PP-1603 Generate OTP for Invites

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/model/InviteOtpRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/InviteOtpRequest.java
@@ -1,0 +1,35 @@
+package uk.gov.pay.adminusers.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class InviteOtpRequest {
+
+    public static final String FIELD_TELEPHONE_NUMBER = "telephone_number";
+    public static final String FIELD_PASSWORD = "password";
+
+    private final String code;
+    private final String telephoneNumber;
+    private final String password;
+
+    private InviteOtpRequest(String code, String telephoneNumber, String password) {
+        this.code = code;
+        this.telephoneNumber = telephoneNumber;
+        this.password = password;
+    }
+
+    public static InviteOtpRequest from(String code, JsonNode jsonNode) {
+        return new InviteOtpRequest(code, jsonNode.get(FIELD_TELEPHONE_NUMBER).asText(), jsonNode.get(FIELD_PASSWORD).asText());
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getTelephoneNumber() {
+        return telephoneNumber;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
@@ -45,6 +45,9 @@ public class InviteEntity extends AbstractEntity {
     @Column(name = "telephone_number")
     private String telephoneNumber;
 
+    @Column(name = "password")
+    private String password;
+
     public InviteEntity() {
         //for jpa
     }
@@ -121,6 +124,14 @@ public class InviteEntity extends AbstractEntity {
 
     public void setTelephoneNumber(String telephoneNumber) {
         this.telephoneNumber = telephoneNumber;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
     }
 
     public Invite toInvite(String inviteUrl) {

--- a/src/main/java/uk/gov/pay/adminusers/resources/InviteRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InviteRequestValidator.java
@@ -8,9 +8,9 @@ import uk.gov.pay.adminusers.validations.RequestValidations;
 import java.util.List;
 import java.util.Optional;
 
+import static uk.gov.pay.adminusers.model.InviteOtpRequest.FIELD_PASSWORD;
+import static uk.gov.pay.adminusers.model.InviteOtpRequest.FIELD_TELEPHONE_NUMBER;
 import static uk.gov.pay.adminusers.model.InviteRequest.*;
-import static uk.gov.pay.adminusers.model.InviteRequest.FIELD_ROLE_NAME;
-import static uk.gov.pay.adminusers.model.InviteRequest.FIELD_SENDER;
 
 public class InviteRequestValidator {
 
@@ -23,9 +23,11 @@ public class InviteRequestValidator {
 
     public Optional<Errors> validateCreateRequest(JsonNode payload) {
         Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExists(payload, FIELD_EMAIL, FIELD_ROLE_NAME, FIELD_SENDER);
-        if (missingMandatoryFields.isPresent()) {
-            return Optional.of(Errors.from(missingMandatoryFields.get()));
-        }
-        return Optional.empty();
+        return missingMandatoryFields.map(Errors::from);
+    }
+
+    public Optional<Errors> validateOtpRequest(JsonNode payload) {
+        Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExists(payload, FIELD_TELEPHONE_NUMBER, FIELD_PASSWORD);
+        return missingMandatoryFields.map(Errors::from);
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
@@ -1,19 +1,17 @@
 package uk.gov.pay.adminusers.resources;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
 import uk.gov.pay.adminusers.logger.PayLoggerFactory;
+import uk.gov.pay.adminusers.model.InviteOtpRequest;
 import uk.gov.pay.adminusers.service.InviteService;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
-import static javax.ws.rs.core.Response.Status.OK;
+import static javax.ws.rs.core.Response.Status.*;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @Path("/v1/api/invites")
@@ -23,10 +21,12 @@ public class InviteResource {
     private static final int MAX_LENGTH_CODE = 255;
 
     private final InviteService inviteService;
+    private final InviteRequestValidator inviteValidator;
 
     @Inject
-    public InviteResource(InviteService service) {
+    public InviteResource(InviteService service, InviteRequestValidator inviteValidator) {
         inviteService = service;
+        this.inviteValidator = inviteValidator;
     }
 
     @GET
@@ -43,5 +43,24 @@ public class InviteResource {
         return inviteService.findByCode(code)
                 .map(invite -> Response.status(OK).type(APPLICATION_JSON).entity(invite).build())
                 .orElseGet(() -> Response.status(NOT_FOUND).build());
+    }
+
+    @POST
+    @Path("/{code}/otp")
+    @Consumes(APPLICATION_JSON)
+    public Response generateOtp(@PathParam("code") String code, JsonNode payload) {
+
+        LOGGER.info("Invite POST request for generating for code - [ {} ]", code);
+
+        if (isNotBlank(code) && code.length() > MAX_LENGTH_CODE) {
+            return Response.status(NOT_FOUND).build();
+        }
+
+        return inviteValidator.validateOtpRequest(payload)
+                .map(errors -> Response.status(BAD_REQUEST).entity(errors).build())
+                .orElseGet(() -> {
+                    inviteService.generateOtp(InviteOtpRequest.from(code, payload));
+                    return Response.status(OK).build();
+                });
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
@@ -48,6 +48,10 @@ public class AdminUsersExceptions {
         return buildWebApplicationException(error, BAD_REQUEST.getStatusCode());
     }
 
+    public static WebApplicationException notFoundException() {
+        return new WebApplicationException(Response.status(NOT_FOUND.getStatusCode()).build());
+    }
+
     public static WebApplicationException userLockedException(String username) {
         String error = format("user [%s] locked due to too many login attempts", username);
         return buildWebApplicationException(error, UNAUTHORIZED.getStatusCode());

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteService.java
@@ -5,6 +5,7 @@ import uk.gov.pay.adminusers.app.config.AdminUsersConfig;
 import uk.gov.pay.adminusers.app.util.RandomIdGenerator;
 import uk.gov.pay.adminusers.logger.PayLoggerFactory;
 import uk.gov.pay.adminusers.model.Invite;
+import uk.gov.pay.adminusers.model.InviteOtpRequest;
 import uk.gov.pay.adminusers.model.InviteRequest;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.dao.RoleDao;
@@ -16,6 +17,7 @@ import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 
 import javax.inject.Inject;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -26,13 +28,17 @@ import static uk.gov.pay.adminusers.service.AdminUsersExceptions.*;
 public class InviteService {
 
     private static final Logger LOGGER = PayLoggerFactory.getLogger(InviteService.class);
+
     private static final String SELFSERVICE_INVITES_PATH = "invites";
+    private static final String SIX_DIGITS_WITH_LEADING_ZEROS = "%06d";
 
     private final RoleDao roleDao;
     private final ServiceDao serviceDao;
     private final UserDao userDao;
     private final InviteDao inviteDao;
+    private final PasswordHasher passwordHasher;
     private final NotificationService notificationService;
+    private final SecondFactorAuthenticator secondFactorAuthenticator;
     private final String selfserviceBaseUrl;
 
     @Inject
@@ -41,13 +47,16 @@ public class InviteService {
                          UserDao userDao,
                          InviteDao inviteDao,
                          AdminUsersConfig config,
-                         NotificationService notificationService) {
+                         PasswordHasher passwordHasher,
+                         NotificationService notificationService, SecondFactorAuthenticator secondFactorAuthenticator) {
         this.roleDao = roleDao;
         this.serviceDao = serviceDao;
         this.userDao = userDao;
         this.inviteDao = inviteDao;
         this.selfserviceBaseUrl = config.getLinks().getSelfserviceUrl();
+        this.passwordHasher = passwordHasher;
         this.notificationService = notificationService;
+        this.secondFactorAuthenticator = secondFactorAuthenticator;
     }
 
     public Optional<Invite> create(InviteRequest invite, int serviceId) {
@@ -56,7 +65,7 @@ public class InviteService {
             throw conflictingEmail(invite.getEmail());
         }
 
-        if(inviteDao.findByEmail(invite.getEmail()).isPresent()) {
+        if (inviteDao.findByEmail(invite.getEmail()).isPresent()) {
             // When multiple services support is implemented
             // then this should include serviceId
             throw conflictingInvite(invite.getEmail());
@@ -102,5 +111,27 @@ public class InviteService {
                     }
                     return Optional.of(inviteEntity.toInvite());
                 }).orElseGet(Optional::empty);
+    }
+
+    public void generateOtp(InviteOtpRequest inviteOtpRequest) {
+        Optional<InviteEntity> inviteOptional = inviteDao.findByCode(inviteOtpRequest.getCode());
+        if (inviteOptional.isPresent()) {
+            InviteEntity invite = inviteOptional.get();
+            invite.setTelephoneNumber(inviteOtpRequest.getTelephoneNumber());
+            invite.setPassword(passwordHasher.hash(inviteOtpRequest.getPassword()));
+            inviteDao.merge(invite);
+            int newPassCode = secondFactorAuthenticator.newPassCode(invite.getOtpKey());
+            String passcode = String.format(Locale.ENGLISH, SIX_DIGITS_WITH_LEADING_ZEROS, newPassCode);
+            notificationService.sendSecondFactorPasscodeSms(inviteOtpRequest.getTelephoneNumber(), passcode)
+                    .thenAcceptAsync(notificationId -> LOGGER.info("sent 2FA token successfully for invite code [{}], notification id [{}]",
+                            inviteOtpRequest.getCode(), notificationId))
+                    .exceptionally(exception -> {
+                        LOGGER.error(format("error sending 2FA token for invite code [%s]", inviteOtpRequest.getCode()), exception);
+                        return null;
+                    });
+            LOGGER.info("New 2FA token generated for invite code [{}]", inviteOtpRequest.getCode());
+        } else {
+            throw notFoundException();
+        }
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
@@ -33,7 +33,7 @@ public class NotificationService {
         this.metricRegistry = metricRegistry;
     }
 
-    public CompletableFuture<String> sendSecondFactorPasscodeSms(String phoneNumber, String passcode) {
+    CompletableFuture<String> sendSecondFactorPasscodeSms(String phoneNumber, String passcode) {
         return CompletableFuture.supplyAsync(() -> {
             HashMap<String, String> personalisation = newHashMap();
             personalisation.put("code", passcode);
@@ -51,7 +51,7 @@ public class NotificationService {
         }, executorService);
     }
 
-    public CompletableFuture<String> sendInviteEmail(String sender, String email, String inviteUrl) {
+    CompletableFuture<String> sendInviteEmail(String sender, String email, String inviteUrl) {
         return CompletableFuture.supplyAsync(() -> {
             HashMap<String, String> personalisation = newHashMap();
             personalisation.put("username", sender);

--- a/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
@@ -19,6 +19,7 @@ public class IntegrationTest {
     static final String USER_SERVICE_RESOURCE = USER_RESOURCE_URL + "/services/%d";
 
     static final String SERVICE_INVITES_RESOURCE_URL = "/v1/api/services/%d/invites";
+    static final String INVITES_OTP_RESOURCE_URL = "/v1/api/invites/%s/otp";
     static final String INVITES_RESOURCE_URL = "/v1/api/invites";
 
     @ClassRule

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpTest.java
@@ -1,0 +1,59 @@
+package uk.gov.pay.adminusers.resources;
+
+import com.google.common.collect.ImmutableMap;
+import com.jayway.restassured.http.ContentType;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.adminusers.fixtures.InviteDbFixture;
+
+import static java.lang.String.format;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
+
+public class InviteResourceOtpTest extends IntegrationTest {
+
+    private String code;
+
+    @Before
+    public void givenAnExistingInvite() {
+        code = InviteDbFixture.inviteDbFixture(databaseHelper).expired().insertInvite();
+    }
+
+    @Test
+    public void generateOtp_shouldSucceed_evenWhenTokenIsExpired_sinceItShouldBeValidatedOnGetInvite() throws Exception {
+
+        String telephoneNumber = "+447999999999";
+
+        ImmutableMap<Object, Object> invitationRequest = ImmutableMap.builder()
+                .put("telephone_number", telephoneNumber)
+                .put("password", "a-secure-password")
+                .build();
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(invitationRequest))
+                .contentType(ContentType.JSON)
+                .post(String.format(INVITES_OTP_RESOURCE_URL, code))
+                .then()
+                .statusCode(OK.getStatusCode());
+    }
+
+    @Test
+    public void generateOtp_shouldFail_whenInviteDoesNotExist() throws Exception {
+
+        String telephoneNumber = "+447999999999";
+
+        ImmutableMap<Object, Object> invitationRequest = ImmutableMap.builder()
+                .put("telephone_number", telephoneNumber)
+                .put("password", "a-secure-password")
+                .build();
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(invitationRequest))
+                .contentType(ContentType.JSON)
+                .post(format(INVITES_OTP_RESOURCE_URL, "not-existing-code"))
+                .then()
+                .statusCode(NOT_FOUND.getStatusCode());
+    }
+}


### PR DESCRIPTION
## WHAT
- OTP generation requires telephone number and password to be sent along with the code of the invite (in url).
- Async send sms code. So a new resource for resending must be provided in next PR.
- InviteService has way too many collaborators, so the refactoring will be done in the last PR for PP-1603.