### PR TITLE
PP-1977 Forgotten password clean up

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/model/ForgottenPassword.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/ForgottenPassword.java
@@ -19,23 +19,21 @@ public class ForgottenPassword {
     private Integer id;
     private String code;
     private ZonedDateTime date;
-    private String username;
     private String userExternalId;
     private List<Link> links;
 
-    public static ForgottenPassword forgottenPassword(String code, String username, String userExternalId) {
-        return forgottenPassword(randomInt(), code, username, ZonedDateTime.now(ZoneId.of("UTC")), userExternalId);
+    public static ForgottenPassword forgottenPassword(String code, String userExternalId) {
+        return forgottenPassword(randomInt(), code, ZonedDateTime.now(ZoneId.of("UTC")), userExternalId);
     }
 
-    public static ForgottenPassword forgottenPassword(Integer id, String code, String username, ZonedDateTime date, String userExternalId) {
-        return new ForgottenPassword(id, code, date, username, userExternalId);
+    public static ForgottenPassword forgottenPassword(Integer id, String code, ZonedDateTime date, String userExternalId) {
+        return new ForgottenPassword(id, code, date, userExternalId);
     }
 
-    private ForgottenPassword(Integer id, String code, ZonedDateTime date, String username, String userExternalId) {
+    private ForgottenPassword(Integer id, String code, ZonedDateTime date, String userExternalId) {
         this.id = id;
         this.code = code;
         this.date = date;
-        this.username = username;
         this.userExternalId = userExternalId;
     }
 
@@ -50,10 +48,6 @@ public class ForgottenPassword {
     @JsonSerialize(using = ZonedDateTimeSerializer.class)
     public ZonedDateTime getDate() {
         return date;
-    }
-
-    public String getUsername() {
-        return username;
     }
 
     public String getUserExternalId() {

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ForgottenPasswordEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ForgottenPasswordEntity.java
@@ -96,6 +96,6 @@ public class ForgottenPasswordEntity extends AbstractEntity {
     }
 
     public ForgottenPassword toForgottenPassword() {
-        return forgottenPassword(getId(), code, user.getUsername(), date, user.getExternalId());
+        return forgottenPassword(getId(), code, date, user.getExternalId());
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/resources/ForgottenPasswordResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ForgottenPasswordResource.java
@@ -18,7 +18,6 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 @Path("/")
 public class ForgottenPasswordResource {
 
-    public static final String FORGOTTEN_PASSWORDS_RESOURCE_V2 = "/v2/api/forgotten-passwords";
     public static final String FORGOTTEN_PASSWORDS_RESOURCE = "/v1/api/forgotten-passwords";
     private static final String FORGOTTEN_PASSWORD_RESOURCE = FORGOTTEN_PASSWORDS_RESOURCE + "/{code}";
     private static final Logger logger = PayLoggerFactory.getLogger(ForgottenPasswordResource.class);
@@ -47,24 +46,6 @@ public class ForgottenPasswordResource {
                     forgottenPasswordServices.create(payload.get("username").asText());
                     return Response.status(Response.Status.OK).build();
                 });
-    }
-
-    @Path(FORGOTTEN_PASSWORDS_RESOURCE_V2)
-    @POST
-    @Produces(APPLICATION_JSON)
-    @Consumes(APPLICATION_JSON)
-    public Response createForgottenPasswordLegacy(JsonNode payload) {
-        logger.info("ForgottenPassword CREATE request - [ {} ]", payload);
-        Optional<Errors> errorsOptional = validator.validateCreateRequest(payload);
-        return errorsOptional
-                .map(errors ->
-                        Response.status(BAD_REQUEST).type(APPLICATION_JSON).entity(errors).build())
-                .orElseGet(() ->
-                        forgottenPasswordServices.createWithoutNotification(payload.get("username").asText())
-                                .map(forgottenPassword ->
-                                        Response.status(CREATED).type(APPLICATION_JSON).entity(forgottenPassword).build())
-                                .orElseGet(() ->
-                                        Response.status(NOT_FOUND).build()));
     }
 
     @Path(FORGOTTEN_PASSWORD_RESOURCE)

--- a/src/main/java/uk/gov/pay/adminusers/service/ForgottenPasswordServices.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ForgottenPasswordServices.java
@@ -37,20 +37,6 @@ public class ForgottenPasswordServices {
         this.selfserviceBaseUrl = config.getLinks().getSelfserviceUrl();
     }
 
-    @Deprecated
-    public Optional<ForgottenPassword> createWithoutNotification(String username) {
-        return userDao.findByUsername(username)
-                .map(userEntity -> {
-                    ForgottenPasswordEntity forgottenPasswordEntity = new ForgottenPasswordEntity(newId(), ZonedDateTime.now(), userEntity);
-                    forgottenPasswordDao.persist(forgottenPasswordEntity);
-                    return Optional.of(linksBuilder.decorate(forgottenPasswordEntity.toForgottenPassword()));
-                })
-                .orElseGet(() -> {
-                    logger.warn("Attempted forgotten password for non existent user {}", username);
-                    return Optional.empty();
-                });
-    }
-
     public void create(String username) {
         Optional<UserEntity> userOptional = userDao.findByUsername(username);
         if (userOptional.isPresent()) {

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/ForgottenPasswordDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/ForgottenPasswordDbFixture.java
@@ -28,7 +28,7 @@ public class ForgottenPasswordDbFixture {
     }
 
     public String insertForgottenPassword() {
-        databaseTestHelper.add(forgottenPassword(nextInt(), forgottenPasswordCode, null, date, RandomIdGenerator.randomUuid()), userId);
+        databaseTestHelper.add(forgottenPassword(nextInt(), forgottenPasswordCode, date, RandomIdGenerator.randomUuid()), userId);
         return forgottenPasswordCode;
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/pact/UsersApiTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/pact/UsersApiTest.java
@@ -55,11 +55,10 @@ public class UsersApiTest {
     @State("a valid forgotten password entry and a related user exists")
     public void aUserExistsWithAForgottenPasswordRequest() throws Exception {
         String code = "avalidforgottenpasswordtoken";
-        String username = randomAlphabetic(20);
-        String externalId = RandomIdGenerator.randomUuid();
-        createUserWithinAService(externalId, username, "password");
-        List<Map<String, Object>> userByUsername = dbHelper.findUserByUsername(username);
-        dbHelper.add(ForgottenPassword.forgottenPassword(code, username, externalId), (Integer) userByUsername.get(0).get("id"));
+        String userExternalId = RandomIdGenerator.randomUuid();
+        createUserWithinAService(userExternalId, randomAlphabetic(20), "password");
+        List<Map<String, Object>> userByExternalId = dbHelper.findUserByExternalId(userExternalId);
+        dbHelper.add(ForgottenPassword.forgottenPassword(code, userExternalId), (Integer) userByExternalId.get(0).get("id"));
     }
 
     @State("a user exists with max login attempts")
@@ -72,10 +71,9 @@ public class UsersApiTest {
     @State("a forgotten password entry exist")
     public void aForgottenPasswordEntryExist() throws Exception {
         String code = "existing-code";
-        String username = "existing-user";
-        String existingExternalId = "7d19aff33f8948deb97ed16b2912dcd3";
-        List<Map<String, Object>> userByName = dbHelper.findUserByUsername(username);
-        dbHelper.add(ForgottenPassword.forgottenPassword(code, username, existingExternalId), (Integer) userByName.get(0).get("id"));
+        String existingUserExternalId = "7d19aff33f8948deb97ed16b2912dcd3";
+        List<Map<String, Object>> userByName = dbHelper.findUserByExternalId(existingUserExternalId);
+        dbHelper.add(ForgottenPassword.forgottenPassword(code, existingUserExternalId), (Integer) userByName.get(0).get("id"));
     }
 
     private static void createUserWithinAService(String externalId, String username, String password) throws Exception {

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/ForgottenPasswordDaoTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/ForgottenPasswordDaoTest.java
@@ -42,10 +42,10 @@ public class ForgottenPasswordDaoTest extends DaoTestBase {
     public void shouldPersistAForgottenPasswordEntity() throws Exception {
         String forgottenPasswordCode = random(10);
         User user = userDbFixture(databaseHelper).insertUser();
-        String username = user.getUsername();
-        UserEntity userEntity = userDao.findByUsername(username).get();
+        String userExternalId = user.getExternalId();
+        UserEntity userEntity = userDao.findByExternalId(userExternalId).get();
 
-        ForgottenPassword forgottenPassword = forgottenPassword(forgottenPasswordCode, username, user.getExternalId());
+        ForgottenPassword forgottenPassword = forgottenPassword(forgottenPasswordCode, userExternalId);
         ForgottenPasswordEntity forgottenPasswordEntity = ForgottenPasswordEntity.from(forgottenPassword, userEntity);
 
         forgottenPasswordDao.persist(forgottenPasswordEntity);
@@ -65,11 +65,11 @@ public class ForgottenPasswordDaoTest extends DaoTestBase {
     public void shouldFindForgottenPasswordByCode_ifNotExpired() throws Exception {
         String forgottenPasswordCode = random(10);
         User user = userDbFixture(databaseHelper).insertUser();
-        String username = user.getUsername();
-        UserEntity userEntity = userDao.findByUsername(username).get();
+        String userExternalId = user.getExternalId();
+        UserEntity userEntity = userDao.findByExternalId(userExternalId).get();
 
         ZonedDateTime notExpired = ZonedDateTime.now().minusMinutes(89);
-        ForgottenPassword forgottenPassword = forgottenPassword(randomInt(), forgottenPasswordCode, username, notExpired, user.getExternalId());
+        ForgottenPassword forgottenPassword = forgottenPassword(randomInt(), forgottenPasswordCode, notExpired, userExternalId);
 
         databaseHelper.add(forgottenPassword, userEntity.getId());
 
@@ -85,11 +85,11 @@ public class ForgottenPasswordDaoTest extends DaoTestBase {
     public void shouldNotFindForgottenPasswordByCode_ifExpired() throws Exception {
         String forgottenPasswordCode = newId();
         User user = userDbFixture(databaseHelper).insertUser();
-        String username = user.getUsername();
-        UserEntity userEntity = userDao.findByUsername(username).get();
+        String userExternalId = user.getExternalId();
+        UserEntity userEntity = userDao.findByExternalId(userExternalId).get();
 
         ZonedDateTime expired = ZonedDateTime.now().minusMinutes(91);
-        ForgottenPassword forgottenPassword = forgottenPassword(randomInt(), forgottenPasswordCode, username, expired, user.getExternalId());
+        ForgottenPassword forgottenPassword = forgottenPassword(randomInt(), forgottenPasswordCode, expired, userExternalId);
 
         databaseHelper.add(forgottenPassword, userEntity.getId());
 
@@ -101,11 +101,11 @@ public class ForgottenPasswordDaoTest extends DaoTestBase {
     public void shouldRemoveForgottenPasswordEntity() {
         String forgottenPasswordCode = newId();
         User user = userDbFixture(databaseHelper).insertUser();
-        String username = user.getUsername();
-        UserEntity userEntity = userDao.findByUsername(username).get();
+        String userExternalId = user.getExternalId();
+        UserEntity userEntity = userDao.findByExternalId(userExternalId).get();
 
         ZonedDateTime notExpired = ZonedDateTime.now().minusMinutes(89);
-        ForgottenPassword forgottenPassword = forgottenPassword(randomInt(), forgottenPasswordCode, username, notExpired, user.getExternalId());
+        ForgottenPassword forgottenPassword = forgottenPassword(randomInt(), forgottenPasswordCode, notExpired, userExternalId);
 
         databaseHelper.add(forgottenPassword, userEntity.getId());
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/ForgottenPasswordResourceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ForgottenPasswordResourceTest.java
@@ -1,29 +1,18 @@
 package uk.gov.pay.adminusers.resources;
 
-import com.jayway.restassured.response.ValidatableResponse;
 import org.junit.Test;
-
-import javax.ws.rs.core.Response.Status;
-import java.time.temporal.ChronoUnit;
 
 import static com.google.common.collect.ImmutableMap.of;
 import static com.jayway.restassured.http.ContentType.JSON;
-import static java.time.ZonedDateTime.now;
 import static javax.ws.rs.core.Response.Status.*;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
-import static org.exparity.hamcrest.date.ZonedDateTimeMatchers.within;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.notNullValue;
 import static uk.gov.pay.adminusers.fixtures.ForgottenPasswordDbFixture.forgottenPasswordDbFixture;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
-import static uk.gov.pay.adminusers.utils.DateTimeUtils.toUTCZonedDateTime;
 
 public class ForgottenPasswordResourceTest extends IntegrationTest {
 
     private static final String FORGOTTEN_PASSWORDS_RESOURCE_URL = "/v1/api/forgotten-passwords";
-    private static final String FORGOTTEN_PASSWORDS_RESOURCE_URL_V2 = "/v2/api/forgotten-passwords";
 
     @Test
     public void shouldGetForgottenPasswordReference_whenCreate_forAnExistingUser() throws Exception {
@@ -38,32 +27,6 @@ public class ForgottenPasswordResourceTest extends IntegrationTest {
                 .post(FORGOTTEN_PASSWORDS_RESOURCE_URL)
                 .then()
                 .statusCode(OK.getStatusCode());
-    }
-
-    @Test
-    public void shouldGetForgottenPasswordReference_whenCreate_forAnExistingUser_Legacy() throws Exception {
-
-        String username = userDbFixture(databaseHelper).insertUser().getUsername();
-
-        ValidatableResponse validatableResponse = givenSetup()
-                .when()
-                .body(mapper.writeValueAsString(of("username", username)))
-                .contentType(JSON)
-                .accept(JSON)
-                .post(FORGOTTEN_PASSWORDS_RESOURCE_URL_V2)
-                .then()
-                .statusCode(CREATED.getStatusCode());
-
-        validatableResponse
-                .body("username", is(username))
-                .body("code", is(notNullValue()))
-                .body("_links", hasSize(1))
-                .body("_links[0].href", is("http://localhost:8080/v1/api/forgotten-passwords/" + validatableResponse.extract().body().path("code").toString()))
-                .body("_links[0].method", is("GET"))
-                .body("_links[0].rel", is("self"));
-
-        String dateTimeString = validatableResponse.extract().body().path("date");
-        assertThat(toUTCZonedDateTime(dateTimeString).get(), within(1, ChronoUnit.MINUTES, now()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/service/ForgottenPasswordServicesTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ForgottenPasswordServicesTest.java
@@ -58,38 +58,6 @@ public class ForgottenPasswordServicesTest {
     }
 
     @Test
-    @Deprecated
-    public void shouldReturnANewForgottenPassword_whenCreating_ifUserFound_Legacy() throws Exception {
-        String existingUsername = "existing-user";
-        String existingExternalId = "7d19aff33f8948deb97ed16b2912dcd3";
-        UserEntity mockUser = mock(UserEntity.class);
-        when(mockUser.getUsername()).thenReturn(existingUsername);
-        when(mockUser.getExternalId()).thenReturn(existingExternalId);
-
-        when(userDao.findByUsername(existingUsername)).thenReturn(Optional.of(mockUser));
-        Optional<ForgottenPassword> forgottenPasswordOptional = forgottenPasswordServices.createWithoutNotification(existingUsername);
-
-        verify(forgottenPasswordDao, times(1)).persist(any(ForgottenPasswordEntity.class));
-        assertTrue(forgottenPasswordOptional.isPresent());
-        assertThat(forgottenPasswordOptional.get().getUsername(), is(existingUsername));
-        assertThat(forgottenPasswordOptional.get().getUserExternalId(), is(existingExternalId));
-        assertThat(forgottenPasswordOptional.get().getCode(), is(notNullValue()));
-        assertThat(forgottenPasswordOptional.get().getLinks().size(), is(1));
-        verifyZeroInteractions(mockNotificationService);
-    }
-
-    @Test
-    @Deprecated
-    public void shouldReturnEmpty_whenCreating_ifUserNotFound_Legacy() throws Exception {
-        String nonExistentUser = "non-existent-user";
-        when(userDao.findByUsername(nonExistentUser)).thenReturn(Optional.empty());
-
-        Optional<ForgottenPassword> forgottenPasswordOptional = forgottenPasswordServices.createWithoutNotification(nonExistentUser);
-        assertFalse(forgottenPasswordOptional.isPresent());
-        verifyZeroInteractions(mockNotificationService);
-    }
-
-    @Test
     public void shouldSendAForgottenPasswordNotification_whenCreating_ifUserFound() throws Exception {
 
         ArgumentCaptor<ForgottenPasswordEntity> expectedForgottenPassword = ArgumentCaptor.forClass(ForgottenPasswordEntity.class);

--- a/src/test/java/uk/gov/pay/adminusers/service/LinksBuilderTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/LinksBuilderTest.java
@@ -28,7 +28,7 @@ public class LinksBuilderTest {
 
     @Test
     public void shouldConstruct_forgottenPasswordSelfLinkCorrectly() throws Exception {
-        ForgottenPassword forgottenPassword = ForgottenPassword.forgottenPassword(1, "a-code", "a-name", ZonedDateTime.now(), "7d19aff33f8948deb97ed16b2912dcd3");
+        ForgottenPassword forgottenPassword = ForgottenPassword.forgottenPassword(1, "a-code", ZonedDateTime.now(), "7d19aff33f8948deb97ed16b2912dcd3");
         ForgottenPassword decorated = linksBuilder.decorate(forgottenPassword);
 
         String linkJson = new ObjectMapper().writeValueAsString(decorated.getLinks().get(0));

--- a/src/test/resources/pacts/selfservice-create-forgotten-password-adminusers.json
+++ b/src/test/resources/pacts/selfservice-create-forgotten-password-adminusers.json
@@ -3,7 +3,7 @@
     "name": "Selfservice-create-forgotten-password"
   },
   "provider": {
-    "name": "adminusers"
+    "name": "AdminUsers"
   },
   "interactions": [
     {
@@ -11,7 +11,7 @@
       "provider_state": "a user exist",
       "request": {
         "method": "POST",
-        "path": "/v2/api/forgotten-passwords",
+        "path": "/v1/api/forgotten-passwords",
         "headers": {
           "Accept": "application/json"
         },
@@ -20,41 +20,9 @@
         }
       },
       "response": {
-        "status": 201,
+        "status": 200,
         "headers": {
           "Content-Type": "application/json"
-        },
-        "body": {
-          "username": "existing-user",
-          "code": "l7jzyxn72zkdno0a7cik9",
-          "date": "2010-12-31T22:59:59.132Z",
-          "_links": [
-            {
-              "href": "http://localhost:8080/v1/api/forgotten-passwords/l7jzyxn72zkdno0a7cik9",
-              "rel": "self",
-              "method": "GET"
-            }
-          ]
-        },
-        "matchingRules": {
-          "$.body.username": {
-            "match": "type"
-          },
-          "$.body.code": {
-            "match": "type"
-          },
-          "$.body.date": {
-            "match": "type"
-          },
-          "$.body._links[0].href": {
-            "match": "type"
-          },
-          "$.body._links[0].rel": {
-            "match": "type"
-          },
-          "$.body._links[0].method": {
-            "match": "type"
-          }
         }
       }
     },

--- a/src/test/resources/pacts/selfservice-get-forgotten-password-adminusers.json
+++ b/src/test/resources/pacts/selfservice-get-forgotten-password-adminusers.json
@@ -3,7 +3,7 @@
     "name": "Selfservice-get-forgotten-password"
   },
   "provider": {
-    "name": "adminusers"
+    "name": "AdminUsers"
   },
   "interactions": [
     {
@@ -22,19 +22,19 @@
           "Content-Type": "application/json"
         },
         "body": {
-          "username": "username",
+          "user_external_id": "userExternalId",
           "code": "existing-code",
           "date": "2010-12-31T22:59:59.132Z",
           "_links": [
             {
-              "href": "http://localhost:8080/v1/api/forgotten-passwords/811o7haan4ovrnrpy14i",
+              "href": "http://localhost:8080/v1/api/forgotten-passwords/r6n05xavt9ab0nxez5mi",
               "rel": "self",
               "method": "GET"
             }
           ]
         },
         "matchingRules": {
-          "$.body.username": {
+          "$.body.user_external_id": {
             "match": "type"
           },
           "$.body.code": {


### PR DESCRIPTION
## WHAT

- Revert back to `/v1/api/forgotten-passwords` endpoint, which uses the new `externalId` logic.
- Remove `username` from `ForgottenPassword`, because we don't need it anymore.