### PR TITLE
PP-2114 Upgraded commons-beanutils dependency which contains vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,12 @@
             <version>3.3.7</version>
             <scope>test</scope>    
         </dependency>
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.9.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
`commons-beanutils:commons-beanutils:jar:1.8.0` brought in as a transient test dependency has the following vulnerability:
 - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-0114
 - https://snyk.io/vuln/SNYK-JAVA-COMMONSBEANUTILS-30077

Pinned down version of the dependency to `1.9.3` and marked explicitly as test scoped.