### PR TITLE
PP-2147 add new columns to support self creation of services

### DIFF
--- a/src/main/resources/migrations/00024_alter_table_invites_add_column_type.sql
+++ b/src/main/resources/migrations/00024_alter_table_invites_add_column_type.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter-table-invites-add-column-type
+ALTER TABLE invites ADD COLUMN type VARCHAR(255) NOT NULL DEFAULT 'user';
+
+--rollback alter table invites drop column type;

--- a/src/main/resources/migrations/00025_alter_table_services_add_column_external_id.sql
+++ b/src/main/resources/migrations/00025_alter_table_services_add_column_external_id.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter-table-service-add-column-external_id
+ALTER TABLE services ADD COLUMN external_id VARCHAR(32) NOT NULL UNIQUE DEFAULT replace(uuid_generate_v4()::VARCHAR,'-','');
+
+--rollback alter table invites drop column external_id;


### PR DESCRIPTION
column type to invites table -> in order to support user and service invites
column external_id to services table. In order to not expose primary keys to public.

with @maxcbc