### PR TITLE
PP-2084 Update pom to make pact a test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,7 @@
             <groupId>au.com.dius</groupId>
             <artifactId>pact-jvm-provider-junit_2.11</artifactId>
             <version>3.3.7</version>
+            <scope>test</scope>    
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## What
Add the test scope attribute to the pact reference

## Why
To prevent false positives in security scans for items that are not deployed.