### PR TITLE
PP-1977 Forgotten Password notifications

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersModule.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersModule.java
@@ -16,8 +16,6 @@ import uk.gov.pay.adminusers.validations.RequestValidations;
 
 import java.util.Properties;
 
-import static uk.gov.pay.adminusers.app.util.TrustStoreLoader.getSSLContext;
-
 public class AdminUsersModule extends AbstractModule {
 
     final AdminUsersConfig configuration;
@@ -74,10 +72,7 @@ public class AdminUsersModule extends AbstractModule {
     private NotificationService provideUserNotificationService() {
         return new NotificationService(
                 environment.lifecycle().executorService("2fa-sms-%d").build(),
-                new NotifyClientProvider(configuration.getNotifyConfiguration(), getSSLContext()),
-                configuration.getNotifyConfiguration().getSecondFactorSmsTemplateId(),
-                configuration.getNotifyConfiguration().getInviteEmailTemplateId(),
-                configuration.getNotifyConfiguration().getForgottenPasswordEmailTemplateId(),
+                configuration.getNotifyConfiguration(),
                 environment.metrics());
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersModule.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersModule.java
@@ -16,7 +16,7 @@ import uk.gov.pay.adminusers.validations.RequestValidations;
 
 import java.util.Properties;
 
-import static uk.gov.pay.adminusers.app.util.TrustStoreLoader.*;
+import static uk.gov.pay.adminusers.app.util.TrustStoreLoader.getSSLContext;
 
 public class AdminUsersModule extends AbstractModule {
 
@@ -77,6 +77,7 @@ public class AdminUsersModule extends AbstractModule {
                 new NotifyClientProvider(configuration.getNotifyConfiguration(), getSSLContext()),
                 configuration.getNotifyConfiguration().getSecondFactorSmsTemplateId(),
                 configuration.getNotifyConfiguration().getInviteEmailTemplateId(),
+                configuration.getNotifyConfiguration().getForgottenPasswordEmailTemplateId(),
                 environment.metrics());
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/app/config/NotifyConfiguration.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/NotifyConfiguration.java
@@ -23,6 +23,10 @@ public class NotifyConfiguration extends Configuration {
     @NotNull
     private String inviteEmailTemplateId;
 
+    @Valid
+    @NotNull
+    private String forgottenPasswordEmailTemplateId;
+
     public String getApiKey() {
         return apiKey;
     }
@@ -37,5 +41,9 @@ public class NotifyConfiguration extends Configuration {
 
     public String getInviteEmailTemplateId() {
         return inviteEmailTemplateId;
+    }
+
+    public String getForgottenPasswordEmailTemplateId() {
+        return forgottenPasswordEmailTemplateId;
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/ForgottenPasswordServices.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ForgottenPasswordServices.java
@@ -1,35 +1,44 @@
 package uk.gov.pay.adminusers.service;
 
 import com.google.inject.Inject;
-import com.google.inject.persist.Transactional;
 import org.slf4j.Logger;
+import uk.gov.pay.adminusers.app.config.AdminUsersConfig;
 import uk.gov.pay.adminusers.logger.PayLoggerFactory;
 import uk.gov.pay.adminusers.model.ForgottenPassword;
 import uk.gov.pay.adminusers.persistence.dao.ForgottenPasswordDao;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
 import uk.gov.pay.adminusers.persistence.entity.ForgottenPasswordEntity;
+import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
+import static java.lang.String.format;
+import static javax.ws.rs.core.UriBuilder.fromUri;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.newId;
 
 public class ForgottenPasswordServices {
 
     private static final Logger logger = PayLoggerFactory.getLogger(ForgottenPasswordServices.class);
+    private static final String SELFSERVICE_FORGOTTEN_PASSWORD_PATH = "reset-password";
+
     private final UserDao userDao;
     private final ForgottenPasswordDao forgottenPasswordDao;
     private final LinksBuilder linksBuilder;
+    private final NotificationService notificationService;
+    private final String selfserviceBaseUrl;
 
     @Inject
-    public ForgottenPasswordServices(UserDao userDao, ForgottenPasswordDao forgottenPasswordDao, LinksBuilder linksBuilder) {
+    public ForgottenPasswordServices(UserDao userDao, ForgottenPasswordDao forgottenPasswordDao, LinksBuilder linksBuilder, NotificationService notificationService, AdminUsersConfig config) {
         this.userDao = userDao;
         this.forgottenPasswordDao = forgottenPasswordDao;
         this.linksBuilder = linksBuilder;
+        this.notificationService = notificationService;
+        this.selfserviceBaseUrl = config.getLinks().getSelfserviceUrl();
     }
 
-    @Transactional
-    public Optional<ForgottenPassword> create(String username) {
+    @Deprecated
+    public Optional<ForgottenPassword> createWithoutNotification(String username) {
         return userDao.findByUsername(username)
                 .map(userEntity -> {
                     ForgottenPasswordEntity forgottenPasswordEntity = new ForgottenPasswordEntity(newId(), ZonedDateTime.now(), userEntity);
@@ -40,6 +49,25 @@ public class ForgottenPasswordServices {
                     logger.warn("Attempted forgotten password for non existent user {}", username);
                     return Optional.empty();
                 });
+    }
+
+    public void create(String username) {
+        Optional<UserEntity> userOptional = userDao.findByUsername(username);
+        if (userOptional.isPresent()) {
+            UserEntity userEntity = userOptional.get();
+            ForgottenPasswordEntity forgottenPasswordEntity = new ForgottenPasswordEntity(newId(), ZonedDateTime.now(), userEntity);
+            forgottenPasswordDao.persist(forgottenPasswordEntity);
+            String forgottenPasswordUrl = fromUri(selfserviceBaseUrl).path(SELFSERVICE_FORGOTTEN_PASSWORD_PATH).path(forgottenPasswordEntity.getCode()).build().toString();
+            notificationService.sendForgottenPasswordEmail(username, forgottenPasswordUrl)
+                    .thenAcceptAsync(notificationId -> logger.info("sent forgot password email successfully user [{}], notification id [{}]", userEntity.getExternalId(), notificationId))
+                    .exceptionally(exception -> {
+                        logger.error(format("error sending forgotten password email for user [%s]", userEntity.getExternalId()), exception);
+                        return null;
+                    });
+        } else {
+            logger.warn("Attempted forgotten password for non existent user {}", username);
+            throw AdminUsersExceptions.notFoundException();
+        }
     }
 
     public Optional<ForgottenPassword> findNonExpired(String code) {

--- a/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
@@ -1,8 +1,8 @@
 package uk.gov.pay.adminusers.service;
 
-
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Stopwatch;
+import uk.gov.pay.adminusers.app.config.NotifyConfiguration;
 import uk.gov.service.notify.SendEmailResponse;
 import uk.gov.service.notify.SendSmsResponse;
 
@@ -13,27 +13,28 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.collect.Maps.newHashMap;
+import static uk.gov.pay.adminusers.app.util.TrustStoreLoader.getSSLContext;
 
 public class NotificationService {
 
     private final ExecutorService executorService;
     private final NotifyClientProvider notifyClientProvider;
+    private final MetricRegistry metricRegistry;
+
     private final String secondFactorSmsTemplateId;
     private final String inviteEmailTemplateId;
     private final String forgottenPasswordEmailTemplateId;
-    private final MetricRegistry metricRegistry;
 
     public NotificationService(ExecutorService executorService,
-                               NotifyClientProvider notificationClientProvider,
-                               String secondFactorSmsTemplateId,
-                               String inviteEmailTemplateId,
-                               String forgottenPasswordEmailTemplateId,
+                               NotifyConfiguration notifyConfiguration,
                                MetricRegistry metricRegistry) {
         this.executorService = executorService;
-        this.notifyClientProvider = notificationClientProvider;
-        this.secondFactorSmsTemplateId = secondFactorSmsTemplateId;
-        this.inviteEmailTemplateId = inviteEmailTemplateId;
-        this.forgottenPasswordEmailTemplateId = forgottenPasswordEmailTemplateId;
+
+        this.notifyClientProvider = new NotifyClientProvider(notifyConfiguration, getSSLContext());
+        this.secondFactorSmsTemplateId = notifyConfiguration.getSecondFactorSmsTemplateId();
+        this.inviteEmailTemplateId = notifyConfiguration.getInviteEmailTemplateId();
+        this.forgottenPasswordEmailTemplateId = notifyConfiguration.getForgottenPasswordEmailTemplateId();
+
         this.metricRegistry = metricRegistry;
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
@@ -7,6 +7,7 @@ import uk.gov.service.notify.SendEmailResponse;
 import uk.gov.service.notify.SendSmsResponse;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -19,17 +20,20 @@ public class NotificationService {
     private final NotifyClientProvider notifyClientProvider;
     private final String secondFactorSmsTemplateId;
     private final String inviteEmailTemplateId;
+    private final String forgottenPasswordEmailTemplateId;
     private final MetricRegistry metricRegistry;
 
-    public NotificationService(ExecutorService executorService, 
-                               NotifyClientProvider notificationClientProvider, 
-                               String secondFactorSmsTemplateId, 
-                               String inviteEmailTemplateId, 
+    public NotificationService(ExecutorService executorService,
+                               NotifyClientProvider notificationClientProvider,
+                               String secondFactorSmsTemplateId,
+                               String inviteEmailTemplateId,
+                               String forgottenPasswordEmailTemplateId,
                                MetricRegistry metricRegistry) {
         this.executorService = executorService;
         this.notifyClientProvider = notificationClientProvider;
         this.secondFactorSmsTemplateId = secondFactorSmsTemplateId;
         this.inviteEmailTemplateId = inviteEmailTemplateId;
+        this.forgottenPasswordEmailTemplateId = forgottenPasswordEmailTemplateId;
         this.metricRegistry = metricRegistry;
     }
 
@@ -52,13 +56,23 @@ public class NotificationService {
     }
 
     CompletableFuture<String> sendInviteEmail(String sender, String email, String inviteUrl) {
+        HashMap<String, String> personalisation = newHashMap();
+        personalisation.put("username", sender);
+        personalisation.put("link", inviteUrl);
+        return sendEmailAsync(inviteEmailTemplateId, email, personalisation);
+    }
+
+    CompletableFuture<String> sendForgottenPasswordEmail(String email, String forgottenPasswordUrl) {
+        HashMap<String, String> personalisation = newHashMap();
+        personalisation.put("code", forgottenPasswordUrl);
+        return sendEmailAsync(forgottenPasswordEmailTemplateId, email, personalisation);
+    }
+
+    private CompletableFuture<String> sendEmailAsync(final String templateId, final String email, final Map<String, String> personalisation) {
         return CompletableFuture.supplyAsync(() -> {
-            HashMap<String, String> personalisation = newHashMap();
-            personalisation.put("username", sender);
-            personalisation.put("link", inviteUrl);
             Stopwatch responseTimeStopwatch = Stopwatch.createStarted();
             try {
-                SendEmailResponse response = notifyClientProvider.get().sendEmail(inviteEmailTemplateId, email, personalisation, null);
+                SendEmailResponse response = notifyClientProvider.get().sendEmail(templateId, email, personalisation, null);
                 return response.getNotificationId().toString();
             } catch (Exception e) {
                 metricRegistry.counter("notify-operations.email.failures").inc();

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -64,6 +64,7 @@ notify:
   notificationBaseURL: ${NOTIFY_BASE_URL:-https://stubs.pymnt.localdomain/notify}
   secondFactorSmsTemplateId: ${NOTIFY_2FA_TEMPLATE_ID:-pay-notify-two-factor-template-id}
   inviteEmailTemplateId: ${NOTIFY_INVITE_EMAIL_TEMPLATE_ID:-pay-notify-invite-email-template-id}
+  forgottenPasswordEmailTemplateId: ${NOTIFY_FORGOTTEN_PASSWORD_EMAIL_TEMPLATE_ID:-pay-notify-forgotten-password-email-template-id}
 
 graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}

--- a/src/test/java/uk/gov/pay/adminusers/resources/ForgottenPasswordResourceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ForgottenPasswordResourceTest.java
@@ -3,11 +3,13 @@ package uk.gov.pay.adminusers.resources;
 import com.jayway.restassured.response.ValidatableResponse;
 import org.junit.Test;
 
+import javax.ws.rs.core.Response.Status;
 import java.time.temporal.ChronoUnit;
 
 import static com.google.common.collect.ImmutableMap.of;
 import static com.jayway.restassured.http.ContentType.JSON;
 import static java.time.ZonedDateTime.now;
+import static javax.ws.rs.core.Response.Status.*;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.exparity.hamcrest.date.ZonedDateTimeMatchers.within;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -28,25 +30,14 @@ public class ForgottenPasswordResourceTest extends IntegrationTest {
 
         String username = userDbFixture(databaseHelper).insertUser().getUsername();
 
-        ValidatableResponse validatableResponse = givenSetup()
+        givenSetup()
                 .when()
                 .body(mapper.writeValueAsString(of("username", username)))
                 .contentType(JSON)
                 .accept(JSON)
                 .post(FORGOTTEN_PASSWORDS_RESOURCE_URL)
                 .then()
-                .statusCode(201);
-
-        validatableResponse
-                .body("username", is(username))
-                .body("code", is(notNullValue()))
-                .body("_links", hasSize(1))
-                .body("_links[0].href", is("http://localhost:8080/v1/api/forgotten-passwords/" + validatableResponse.extract().body().path("code").toString()))
-                .body("_links[0].method", is("GET"))
-                .body("_links[0].rel", is("self"));
-
-        String dateTimeString = validatableResponse.extract().body().path("date");
-        assertThat(toUTCZonedDateTime(dateTimeString).get(), within(1, ChronoUnit.MINUTES, now()));
+                .statusCode(OK.getStatusCode());
     }
 
     @Test
@@ -61,7 +52,7 @@ public class ForgottenPasswordResourceTest extends IntegrationTest {
                 .accept(JSON)
                 .post(FORGOTTEN_PASSWORDS_RESOURCE_URL_V2)
                 .then()
-                .statusCode(201);
+                .statusCode(CREATED.getStatusCode());
 
         validatableResponse
                 .body("username", is(username))
@@ -85,7 +76,7 @@ public class ForgottenPasswordResourceTest extends IntegrationTest {
                 .accept(JSON)
                 .post(FORGOTTEN_PASSWORDS_RESOURCE_URL)
                 .then()
-                .statusCode(404);
+                .statusCode(NOT_FOUND.getStatusCode());
 
     }
 
@@ -100,7 +91,7 @@ public class ForgottenPasswordResourceTest extends IntegrationTest {
                 .accept(JSON)
                 .get(FORGOTTEN_PASSWORDS_RESOURCE_URL + "/" + forgottenPasswordCode)
                 .then()
-                .statusCode(200)
+                .statusCode(OK.getStatusCode())
                 .body("code", is(forgottenPasswordCode));
 
     }
@@ -113,7 +104,7 @@ public class ForgottenPasswordResourceTest extends IntegrationTest {
                 .accept(JSON)
                 .get(FORGOTTEN_PASSWORDS_RESOURCE_URL + "/non-existent-code")
                 .then()
-                .statusCode(404);
+                .statusCode(NOT_FOUND.getStatusCode());
 
     }
 
@@ -125,7 +116,7 @@ public class ForgottenPasswordResourceTest extends IntegrationTest {
                 .accept(JSON)
                 .get(FORGOTTEN_PASSWORDS_RESOURCE_URL + "/" + randomAlphanumeric(256))
                 .then()
-                .statusCode(404);
+                .statusCode(NOT_FOUND.getStatusCode());
 
     }
 }

--- a/src/test/resources/pacts/selfservice-create-forgotten-password-adminusers.json
+++ b/src/test/resources/pacts/selfservice-create-forgotten-password-adminusers.json
@@ -11,7 +11,7 @@
       "provider_state": "a user exist",
       "request": {
         "method": "POST",
-        "path": "/v1/api/forgotten-passwords",
+        "path": "/v2/api/forgotten-passwords",
         "headers": {
           "Accept": "application/json"
         },


### PR DESCRIPTION
## WHAT
- Added notifications as part of forgotten password journey. Since we don't need any information to send back to selfservice (was building the link for the notification in that side), removed response payload, returning a 200 OK response when creating a Forgotten Password successfully (consistent with second factor)

- These changes assume selfservice is using v2 of the resource. This PR will make possible then to use this new version (next PR). So this PR depends on https://github.com/alphagov/pay-selfservice/pull/332 to be merged and deployed.