### PR TITLE
PP-1615 EmailValidator initial implementation

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.adminusers.utils.email;
 
+import com.google.common.base.Joiner;
+
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -37,27 +39,33 @@ public class EmailValidator {
     }
     private static final Pattern PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERN;
     static {
-        StringBuilder domainRegExPatternStringBuilder = new StringBuilder();
-        for (int i = 0, size = PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERNS.size(); i < size; i++) {
-            if (i != 0) {
-                domainRegExPatternStringBuilder.append("|");
-            }
-            domainRegExPatternStringBuilder.append(PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERNS.get(i));
-        }
-        String domainRegExPatternString = domainRegExPatternStringBuilder.toString();
+        String domainRegExPatternString = Joiner.on("|").join(PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERNS);
 
-        // We are splitting the logic into two parts
-        // for domains and subdomains
-        String regExDomainsOnlyPart = "(" + domainRegExPatternString + ")"; // this is "OR" of all domains
-        // the subdomain part:
-        // - cannot start with "-"
-        // - can have any alphanumeric letter or -
-        // - cannot end with "-"
+        // We are splitting the logic into two parts for whitelisted domains and subdomains
+        String regExDomainsOnlyPart = "(" + domainRegExPatternString + ")";
         String regExSubdomainsPart = "(((?!-)[A-Za-z0-9-]+(?<!-)\\.)+(" + domainRegExPatternString + "))";
         PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERN =
                 Pattern.compile("^" + regExDomainsOnlyPart +  "|" + regExSubdomainsPart + "$");
     }
 
+    /**
+     * This method checks that an email belongs to a public sector domain name
+     * <p>
+     * The logic is split into two parts:
+     * <ol>
+     *   <li>checks the subdomains and that they:</li>
+     *   <ul>
+     *     <li>don't start with "-" </li>
+     *     <li>only have any alphanumeric characters or "-"</li>
+     *     <li>don't end with "-"</li>
+     *   </ul>
+     *   <li>checks the whitelisted domains</li>
+     * </ol>
+     * </p>
+     *
+     * @param email the email to check
+     * @return <b>boolean</b> whether or not it is from a public sector domain
+     */
     public static boolean isPublicSectorEmail(String email) {
         email = email.toLowerCase();
         String[] emailParts = email.split("@");

--- a/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
@@ -1,0 +1,73 @@
+package uk.gov.pay.adminusers.utils.email;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class EmailValidator {
+
+    /**
+     * {@link #PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERNS} is based on:<br>
+     * - <a href="https://en.wikipedia.org/wiki/.uk">en.wikipedia.org/wiki/.uk</a><br>
+     * - <a href="https://github.com/alphagov/notifications-admin/blob/9391181b2c7d077ea8fe0a72c718ab8f7fdbcd0c/app/config.py#L67">alphagov/notifications-admin</a><br>
+     */
+    private static final List<String> PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERNS;
+    static {
+        PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERNS = Collections.unmodifiableList(Arrays.asList(
+                "assembly\\.wales",
+                "cynulliad\\.cymru",
+                "gov\\.scot",
+                "gov\\.uk",
+                "gov\\.wales",
+                "hmcts\\.net",
+                "judiciary\\.uk",
+                "llyw\\.cymru",
+                "mil\\.uk",
+                "mod\\.uk",
+                "naturalengland\\.org\\.uk",
+                "nhs\\.net",
+                "nhs\\.uk",
+                "parliament\\.scot",
+                "parliament\\.uk",
+                "police\\.uk",
+                "scotent\\.co\\.uk",
+                "slc\\.co\\.uk",
+                "ucds\\.email"
+        ));
+    }
+    private static final Pattern PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERN;
+    static {
+        StringBuilder domainRegExPatternStringBuilder = new StringBuilder();
+        for (int i = 0, size = PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERNS.size(); i < size; i++) {
+            if (i != 0) {
+                domainRegExPatternStringBuilder.append("|");
+            }
+            domainRegExPatternStringBuilder.append(PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERNS.get(i));
+        }
+        String domainRegExPatternString = domainRegExPatternStringBuilder.toString();
+
+        // We are splitting the logic into two parts
+        // for domains and subdomains
+        String regExDomainsOnlyPart = "(" + domainRegExPatternString + ")"; // this is "OR" of all domains
+        // the subdomain part:
+        // - cannot start with "-"
+        // - can have any alphanumeric letter or -
+        // - cannot end with "-"
+        String regExSubdomainsPart = "(((?!-)[A-Za-z0-9-]+(?<!-)\\.)+(" + domainRegExPatternString + "))";
+        PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERN =
+                Pattern.compile("^" + regExDomainsOnlyPart +  "|" + regExSubdomainsPart + "$");
+    }
+
+    public static boolean isPublicSectorEmail(String email) {
+        email = email.toLowerCase();
+        String[] emailParts = email.split("@");
+        if ((emailParts.length != 2) || emailParts[0].isEmpty() || emailParts[1].isEmpty()) {
+            return false;
+        }
+        String domain = emailParts[1];
+
+        Matcher matcher = PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERN.matcher(domain);
+
+        return matcher.matches();
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/utils/email/EmailValidatorIsPublicSectorEmailTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/email/EmailValidatorIsPublicSectorEmailTest.java
@@ -1,0 +1,109 @@
+package uk.gov.pay.adminusers.utils.email;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(Parameterized.class)
+public class EmailValidatorIsPublicSectorEmailTest {
+
+    private String email;
+
+    private boolean testResult;
+
+    public EmailValidatorIsPublicSectorEmailTest(String email, boolean testResult) {
+        this.email = email;
+        this.testResult = testResult;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                // main validations
+                {"", false},
+                {"@", false},
+
+                // gov.uk validations
+                {".gov.uk", false},
+                {"..gov.uk", false},
+                {"gov.uk", false},
+                {"@gov.uk", false},
+                {"@@gov.uk", false},
+                {"invalid@gov.uk.", false},
+                {"invalid@-gov.uk", false},
+                {"invalid@-subdomain.gov.uk", false},
+                {"invalid@a+gov.uk", false},
+                {"@gov.sub1.uk", false},
+                {"valid@sub2.sub1.gov.uk", true},
+                {"valid@sub2-2.sub2-1.sub1.gov.uk", true},
+
+                // naturalengland.org.uk validations
+                {".naturalengland.org.uk", false},
+                {"..naturalengland.org.uk", false},
+                {"naturalengland.org.uk", false},
+                {"@naturalengland.org.uk", false},
+                {"@@naturalengland.org.uk", false},
+                {"invalid@naturalengland.org.uk.", false},
+                {"invalid@-naturalengland.org.uk", false},
+                {"invalid@-subdomain.naturalengland.org.uk", false},
+                {"invalid@a+naturalengland.org.uk", false},
+                {"@naturalengland.org.sub1.uk", false},
+                {"valid@sub2.sub1.naturalengland.org.uk", true},
+                {"valid@sub2-2.sub2-1.sub1.naturalengland.org.uk", true},
+
+                // all valid emails with domains
+                {"valid@assembly.wales", true},
+                {"valid@cynulliad.cymru", true},
+                {"valid@gov.scot", true},
+                {"valid@gov.uk", true},
+                {"valid@gov.wales", true},
+                {"valid@hmcts.net", true},
+                {"valid@judiciary.uk", true},
+                {"valid@llyw.cymru", true},
+                {"valid@mil.uk", true},
+                {"valid@mod.uk", true},
+                {"valid@naturalengland.org.uk", true},
+                {"valid@nhs.net", true},
+                {"valid@nhs.uk", true},
+                {"valid@parliament.scot", true},
+                {"valid@parliament.uk", true},
+                {"valid@police.uk", true},
+                {"valid@scotent.co.uk", true},
+                {"valid@slc.co.uk", true},
+                {"valid@ucds.email", true},
+
+                // all valid emails with subdomains
+                {"valid@subdomain.assembly.wales", true},
+                {"valid@subdomain.cynulliad.cymru", true},
+                {"valid@subdomain.gov.scot", true},
+                {"valid@subdomain.gov.uk", true},
+                {"valid@subdomain.gov.wales", true},
+                {"valid@subdomain.hmcts.net", true},
+                {"valid@subdomain.judiciary.uk", true},
+                {"valid@subdomain.llyw.cymru", true},
+                {"valid@subdomain.mil.uk", true},
+                {"valid@subdomain.mod.uk", true},
+                {"valid@subdomain.naturalengland.org.uk", true},
+                {"valid@subdomain.nhs.net", true},
+                {"valid@subdomain.nhs.uk", true},
+                {"valid@subdomain.parliament.scot", true},
+                {"valid@subdomain.parliament.uk", true},
+                {"valid@subdomain.police.uk", true},
+                {"valid@subdomain.scotent.co.uk", true},
+                {"valid@subdomain.slc.co.uk", true},
+                {"valid@subdomain.ucds.email", true}
+        });
+    }
+
+    @Test
+    public void isPublicSectorEmail_shouldEvaluateWhetherOrNotItIsPublicSectorEmail() {
+        boolean result = EmailValidator.isPublicSectorEmail(email);
+        assertThat("Expected " + email + " to be " + (testResult ? "valid" : "invalid"), result, is(testResult));
+    }
+}


### PR DESCRIPTION
## WHAT

EmailValidator initial implementation

## HOW

- Implemented isPublicSectorEmail() method which checks if the email belongs to UK public sector domain.
- Generic email validation is not implemented here (it is implemented in Self Service).

with @maxcbc