### PR TITLE
PP-1977 Add userExternalId to ForgottenPassword

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/model/ForgottenPassword.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/ForgottenPassword.java
@@ -14,26 +14,29 @@ import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class ForgottenPassword {
+
     @JsonIgnore
     private Integer id;
     private String code;
     private ZonedDateTime date;
     private String username;
+    private String userExternalId;
     private List<Link> links;
 
-    public static ForgottenPassword forgottenPassword(String code, String username) {
-        return forgottenPassword(randomInt(), code, username, ZonedDateTime.now(ZoneId.of("UTC")));
+    public static ForgottenPassword forgottenPassword(String code, String username, String userExternalId) {
+        return forgottenPassword(randomInt(), code, username, ZonedDateTime.now(ZoneId.of("UTC")), userExternalId);
     }
 
-    public static ForgottenPassword forgottenPassword(Integer id, String code, String username, ZonedDateTime date) {
-        return new ForgottenPassword(id, code, date, username);
+    public static ForgottenPassword forgottenPassword(Integer id, String code, String username, ZonedDateTime date, String userExternalId) {
+        return new ForgottenPassword(id, code, date, username, userExternalId);
     }
 
-    private ForgottenPassword(Integer id, String code, ZonedDateTime date, String username) {
+    private ForgottenPassword(Integer id, String code, ZonedDateTime date, String username, String userExternalId) {
         this.id = id;
         this.code = code;
         this.date = date;
         this.username = username;
+        this.userExternalId = userExternalId;
     }
 
     public Integer getId() {
@@ -51,6 +54,10 @@ public class ForgottenPassword {
 
     public String getUsername() {
         return username;
+    }
+
+    public String getUserExternalId() {
+        return userExternalId;
     }
 
     public void setLinks(List<Link> links) {

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ForgottenPasswordEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ForgottenPasswordEntity.java
@@ -96,6 +96,6 @@ public class ForgottenPasswordEntity extends AbstractEntity {
     }
 
     public ForgottenPassword toForgottenPassword() {
-        return forgottenPassword(getId(), code, user.getUsername(), date);
+        return forgottenPassword(getId(), code, user.getUsername(), date, user.getExternalId());
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/ForgottenPasswordDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/ForgottenPasswordDbFixture.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.adminusers.fixtures;
 
 import org.apache.commons.lang3.RandomStringUtils;
+import uk.gov.pay.adminusers.app.util.RandomIdGenerator;
 import uk.gov.pay.adminusers.utils.DatabaseTestHelper;
 
 import java.time.ZoneId;
@@ -27,7 +28,7 @@ public class ForgottenPasswordDbFixture {
     }
 
     public String insertForgottenPassword() {
-        databaseTestHelper.add(forgottenPassword(nextInt(), forgottenPasswordCode, null, date), userId);
+        databaseTestHelper.add(forgottenPassword(nextInt(), forgottenPasswordCode, null, date, RandomIdGenerator.randomUuid()), userId);
         return forgottenPasswordCode;
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/pact/UsersApiTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/pact/UsersApiTest.java
@@ -56,9 +56,10 @@ public class UsersApiTest {
     public void aUserExistsWithAForgottenPasswordRequest() throws Exception {
         String code = "avalidforgottenpasswordtoken";
         String username = randomAlphabetic(20);
-        createUserWithinAService(RandomIdGenerator.randomUuid(), username, "password");
+        String externalId = RandomIdGenerator.randomUuid();
+        createUserWithinAService(externalId, username, "password");
         List<Map<String, Object>> userByUsername = dbHelper.findUserByUsername(username);
-        dbHelper.add(ForgottenPassword.forgottenPassword(code, username), (Integer) userByUsername.get(0).get("id"));
+        dbHelper.add(ForgottenPassword.forgottenPassword(code, username, externalId), (Integer) userByUsername.get(0).get("id"));
     }
 
     @State("a user exists with max login attempts")
@@ -72,8 +73,9 @@ public class UsersApiTest {
     public void aForgottenPasswordEntryExist() throws Exception {
         String code = "existing-code";
         String username = "existing-user";
+        String existingExternalId = "7d19aff33f8948deb97ed16b2912dcd3";
         List<Map<String, Object>> userByName = dbHelper.findUserByUsername(username);
-        dbHelper.add(ForgottenPassword.forgottenPassword(code, username), (Integer) userByName.get(0).get("id"));
+        dbHelper.add(ForgottenPassword.forgottenPassword(code, username, existingExternalId), (Integer) userByName.get(0).get("id"));
     }
 
     private static void createUserWithinAService(String externalId, String username, String password) throws Exception {

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/ForgottenPasswordDaoTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/ForgottenPasswordDaoTest.java
@@ -3,6 +3,7 @@ package uk.gov.pay.adminusers.persistence.dao;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.ForgottenPassword;
+import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.persistence.entity.ForgottenPasswordEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 
@@ -40,10 +41,11 @@ public class ForgottenPasswordDaoTest extends DaoTestBase {
     @Test
     public void shouldPersistAForgottenPasswordEntity() throws Exception {
         String forgottenPasswordCode = random(10);
-        String username = userDbFixture(databaseHelper).insertUser().getUsername();
+        User user = userDbFixture(databaseHelper).insertUser();
+        String username = user.getUsername();
         UserEntity userEntity = userDao.findByUsername(username).get();
 
-        ForgottenPassword forgottenPassword = forgottenPassword(forgottenPasswordCode, username);
+        ForgottenPassword forgottenPassword = forgottenPassword(forgottenPasswordCode, username, user.getExternalId());
         ForgottenPasswordEntity forgottenPasswordEntity = ForgottenPasswordEntity.from(forgottenPassword, userEntity);
 
         forgottenPasswordDao.persist(forgottenPasswordEntity);
@@ -62,11 +64,12 @@ public class ForgottenPasswordDaoTest extends DaoTestBase {
     @Test
     public void shouldFindForgottenPasswordByCode_ifNotExpired() throws Exception {
         String forgottenPasswordCode = random(10);
-        String username = userDbFixture(databaseHelper).insertUser().getUsername();
+        User user = userDbFixture(databaseHelper).insertUser();
+        String username = user.getUsername();
         UserEntity userEntity = userDao.findByUsername(username).get();
 
         ZonedDateTime notExpired = ZonedDateTime.now().minusMinutes(89);
-        ForgottenPassword forgottenPassword = forgottenPassword(randomInt(), forgottenPasswordCode, username, notExpired);
+        ForgottenPassword forgottenPassword = forgottenPassword(randomInt(), forgottenPasswordCode, username, notExpired, user.getExternalId());
 
         databaseHelper.add(forgottenPassword, userEntity.getId());
 
@@ -81,11 +84,12 @@ public class ForgottenPasswordDaoTest extends DaoTestBase {
     @Test
     public void shouldNotFindForgottenPasswordByCode_ifExpired() throws Exception {
         String forgottenPasswordCode = newId();
-        String username = userDbFixture(databaseHelper).insertUser().getUsername();
+        User user = userDbFixture(databaseHelper).insertUser();
+        String username = user.getUsername();
         UserEntity userEntity = userDao.findByUsername(username).get();
 
         ZonedDateTime expired = ZonedDateTime.now().minusMinutes(91);
-        ForgottenPassword forgottenPassword = forgottenPassword(randomInt(), forgottenPasswordCode, username, expired);
+        ForgottenPassword forgottenPassword = forgottenPassword(randomInt(), forgottenPasswordCode, username, expired, user.getExternalId());
 
         databaseHelper.add(forgottenPassword, userEntity.getId());
 
@@ -96,11 +100,12 @@ public class ForgottenPasswordDaoTest extends DaoTestBase {
     @Test
     public void shouldRemoveForgottenPasswordEntity() {
         String forgottenPasswordCode = newId();
-        String username = userDbFixture(databaseHelper).insertUser().getUsername();
+        User user = userDbFixture(databaseHelper).insertUser();
+        String username = user.getUsername();
         UserEntity userEntity = userDao.findByUsername(username).get();
 
         ZonedDateTime notExpired = ZonedDateTime.now().minusMinutes(89);
-        ForgottenPassword forgottenPassword = forgottenPassword(randomInt(), forgottenPasswordCode, username, notExpired);
+        ForgottenPassword forgottenPassword = forgottenPassword(randomInt(), forgottenPasswordCode, username, notExpired, user.getExternalId());
 
         databaseHelper.add(forgottenPassword, userEntity.getId());
 

--- a/src/test/java/uk/gov/pay/adminusers/service/ForgottenPasswordServicesTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ForgottenPasswordServicesTest.java
@@ -55,8 +55,10 @@ public class ForgottenPasswordServicesTest {
     @Deprecated
     public void shouldReturnANewForgottenPassword_whenCreating_ifUserFound_Legacy() throws Exception {
         String existingUsername = "existing-user";
+        String existingExternalId = "7d19aff33f8948deb97ed16b2912dcd3";
         UserEntity mockUser = mock(UserEntity.class);
         when(mockUser.getUsername()).thenReturn(existingUsername);
+        when(mockUser.getExternalId()).thenReturn(existingExternalId);
 
         when(userDao.findByUsername(existingUsername)).thenReturn(Optional.of(mockUser));
         Optional<ForgottenPassword> forgottenPasswordOptional = forgottenPasswordServices.createWithoutNotification(existingUsername);
@@ -64,6 +66,7 @@ public class ForgottenPasswordServicesTest {
         verify(forgottenPasswordDao, times(1)).persist(any(ForgottenPasswordEntity.class));
         assertTrue(forgottenPasswordOptional.isPresent());
         assertThat(forgottenPasswordOptional.get().getUsername(), is(existingUsername));
+        assertThat(forgottenPasswordOptional.get().getUserExternalId(), is(existingExternalId));
         assertThat(forgottenPasswordOptional.get().getCode(), is(notNullValue()));
         assertThat(forgottenPasswordOptional.get().getLinks().size(), is(1));
         verifyZeroInteractions(mockNotificationService);

--- a/src/test/java/uk/gov/pay/adminusers/service/LinksBuilderTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/LinksBuilderTest.java
@@ -28,7 +28,7 @@ public class LinksBuilderTest {
 
     @Test
     public void shouldConstruct_forgottenPasswordSelfLinkCorrectly() throws Exception {
-        ForgottenPassword forgottenPassword = ForgottenPassword.forgottenPassword(1, "a-code", "a-name", ZonedDateTime.now());
+        ForgottenPassword forgottenPassword = ForgottenPassword.forgottenPassword(1, "a-code", "a-name", ZonedDateTime.now(), "7d19aff33f8948deb97ed16b2912dcd3");
         ForgottenPassword decorated = linksBuilder.decorate(forgottenPassword);
 
         String linkJson = new ObjectMapper().writeValueAsString(decorated.getLinks().get(0));


### PR DESCRIPTION
## WHAT

Add `userExternalId` to `ForgottenPassword` API object.

## WHY

When we get `ForgottenPassword` by code, self service will need `userExternalId` property