### PR TITLE
PP-2147 create service invite resource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,12 @@
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
             <version>1.6</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-collections</groupId>
+                    <artifactId>commons-collections</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- testing -->

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,11 @@
             <artifactId>notifications-java-client</artifactId>
             <version>3.1.2-RELEASE</version>
         </dependency>
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>1.6</version>
+        </dependency>
 
         <!-- testing -->
         <dependency>

--- a/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersModule.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersModule.java
@@ -31,13 +31,13 @@ public class AdminUsersModule extends AbstractModule {
         bind(AdminUsersConfig.class).toInstance(configuration);
         bind(Environment.class).toInstance(environment);
         bind(LinksBuilder.class).toInstance(new LinksBuilder(configuration.getBaseUrl()));
+        bind(LinksConfig.class).toInstance(configuration.getLinks());
 
         bind(PasswordHasher.class).in(Singleton.class);
         bind(RequestValidations.class).in(Singleton.class);
         bind(UserRequestValidator.class).in(Singleton.class);
         bind(ResetPasswordValidator.class).in(Singleton.class);
         bind(Integer.class).annotatedWith(Names.named("LOGIN_ATTEMPT_CAP")).toInstance(configuration.getLoginAttemptCap());
-        bind(String.class).annotatedWith(Names.named("SELFSERVICE_BASE_URL")).toInstance(configuration.getLinks().getSelfserviceUrl());
         bind(SecondFactorAuthenticator.class).in(Singleton.class);
         bind(UserServices.class).in(Singleton.class);
         bind(ForgottenPasswordServices.class).in(Singleton.class);

--- a/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersModule.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersModule.java
@@ -37,6 +37,7 @@ public class AdminUsersModule extends AbstractModule {
         bind(UserRequestValidator.class).in(Singleton.class);
         bind(ResetPasswordValidator.class).in(Singleton.class);
         bind(Integer.class).annotatedWith(Names.named("LOGIN_ATTEMPT_CAP")).toInstance(configuration.getLoginAttemptCap());
+        bind(String.class).annotatedWith(Names.named("SELFSERVICE_BASE_URL")).toInstance(configuration.getLinks().getSelfserviceUrl());
         bind(SecondFactorAuthenticator.class).in(Singleton.class);
         bind(UserServices.class).in(Singleton.class);
         bind(ForgottenPasswordServices.class).in(Singleton.class);
@@ -47,6 +48,8 @@ public class AdminUsersModule extends AbstractModule {
         install(jpaModule(configuration));
         install(new FactoryModuleBuilder().build(UserServicesFactory.class));
         install(new FactoryModuleBuilder().build(ServiceServicesFactory.class));
+        install(new FactoryModuleBuilder().build(InviteServiceFactory.class));
+
     }
 
     private JpaPersistModule jpaModule(AdminUsersConfig configuration) {

--- a/src/main/java/uk/gov/pay/adminusers/app/config/LinksConfig.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/LinksConfig.java
@@ -5,8 +5,13 @@ import io.dropwizard.Configuration;
 public class LinksConfig extends Configuration {
 
     private String selfserviceUrl;
+    private String frontendUrl;
 
     public String getSelfserviceUrl() {
         return selfserviceUrl;
+    }
+
+    public String getFrontendUrl() {
+        return frontendUrl;
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/app/config/LinksConfig.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/LinksConfig.java
@@ -5,13 +5,28 @@ import io.dropwizard.Configuration;
 public class LinksConfig extends Configuration {
 
     private String selfserviceUrl;
-    private String frontendUrl;
+    private String selfserviceInvitesUrl;
+    private String selfserviceLoginUrl;
+    private String selfserviceForgottenPasswordUrl;
+    private String supportUrl;
 
     public String getSelfserviceUrl() {
         return selfserviceUrl;
     }
 
-    public String getFrontendUrl() {
-        return frontendUrl;
+    public String getSelfserviceInvitesUrl() {
+        return selfserviceInvitesUrl;
+    }
+
+    public String getSelfserviceLoginUrl() {
+        return selfserviceLoginUrl;
+    }
+
+    public String getSelfserviceForgottenPasswordUrl() {
+        return selfserviceForgottenPasswordUrl;
+    }
+
+    public String getSupportUrl() {
+        return supportUrl;
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/app/config/NotifyConfiguration.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/NotifyConfiguration.java
@@ -25,6 +25,10 @@ public class NotifyConfiguration extends Configuration {
 
     @Valid
     @NotNull
+    private String createServiceInvitationEmailTemplateId;
+
+    @Valid
+    @NotNull
     private String forgottenPasswordEmailTemplateId;
 
     public String getApiKey() {
@@ -45,5 +49,9 @@ public class NotifyConfiguration extends Configuration {
 
     public String getForgottenPasswordEmailTemplateId() {
         return forgottenPasswordEmailTemplateId;
+    }
+
+    public String getCreateServiceInvitationEmailTemplateId() {
+        return createServiceInvitationEmailTemplateId;
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/app/config/NotifyConfiguration.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/NotifyConfiguration.java
@@ -21,11 +21,11 @@ public class NotifyConfiguration extends Configuration {
 
     @Valid
     @NotNull
-    private String inviteEmailTemplateId;
+    private String inviteUserEmailTemplateId;
 
     @Valid
     @NotNull
-    private String createServiceInvitationEmailTemplateId;
+    private String inviteServiceEmailTemplateId;
 
     @Valid
     @NotNull
@@ -33,7 +33,7 @@ public class NotifyConfiguration extends Configuration {
 
     @Valid
     @NotNull
-    private String createServiceInvitationUserExistsEmailTemplateId;
+    private String inviteServiceUserExistsEmailTemplateId;
 
     public String getApiKey() {
         return apiKey;
@@ -47,19 +47,19 @@ public class NotifyConfiguration extends Configuration {
         return secondFactorSmsTemplateId;
     }
 
-    public String getInviteEmailTemplateId() {
-        return inviteEmailTemplateId;
+    public String getInviteUserEmailTemplateId() {
+        return inviteUserEmailTemplateId;
     }
 
     public String getForgottenPasswordEmailTemplateId() {
         return forgottenPasswordEmailTemplateId;
     }
 
-    public String getCreateServiceInvitationEmailTemplateId() {
-        return createServiceInvitationEmailTemplateId;
+    public String getInviteServiceEmailTemplateId() {
+        return inviteServiceEmailTemplateId;
     }
 
-    public String getCreateServiceInvitationUserExistsEmailTemplateId() {
-        return createServiceInvitationUserExistsEmailTemplateId;
+    public String getInviteServiceUserExistsEmailTemplateId() {
+        return inviteServiceUserExistsEmailTemplateId;
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/app/config/NotifyConfiguration.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/NotifyConfiguration.java
@@ -31,6 +31,10 @@ public class NotifyConfiguration extends Configuration {
     @NotNull
     private String forgottenPasswordEmailTemplateId;
 
+    @Valid
+    @NotNull
+    private String createServiceInvitationUserExistsEmailTemplateId;
+
     public String getApiKey() {
         return apiKey;
     }
@@ -53,5 +57,9 @@ public class NotifyConfiguration extends Configuration {
 
     public String getCreateServiceInvitationEmailTemplateId() {
         return createServiceInvitationEmailTemplateId;
+    }
+
+    public String getCreateServiceInvitationUserExistsEmailTemplateId() {
+        return createServiceInvitationUserExistsEmailTemplateId;
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/model/Invite.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Invite.java
@@ -20,17 +20,19 @@ public class Invite {
     private Integer loginCounter = 0;
 
     private List<Link> links = new ArrayList<>();
+    private String type;
 
     public Invite(String email) {
         this.email = email;
     }
 
     public Invite(String email, String telephoneNumber,
-                  Boolean disabled, Integer loginCounter) {
+                  Boolean disabled, Integer loginCounter, String type) {
         this.email = email;
         this.telephoneNumber = telephoneNumber;
         this.disabled = disabled;
         this.loginCounter = loginCounter;
+        this.type = type;
     }
 
     @JsonProperty("email")
@@ -61,5 +63,13 @@ public class Invite {
     public void setInviteLink(String targetUrl) {
         Link inviteLink = Link.from(Link.Rel.invite, "GET", targetUrl);
         this.links = ImmutableList.of(inviteLink);
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/model/Invite.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Invite.java
@@ -61,7 +61,7 @@ public class Invite {
 
     public void setInviteLink(String targetUrl) {
         Link inviteLink = Link.from(Link.Rel.invite, "GET", targetUrl);
-        this.links = ImmutableList.of(inviteLink);
+        this.links.add(inviteLink);
     }
 
     public String getType() {

--- a/src/main/java/uk/gov/pay/adminusers/model/Invite.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Invite.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.adminusers.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -14,6 +15,7 @@ import java.util.List;
 @JsonInclude(Include.NON_NULL)
 public class Invite {
 
+    private String code;
     private final String email;
     private String telephoneNumber;
     private Boolean disabled = Boolean.FALSE;
@@ -22,12 +24,9 @@ public class Invite {
     private List<Link> links = new ArrayList<>();
     private String type;
 
-    public Invite(String email) {
-        this.email = email;
-    }
-
-    public Invite(String email, String telephoneNumber,
+    public Invite(String code, String email, String telephoneNumber,
                   Boolean disabled, Integer loginCounter, String type) {
+        this.code = code;
         this.email = email;
         this.telephoneNumber = telephoneNumber;
         this.disabled = disabled;
@@ -71,5 +70,14 @@ public class Invite {
 
     public void setType(String type) {
         this.type = type;
+    }
+
+    @JsonIgnore
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/model/Invite.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Invite.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,18 +18,18 @@ public class Invite {
     private final String email;
     private String telephoneNumber;
     private Boolean disabled = Boolean.FALSE;
-    private Integer loginCounter = 0;
+    private Integer attemptCounter = 0;
 
     private List<Link> links = new ArrayList<>();
     private String type;
 
     public Invite(String code, String email, String telephoneNumber,
-                  Boolean disabled, Integer loginCounter, String type) {
+                  Boolean disabled, Integer attemptCounter, String type) {
         this.code = code;
         this.email = email;
         this.telephoneNumber = telephoneNumber;
         this.disabled = disabled;
-        this.loginCounter = loginCounter;
+        this.attemptCounter = attemptCounter;
         this.type = type;
     }
 
@@ -49,9 +48,9 @@ public class Invite {
         return disabled;
     }
 
-    @JsonProperty("login_counter")
-    public Integer getLoginCounter() {
-        return loginCounter;
+    @JsonProperty("attempt_counter")
+    public Integer getAttemptCounter() {
+        return attemptCounter;
     }
 
     @JsonProperty("_links")

--- a/src/main/java/uk/gov/pay/adminusers/model/InviteRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/InviteRequest.java
@@ -5,31 +5,20 @@ import com.fasterxml.jackson.databind.JsonNode;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 
-public class InviteRequest {
+public abstract class InviteRequest {
 
-    public static final String FIELD_SENDER = "sender";
     public static final String FIELD_EMAIL = "email";
     public static final String FIELD_ROLE_NAME = "role_name";
     public static final String FIELD_OTP_KEY = "otp_key";
 
-    private final String sender;
-    private final String email;
-    private final String roleName;
-    private final String otpKey;
+    protected final String roleName;
+    protected final String email;
+    protected final String otpKey;
 
-    private InviteRequest(String sender, String email, String roleName, String otpKey) {
-        this.sender = sender;
-        this.email = email;
+    public InviteRequest(String roleName, String email, String otpKey) {
         this.roleName = roleName;
+        this.email = email;
         this.otpKey = otpKey;
-    }
-
-    public static InviteRequest from(JsonNode jsonNode) {
-        return new InviteRequest(jsonNode.get(FIELD_SENDER).asText(), jsonNode.get(FIELD_EMAIL).asText(), jsonNode.get(FIELD_ROLE_NAME).asText(), getOrElseRandom(jsonNode.get(FIELD_OTP_KEY)));
-    }
-
-    public String getSender() {
-        return sender;
     }
 
     public String getEmail() {
@@ -44,7 +33,7 @@ public class InviteRequest {
         return otpKey;
     }
 
-    private static String getOrElseRandom(JsonNode elementNode) {
+    protected static String getOrElseRandom(JsonNode elementNode) {
         return elementNode == null || isBlank(elementNode.asText()) ? randomUuid() : elementNode.asText();
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/model/InviteServiceRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/InviteServiceRequest.java
@@ -1,0 +1,59 @@
+package uk.gov.pay.adminusers.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
+
+public class InviteServiceRequest extends InviteRequest {
+    public static final String FIELD_PASSWORD = "password";
+    public static final String FIELD_TELEPHONE_NUMBER = "telephone_number";
+    private static final String DEFAULT_ROLE_NAME = "admin";
+
+    private String password;
+    private String telephoneNumber;
+
+    private InviteServiceRequest(String roleName,
+                                 String password,
+                                 String email,
+                                 String telephoneNumber,
+                                 String otpKey) {
+        super(roleName, email, otpKey);
+        this.password = password;
+        this.telephoneNumber = telephoneNumber;
+    }
+
+    public InviteServiceRequest(
+            String password,
+            String email,
+            String telephoneNumber) {
+        this(DEFAULT_ROLE_NAME, password, email, telephoneNumber, randomUuid());
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getTelephoneNumber() {
+        return telephoneNumber;
+    }
+
+    public void setTelephoneNumber(String telephoneNumber) {
+        this.telephoneNumber = telephoneNumber;
+    }
+
+
+    public static InviteServiceRequest from(JsonNode payload) {
+        return new InviteServiceRequest(
+                DEFAULT_ROLE_NAME,
+                payload.get(FIELD_PASSWORD).asText(),
+                payload.get(FIELD_EMAIL).asText(),
+                payload.get(FIELD_TELEPHONE_NUMBER).asText(),
+                getOrElseRandom(payload.get(FIELD_OTP_KEY))
+        );
+    }
+
+}

--- a/src/main/java/uk/gov/pay/adminusers/model/InviteType.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/InviteType.java
@@ -1,0 +1,28 @@
+package uk.gov.pay.adminusers.model;
+
+import static java.lang.String.format;
+
+public enum InviteType {
+
+    USER("user"), SERVICE("service");
+
+    private String type;
+
+    InviteType(String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public static InviteType from(String inviteType) {
+        if (USER.type.equals(inviteType)) {
+            return USER;
+        } else if (SERVICE.type.equals(inviteType)) {
+            return SERVICE;
+        } else {
+            throw new RuntimeException(format("invalid invite type: [%s]", inviteType));
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/model/InviteUserRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/InviteUserRequest.java
@@ -1,0 +1,27 @@
+package uk.gov.pay.adminusers.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
+
+public class InviteUserRequest extends InviteRequest {
+
+    public static final String FIELD_SENDER = "sender";
+
+    private final String sender;
+
+    private InviteUserRequest(String sender, String email, String roleName, String otpKey) {
+        super(roleName, email, otpKey);
+        this.sender = sender;
+    }
+
+    public static InviteUserRequest from(JsonNode jsonNode) {
+        return new InviteUserRequest(jsonNode.get(FIELD_SENDER).asText(), jsonNode.get(FIELD_EMAIL).asText(), jsonNode.get(FIELD_ROLE_NAME).asText(), getOrElseRandom(jsonNode.get(FIELD_OTP_KEY)));
+    }
+
+    public String getSender() {
+        return sender;
+    }
+
+}

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
@@ -2,6 +2,7 @@ package uk.gov.pay.adminusers.persistence.entity;
 
 import uk.gov.pay.adminusers.app.util.RandomIdGenerator;
 import uk.gov.pay.adminusers.model.Invite;
+import uk.gov.pay.adminusers.model.InviteType;
 
 import javax.persistence.*;
 import java.time.ZoneId;
@@ -9,6 +10,7 @@ import java.time.ZonedDateTime;
 
 import static java.time.ZonedDateTime.now;
 import static java.time.temporal.ChronoUnit.DAYS;
+import static uk.gov.pay.adminusers.model.InviteType.USER;
 import static uk.gov.pay.adminusers.persistence.entity.UTCDateTimeConverter.UTC;
 
 @Entity
@@ -57,6 +59,9 @@ public class InviteEntity extends AbstractEntity {
 
     @Column(name = "login_counter")
     private Integer loginCounter = 0;
+
+    @Column(name = "type")
+    private String type = USER.getType();
 
     public InviteEntity() {
         //for jpa
@@ -187,14 +192,22 @@ public class InviteEntity extends AbstractEntity {
         this.loginCounter = loginCount;
     }
 
+    public String getType() {
+        return type;
+    }
+
+    public void setType(InviteType type) {
+        this.type = type.getType();
+    }
+
     public Invite toInvite(String inviteUrl) {
-        Invite invite = new Invite(email);
+        Invite invite = toInvite();
         invite.setInviteLink(inviteUrl);
         return invite;
     }
 
     public Invite toInvite() {
-        return new Invite(email, telephoneNumber, disabled, loginCounter);
+        return new Invite(email, telephoneNumber, disabled, loginCounter, type);
     }
 
     public boolean isExpired() {

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
@@ -207,7 +207,7 @@ public class InviteEntity extends AbstractEntity {
     }
 
     public Invite toInvite() {
-        return new Invite(email, telephoneNumber, disabled, loginCounter, type);
+        return new Invite(code, email, telephoneNumber, disabled, loginCounter, type);
     }
 
     public boolean isExpired() {

--- a/src/main/java/uk/gov/pay/adminusers/resources/InviteRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InviteRequestValidator.java
@@ -2,21 +2,28 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.inject.Inject;
+import org.apache.commons.lang3.StringUtils;
+import uk.gov.pay.adminusers.model.InviteServiceRequest;
 import uk.gov.pay.adminusers.model.InviteValidateOtpRequest;
+import uk.gov.pay.adminusers.service.AdminUsersExceptions;
 import uk.gov.pay.adminusers.utils.Errors;
 import uk.gov.pay.adminusers.validations.RequestValidations;
 
 import java.util.List;
 import java.util.Optional;
 
+import static java.lang.String.format;
 import static uk.gov.pay.adminusers.model.InviteOtpRequest.*;
-import static uk.gov.pay.adminusers.model.InviteRequest.*;
+import static uk.gov.pay.adminusers.model.InviteUserRequest.*;
 import static uk.gov.pay.adminusers.model.InviteValidateOtpRequest.FIELD_OTP;
+import static uk.gov.pay.adminusers.utils.email.EmailValidator.isPublicSectorEmail;
+import static uk.gov.pay.adminusers.utils.email.EmailValidator.isValid;
 
 public class InviteRequestValidator {
 
     private static final int MAX_LENGTH_CODE = 255;
     private final RequestValidations requestValidations;
+
 
     @Inject
     public InviteRequestValidator(RequestValidations requestValidations) {
@@ -53,5 +60,28 @@ public class InviteRequestValidator {
         }
         Optional<List<String>> invalidLength = requestValidations.checkMaxLength(payload, MAX_LENGTH_CODE, InviteValidateOtpRequest.FIELD_CODE);
         return invalidLength.map(Errors::from);
+    }
+
+    public Optional<Errors> validateCreateServiceRequest(JsonNode payload) {
+        Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExists(payload, InviteServiceRequest.FIELD_EMAIL, InviteServiceRequest.FIELD_TELEPHONE_NUMBER, InviteServiceRequest.FIELD_PASSWORD);
+        if (missingMandatoryFields.isPresent()) {
+            return Optional.of(Errors.from(missingMandatoryFields.get()));
+        }
+
+
+        String email = payload.get(InviteServiceRequest.FIELD_EMAIL).asText();
+        if(!isValid(email)) {
+            return Optional.of(Errors.from(format("Field [%s] must be a valid email address", InviteServiceRequest.FIELD_EMAIL)));
+        } else if (!isPublicSectorEmail(email)) {
+            throw AdminUsersExceptions.invalidPublicSectorEmail(email);
+        }
+
+        String telephoneNumber = payload.get(InviteServiceRequest.FIELD_TELEPHONE_NUMBER).asText();
+        if (telephoneNumber.length() < 11 || !StringUtils.isNumeric(telephoneNumber)) {
+            return Optional.of(Errors.from(format("Field [%s] must be a valid telephone number", InviteServiceRequest.FIELD_TELEPHONE_NUMBER)));
+        }
+
+        return Optional.empty();
+
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
@@ -16,8 +16,11 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.*;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-@Path("/v1/api/invites")
+@Path(InviteResource.INVITES_RESOURCE)
 public class InviteResource {
+
+    public static final String INVITES_RESOURCE = "/v1/api/invites";
+    public static final String INVITE_RESOURCE = INVITES_RESOURCE + "/{code}";
 
     private static final Logger LOGGER = PayLoggerFactory.getLogger(InviteResource.class);
     private static final int MAX_LENGTH_CODE = 255;
@@ -34,7 +37,7 @@ public class InviteResource {
     }
 
     @GET
-    @Path("/{code}")
+    @Path(INVITE_RESOURCE)
     @Produces(APPLICATION_JSON)
     public Response getInvite(@PathParam("code") String code) {
 

--- a/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
@@ -20,7 +20,6 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 public class InviteResource {
 
     public static final String INVITES_RESOURCE = "/v1/api/invites";
-    public static final String INVITE_RESOURCE = INVITES_RESOURCE + "/{code}";
 
     private static final Logger LOGGER = PayLoggerFactory.getLogger(InviteResource.class);
     private static final int MAX_LENGTH_CODE = 255;
@@ -37,7 +36,7 @@ public class InviteResource {
     }
 
     @GET
-    @Path(INVITE_RESOURCE)
+    @Path("/{code}")
     @Produces(APPLICATION_JSON)
     public Response getInvite(@PathParam("code") String code) {
 

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
@@ -5,7 +5,7 @@ import com.google.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import uk.gov.pay.adminusers.logger.PayLoggerFactory;
-import uk.gov.pay.adminusers.model.InviteRequest;
+import uk.gov.pay.adminusers.model.InviteUserRequest;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
@@ -117,7 +117,7 @@ public class ServiceResource {
 
         return inviteValidator.validateCreateRequest(payload)
                 .map(errors -> Response.status(BAD_REQUEST).entity(errors).build())
-                .orElseGet(() -> inviteService.create(InviteRequest.from(payload), serviceId)
+                .orElseGet(() -> inviteService.create(InviteUserRequest.from(payload), serviceId)
                         .map(invite -> Response.status(CREATED).entity(invite).build())
                         .orElseGet(() -> Response.status(NOT_FOUND).build()));
     }

--- a/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
@@ -103,4 +103,9 @@ public class AdminUsersExceptions {
                 .build();
         return new WebApplicationException(response);
     }
+
+    public static WebApplicationException invalidPublicSectorEmail(String email) {
+        String error = format("Email [%s] is not a valid public sector email", email);
+        return buildWebApplicationException(error, FORBIDDEN.getStatusCode());
+    }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteCreator.java
@@ -1,18 +1,19 @@
 package uk.gov.pay.adminusers.service;
 
-import com.google.inject.name.Named;
 import com.google.inject.persist.Transactional;
 import org.slf4j.Logger;
+import uk.gov.pay.adminusers.app.config.LinksConfig;
 import uk.gov.pay.adminusers.logger.PayLoggerFactory;
 import uk.gov.pay.adminusers.model.Invite;
 import uk.gov.pay.adminusers.model.InviteServiceRequest;
-import uk.gov.pay.adminusers.model.InviteType;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.dao.RoleDao;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
+import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 
 import javax.inject.Inject;
+import javax.ws.rs.core.UriBuilder;
 import java.util.Optional;
 
 import static java.lang.String.format;
@@ -25,53 +26,76 @@ public class InviteCreator {
 
     private static final Logger LOGGER = PayLoggerFactory.getLogger(InviteCreator.class);
     private static final String SELFSERVICE_INVITES_PATH = "invites";
+    private static final String SELFSERVICE_LOGIN_PATH = "login";
+    private static final String SELFSERVICE_FORGOTTEN_PASSWORD_PATH = "reset-password";
+    private static final String FEEDBACK_PATH = "support.html";
 
     private final InviteDao inviteDao;
     private final UserDao userDao;
     private RoleDao roleDao;
     private final LinksBuilder linksBuilder;
-    private String selfserviceBaseUrl;
+    private LinksConfig linksConfig;
     private final NotificationService notificationService;
 
     @Inject
-    public InviteCreator(InviteDao inviteDao, UserDao userDao, RoleDao roleDao,LinksBuilder linksBuilder,
-                         @Named("SELFSERVICE_BASE_URL") String selfserviceBaseUrl, NotificationService notificationService) {
+    public InviteCreator(InviteDao inviteDao, UserDao userDao, RoleDao roleDao, LinksBuilder linksBuilder,
+                         LinksConfig linksConfig, NotificationService notificationService) {
         this.inviteDao = inviteDao;
         this.userDao = userDao;
         this.roleDao = roleDao;
         this.linksBuilder = linksBuilder;
-        this.selfserviceBaseUrl = selfserviceBaseUrl;
+        this.linksConfig = linksConfig;
         this.notificationService = notificationService;
     }
 
     @Transactional
     public Invite doCreate(InviteServiceRequest inviteServiceRequest) {
-        if (userDao.findByEmail(inviteServiceRequest.getEmail()).isPresent()) {
-            throw conflictingEmail(inviteServiceRequest.getEmail());
+        String requestEmail = inviteServiceRequest.getEmail();
+        Optional<UserEntity> anExistingUser = userDao.findByEmail(requestEmail);
+        if (anExistingUser.isPresent()) {
+            UserEntity user = anExistingUser.get();
+            if (!user.isDisabled()) {
+                sendUserExitsNotification(requestEmail, user.getExternalId());
+            } else {
+                //TODO: what should we do here: Discuss with stephen m ??
+            }
+            throw conflictingEmail(requestEmail);
         }
 
-        Optional<InviteEntity> inviteOptional = inviteDao.findByEmail(inviteServiceRequest.getEmail());
+        Optional<InviteEntity> inviteOptional = inviteDao.findByEmail(requestEmail);
         if (inviteOptional.isPresent()) {
-            // When multiple services support is implemented
-            // then this should include serviceId
             InviteEntity foundInvite = inviteOptional.get();
             if (!foundInvite.isExpired() && !foundInvite.isDisabled()) {
-                throw conflictingInvite(inviteServiceRequest.getEmail());
+                //TODO: what should we do here: Discuss with stephen m ??
+                throw conflictingInvite(requestEmail);
             }
         }
 
         return roleDao.findByRoleName(inviteServiceRequest.getRoleName())
                 .map(roleEntity -> {
-                    InviteEntity inviteEntity = new InviteEntity(inviteServiceRequest.getEmail(), randomUuid(), inviteServiceRequest.getOtpKey(), null, null, roleEntity);
+                    InviteEntity inviteEntity = new InviteEntity(requestEmail, randomUuid(), inviteServiceRequest.getOtpKey(), null, null, roleEntity);
                     inviteEntity.setTelephoneNumber(inviteServiceRequest.getTelephoneNumber());
                     inviteEntity.setType(SERVICE);
                     inviteDao.persist(inviteEntity);
-                    String inviteUrl = fromUri(selfserviceBaseUrl).path(SELFSERVICE_INVITES_PATH).path(inviteEntity.getCode()).build().toString();
+                    String inviteUrl = toUri(linksConfig.getSelfserviceUrl(), SELFSERVICE_INVITES_PATH, inviteEntity.getCode());
                     sendInviteNotification(inviteEntity, inviteUrl);
-                    return inviteEntity.toInvite(inviteUrl);
+                    return linksBuilder.decorate(inviteEntity.toInvite(inviteUrl));
                 })
-                .orElseThrow(()-> internalServerError(format("Role [%s] not a valid role for creating a invite service request",inviteServiceRequest.getRoleName())));
+                .orElseThrow(() -> internalServerError(format("Role [%s] not a valid role for creating a invite service request", inviteServiceRequest.getRoleName())));
 
+    }
+
+    private void sendUserExitsNotification(String email, String userExternalId) {
+        String signInLink = toUri(linksConfig.getSelfserviceUrl(), SELFSERVICE_LOGIN_PATH);
+        String forgottenPasswordLink = toUri(linksConfig.getSelfserviceUrl(), SELFSERVICE_FORGOTTEN_PASSWORD_PATH);
+        String feedbackLink = toUri(linksConfig.getFrontendUrl(), FEEDBACK_PATH);
+        notificationService.sendServiceInviteUserExistsEmail(email, signInLink, forgottenPasswordLink, feedbackLink)
+                .thenAcceptAsync(notificationId -> LOGGER.info("sent create service, user exists email successfully, notification id [{}]", notificationId))
+                .exceptionally(exception -> {
+                    LOGGER.error("error sending service creation, users exists email", exception);
+                    return null;
+                });
+        LOGGER.info("Existing user tried to create a service - user_id={}", userExternalId);
     }
 
     private void sendInviteNotification(InviteEntity invite, String targetUrl) {
@@ -82,5 +106,13 @@ public class InviteCreator {
                     return null;
                 });
         LOGGER.info("New service creation invitation created");
+    }
+
+    private String toUri(String baseUrl, String... pathParams) {
+        UriBuilder uriBuilder = fromUri(baseUrl);
+        for (String pathParam : pathParams) {
+            uriBuilder.path(pathParam);
+        }
+        return uriBuilder.build().toString();
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteCreator.java
@@ -1,0 +1,86 @@
+package uk.gov.pay.adminusers.service;
+
+import com.google.inject.name.Named;
+import com.google.inject.persist.Transactional;
+import org.slf4j.Logger;
+import uk.gov.pay.adminusers.logger.PayLoggerFactory;
+import uk.gov.pay.adminusers.model.Invite;
+import uk.gov.pay.adminusers.model.InviteServiceRequest;
+import uk.gov.pay.adminusers.model.InviteType;
+import uk.gov.pay.adminusers.persistence.dao.InviteDao;
+import uk.gov.pay.adminusers.persistence.dao.RoleDao;
+import uk.gov.pay.adminusers.persistence.dao.UserDao;
+import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
+
+import javax.inject.Inject;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static javax.ws.rs.core.UriBuilder.fromUri;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
+import static uk.gov.pay.adminusers.model.InviteType.SERVICE;
+import static uk.gov.pay.adminusers.service.AdminUsersExceptions.*;
+
+public class InviteCreator {
+
+    private static final Logger LOGGER = PayLoggerFactory.getLogger(InviteCreator.class);
+    private static final String SELFSERVICE_INVITES_PATH = "invites";
+
+    private final InviteDao inviteDao;
+    private final UserDao userDao;
+    private RoleDao roleDao;
+    private final LinksBuilder linksBuilder;
+    private String selfserviceBaseUrl;
+    private final NotificationService notificationService;
+
+    @Inject
+    public InviteCreator(InviteDao inviteDao, UserDao userDao, RoleDao roleDao,LinksBuilder linksBuilder,
+                         @Named("SELFSERVICE_BASE_URL") String selfserviceBaseUrl, NotificationService notificationService) {
+        this.inviteDao = inviteDao;
+        this.userDao = userDao;
+        this.roleDao = roleDao;
+        this.linksBuilder = linksBuilder;
+        this.selfserviceBaseUrl = selfserviceBaseUrl;
+        this.notificationService = notificationService;
+    }
+
+    @Transactional
+    public Invite doCreate(InviteServiceRequest inviteServiceRequest) {
+        if (userDao.findByEmail(inviteServiceRequest.getEmail()).isPresent()) {
+            throw conflictingEmail(inviteServiceRequest.getEmail());
+        }
+
+        Optional<InviteEntity> inviteOptional = inviteDao.findByEmail(inviteServiceRequest.getEmail());
+        if (inviteOptional.isPresent()) {
+            // When multiple services support is implemented
+            // then this should include serviceId
+            InviteEntity foundInvite = inviteOptional.get();
+            if (!foundInvite.isExpired() && !foundInvite.isDisabled()) {
+                throw conflictingInvite(inviteServiceRequest.getEmail());
+            }
+        }
+
+        return roleDao.findByRoleName(inviteServiceRequest.getRoleName())
+                .map(roleEntity -> {
+                    InviteEntity inviteEntity = new InviteEntity(inviteServiceRequest.getEmail(), randomUuid(), inviteServiceRequest.getOtpKey(), null, null, roleEntity);
+                    inviteEntity.setTelephoneNumber(inviteServiceRequest.getTelephoneNumber());
+                    inviteEntity.setType(SERVICE);
+                    inviteDao.persist(inviteEntity);
+                    String inviteUrl = fromUri(selfserviceBaseUrl).path(SELFSERVICE_INVITES_PATH).path(inviteEntity.getCode()).build().toString();
+                    sendInviteNotification(inviteEntity, inviteUrl);
+                    return inviteEntity.toInvite(inviteUrl);
+                })
+                .orElseThrow(()-> internalServerError(format("Role [%s] not a valid role for creating a invite service request",inviteServiceRequest.getRoleName())));
+
+    }
+
+    private void sendInviteNotification(InviteEntity invite, String targetUrl) {
+        notificationService.sendServiceInviteEmail(invite.getEmail(), targetUrl)
+                .thenAcceptAsync(notificationId -> LOGGER.info("sent create service invitation email successfully, notification id [{}]", notificationId))
+                .exceptionally(exception -> {
+                    LOGGER.error("error sending create service invitation", exception);
+                    return null;
+                });
+        LOGGER.info("New service creation invitation created");
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteService.java
@@ -7,7 +7,7 @@ import uk.gov.pay.adminusers.app.config.AdminUsersConfig;
 import uk.gov.pay.adminusers.logger.PayLoggerFactory;
 import uk.gov.pay.adminusers.model.Invite;
 import uk.gov.pay.adminusers.model.InviteOtpRequest;
-import uk.gov.pay.adminusers.model.InviteRequest;
+import uk.gov.pay.adminusers.model.InviteUserRequest;
 import uk.gov.pay.adminusers.model.InviteValidateOtpRequest;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.dao.RoleDao;
@@ -71,7 +71,7 @@ public class InviteService {
     }
 
     @Transactional
-    public Optional<Invite> create(InviteRequest invite, int serviceId) {
+    public Optional<Invite> create(InviteUserRequest invite, int serviceId) {
 
         if (userDao.findByEmail(invite.getEmail()).isPresent()) {
             throw conflictingEmail(invite.getEmail());
@@ -94,7 +94,7 @@ public class InviteService {
                         .orElseThrow(() -> undefinedRoleException(invite.getRoleName())));
     }
 
-    private Function<RoleEntity, Optional<Invite>> doInvite(InviteRequest invite, ServiceEntity serviceEntity) {
+    private Function<RoleEntity, Optional<Invite>> doInvite(InviteUserRequest invite, ServiceEntity serviceEntity) {
         return role -> {
             Optional<UserEntity> userSender = userDao.findByExternalId(invite.getSender());
             if (userSender.isPresent() && userSender.get().canInviteUsersTo(serviceEntity.getId())) {

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteServiceFactory.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteServiceFactory.java
@@ -1,0 +1,7 @@
+package uk.gov.pay.adminusers.service;
+
+
+public interface InviteServiceFactory {
+
+    InviteCreator serviceInvite();
+}

--- a/src/main/java/uk/gov/pay/adminusers/service/LinksBuilder.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/LinksBuilder.java
@@ -1,16 +1,14 @@
 package uk.gov.pay.adminusers.service;
 
 import com.google.common.collect.ImmutableList;
-import uk.gov.pay.adminusers.model.ForgottenPassword;
-import uk.gov.pay.adminusers.model.Link;
+import uk.gov.pay.adminusers.model.*;
 import uk.gov.pay.adminusers.model.Link.Rel;
-import uk.gov.pay.adminusers.model.Service;
-import uk.gov.pay.adminusers.model.User;
 
 import java.net.URI;
 
 import static javax.ws.rs.core.UriBuilder.fromUri;
 import static uk.gov.pay.adminusers.resources.ForgottenPasswordResource.FORGOTTEN_PASSWORDS_RESOURCE;
+import static uk.gov.pay.adminusers.resources.InviteResource.INVITES_RESOURCE;
 import static uk.gov.pay.adminusers.resources.ServiceResource.SERVICES_RESOURCE;
 import static uk.gov.pay.adminusers.resources.UserResource.USERS_RESOURCE;
 
@@ -45,5 +43,13 @@ public class LinksBuilder {
         Link selfLink = Link.from(Rel.self, "GET", uri.toString());
         forgottenPassword.setLinks(ImmutableList.of(selfLink));
         return forgottenPassword;
+    }
+
+    public Invite decorate(Invite invite) {
+        URI uri = fromUri(baseUrl).path(INVITES_RESOURCE).path(invite.getCode())
+                .build();
+        Link selfLink = Link.from(Rel.self, "GET", uri.toString());
+        invite.getLinks().add(selfLink);
+        return invite;
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
@@ -20,6 +20,7 @@ public class NotificationService {
     private final ExecutorService executorService;
     private final NotifyClientProvider notifyClientProvider;
     private final MetricRegistry metricRegistry;
+    private final NotifyConfiguration notifyConfiguration;
 
     private final String secondFactorSmsTemplateId;
     private final String inviteEmailTemplateId;
@@ -29,6 +30,7 @@ public class NotificationService {
                                NotifyConfiguration notifyConfiguration,
                                MetricRegistry metricRegistry) {
         this.executorService = executorService;
+        this.notifyConfiguration = notifyConfiguration;
 
         this.notifyClientProvider = new NotifyClientProvider(notifyConfiguration, getSSLContext());
         this.secondFactorSmsTemplateId = notifyConfiguration.getSecondFactorSmsTemplateId();
@@ -61,6 +63,13 @@ public class NotificationService {
         personalisation.put("username", sender);
         personalisation.put("link", inviteUrl);
         return sendEmailAsync(inviteEmailTemplateId, email, personalisation);
+    }
+
+    CompletableFuture<String> sendServiceInviteEmail(String email, String inviteUrl) {
+        HashMap<String, String> personalisation = newHashMap();
+        personalisation.put("name", email);
+        personalisation.put("link", inviteUrl);
+        return sendEmailAsync(notifyConfiguration.getCreateServiceInvitationEmailTemplateId(), email, personalisation);
     }
 
     CompletableFuture<String> sendForgottenPasswordEmail(String email, String forgottenPasswordUrl) {

--- a/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
@@ -35,7 +35,7 @@ public class NotificationService {
 
         this.notifyClientProvider = new NotifyClientProvider(notifyConfiguration, getSSLContext());
         this.secondFactorSmsTemplateId = notifyConfiguration.getSecondFactorSmsTemplateId();
-        this.inviteEmailTemplateId = notifyConfiguration.getInviteEmailTemplateId();
+        this.inviteEmailTemplateId = notifyConfiguration.getInviteUserEmailTemplateId();
         this.forgottenPasswordEmailTemplateId = notifyConfiguration.getForgottenPasswordEmailTemplateId();
 
         this.metricRegistry = metricRegistry;
@@ -70,7 +70,7 @@ public class NotificationService {
         HashMap<String, String> personalisation = newHashMap();
         personalisation.put("name", email);
         personalisation.put("link", inviteUrl);
-        return sendEmailAsync(notifyConfiguration.getCreateServiceInvitationEmailTemplateId(), email, personalisation);
+        return sendEmailAsync(notifyConfiguration.getInviteServiceEmailTemplateId(), email, personalisation);
     }
 
     CompletableFuture<String> sendForgottenPasswordEmail(String email, String forgottenPasswordUrl) {
@@ -84,7 +84,7 @@ public class NotificationService {
         personalisation.put("signin_link", signInLink);
         personalisation.put("forgotten_password_link", forgottenPasswordLink);
         personalisation.put("feedback_link", feedbackLink);
-        return sendEmailAsync(notifyConfiguration.getCreateServiceInvitationUserExistsEmailTemplateId(), email, personalisation);
+        return sendEmailAsync(notifyConfiguration.getInviteServiceUserExistsEmailTemplateId(), email, personalisation);
     }
 
     private CompletableFuture<String> sendEmailAsync(final String templateId, final String email, final Map<String, String> personalisation) {

--- a/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
@@ -9,6 +9,7 @@ import uk.gov.service.notify.SendSmsResponse;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -76,6 +77,14 @@ public class NotificationService {
         HashMap<String, String> personalisation = newHashMap();
         personalisation.put("code", forgottenPasswordUrl);
         return sendEmailAsync(forgottenPasswordEmailTemplateId, email, personalisation);
+    }
+
+    CompletionStage<String> sendServiceInviteUserExistsEmail(String email, String signInLink, String forgottenPasswordLink, String feedbackLink) {
+        HashMap<String, String> personalisation = newHashMap();
+        personalisation.put("signin_link", signInLink);
+        personalisation.put("forgotten_password_link", forgottenPasswordLink);
+        personalisation.put("feedback_link", feedbackLink);
+        return sendEmailAsync(notifyConfiguration.getCreateServiceInvitationUserExistsEmailTemplateId(), email, personalisation);
     }
 
     private CompletableFuture<String> sendEmailAsync(final String templateId, final String email, final Map<String, String> personalisation) {

--- a/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
@@ -14,6 +14,7 @@ public class EmailValidator {
      * - <a href="https://github.com/alphagov/notifications-admin/blob/9391181b2c7d077ea8fe0a72c718ab8f7fdbcd0c/app/config.py#L67">alphagov/notifications-admin</a><br>
      */
     private static final List<String> PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERNS;
+    private static final org.apache.commons.validator.routines.EmailValidator commonsEmailValidator = org.apache.commons.validator.routines.EmailValidator.getInstance();
     static {
         PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERNS = Collections.unmodifiableList(Arrays.asList(
                 "assembly\\.wales",
@@ -46,6 +47,10 @@ public class EmailValidator {
         String regExSubdomainsPart = "(((?!-)[A-Za-z0-9-]+(?<!-)\\.)+(" + domainRegExPatternString + "))";
         PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERN =
                 Pattern.compile("^" + regExDomainsOnlyPart +  "|" + regExSubdomainsPart + "$");
+    }
+
+    public static final boolean isValid(String email) {
+        return commonsEmailValidator.isValid(email);
     }
 
     /**

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -74,8 +74,11 @@ graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}
 
 links:
-  selfserviceUrl: ${SELFSERVICE_URL}
-  frontendUrl: ${FRONTEND_URL}
+  selfserviceUrl: ${SELFSERVICE_URL:-https://selfservice.pymnt.localdomain}
+  selfserviceInvitesUrl: ${SELFSERVICE_INVITES_URL:-https://selfservice.pymnt.localdomain/invites}
+  selfserviceLoginUrl: ${SELFSERVICE_LOGIN_URL:-https://selfservice.pymnt.localdomain/login}
+  selfserviceForgottenPasswordUrl: ${SELFSERVICE_FORGOTTEN_PASSWORD_URL:-https://selfservice.pymnt.localdomain/reset-password}
+  supportUrl: ${SUPPORT_URL:-https://frontend.pymnt.localdomain/support.html}
 
 baseUrl: ${BASE_URL:-http://localhost:8080}
 loginAttemptCap: ${LOGIN_ATTEMPT_CAP:-10}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -63,10 +63,10 @@ notify:
   apiKey: ${NOTIFY_API_KEY:-api_key-pay-notify-service-id-pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs}
   notificationBaseURL: ${NOTIFY_BASE_URL:-https://stubs.pymnt.localdomain/notify}
   secondFactorSmsTemplateId: ${NOTIFY_2FA_TEMPLATE_ID:-pay-notify-two-factor-template-id}
-  inviteEmailTemplateId: ${NOTIFY_INVITE_EMAIL_TEMPLATE_ID:-pay-notify-invite-email-template-id}
-  createServiceInvitationEmailTemplateId: ${NOTIFY_INVITE_EMAIL_TEMPLATE_ID:-pay-notify-create-service-invitation-email-template-id}
+  inviteUserEmailTemplateId: ${NOTIFY_INVITE_USER_EMAIL_TEMPLATE_ID:-pay-notify-invite-user-email-template-id}
   forgottenPasswordEmailTemplateId: ${NOTIFY_FORGOTTEN_PASSWORD_EMAIL_TEMPLATE_ID:-pay-notify-forgotten-password-email-template-id}
-  createServiceInvitationUserExistsEmailTemplateId: ${NOTIFY_SERVICE_INVITE_USER_EXITS_EMAIL_TEMPLATE_ID:-pay-notify-create-service-invitation-user-exists-email-template-id}
+  inviteServiceEmailTemplateId: ${NOTIFY_INVITE_SERVICE_EMAIL_TEMPLATE_ID:-pay-notify-invite-service-email-template-id}
+  inviteServiceUserExistsEmailTemplateId: ${NOTIFY_INVITE_SERVICE_USER_EXITS_EMAIL_TEMPLATE_ID:-pay-notify-invite-service-user-exists-email-template-id}
 
 forgottenPasswordExpiryMinutes: ${FORGOTTEN_PASSWORD_EXPIRY_MINUTES:-90}
 

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -64,6 +64,7 @@ notify:
   notificationBaseURL: ${NOTIFY_BASE_URL:-https://stubs.pymnt.localdomain/notify}
   secondFactorSmsTemplateId: ${NOTIFY_2FA_TEMPLATE_ID:-pay-notify-two-factor-template-id}
   inviteEmailTemplateId: ${NOTIFY_INVITE_EMAIL_TEMPLATE_ID:-pay-notify-invite-email-template-id}
+  createServiceInvitationEmailTemplateId: ${NOTIFY_INVITE_EMAIL_TEMPLATE_ID:-pay-notify-create-service-invitation-email-template-id}
   forgottenPasswordEmailTemplateId: ${NOTIFY_FORGOTTEN_PASSWORD_EMAIL_TEMPLATE_ID:-pay-notify-forgotten-password-email-template-id}
 
 forgottenPasswordExpiryMinutes: ${FORGOTTEN_PASSWORD_EXPIRY_MINUTES:-90}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -66,6 +66,7 @@ notify:
   inviteEmailTemplateId: ${NOTIFY_INVITE_EMAIL_TEMPLATE_ID:-pay-notify-invite-email-template-id}
   createServiceInvitationEmailTemplateId: ${NOTIFY_INVITE_EMAIL_TEMPLATE_ID:-pay-notify-create-service-invitation-email-template-id}
   forgottenPasswordEmailTemplateId: ${NOTIFY_FORGOTTEN_PASSWORD_EMAIL_TEMPLATE_ID:-pay-notify-forgotten-password-email-template-id}
+  createServiceInvitationUserExistsEmailTemplateId: ${NOTIFY_SERVICE_INVITE_USER_EXITS_EMAIL_TEMPLATE_ID:-pay-notify-create-service-invitation-user-exists-email-template-id}
 
 forgottenPasswordExpiryMinutes: ${FORGOTTEN_PASSWORD_EXPIRY_MINUTES:-90}
 
@@ -74,6 +75,7 @@ graphitePort: ${METRICS_PORT:-8092}
 
 links:
   selfserviceUrl: ${SELFSERVICE_URL}
+  frontendUrl: ${FRONTEND_URL}
 
 baseUrl: ${BASE_URL:-http://localhost:8080}
 loginAttemptCap: ${LOGIN_ATTEMPT_CAP:-10}

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateServiceTest.java
@@ -35,7 +35,7 @@ public class InviteResourceCreateServiceTest extends IntegrationTest {
                 .statusCode(CREATED.getStatusCode())
                 .body("email", is(email.toLowerCase()))
                 .body("telephone_number", is(telephoneNumber))
-                .body("_links", hasSize(1))
+                .body("_links", hasSize(2))
                 .body("_links[0].href", matchesPattern("^http://selfservice/invites/[0-9a-z]{32}$"))
                 .body("_links[0].method", is("GET"))
                 .body("_links[0].rel", is("invite"));

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateServiceTest.java
@@ -36,7 +36,7 @@ public class InviteResourceCreateServiceTest extends IntegrationTest {
                 .body("email", is(email.toLowerCase()))
                 .body("telephone_number", is(telephoneNumber))
                 .body("_links", hasSize(2))
-                .body("_links[0].href", matchesPattern("^http://selfservice/invites/[0-9a-z]{32}$"))
+                .body("_links[0].href", matchesPattern("^https://selfservice.pymnt.localdomain/invites/[0-9a-z]{32}$"))
                 .body("_links[0].method", is("GET"))
                 .body("_links[0].rel", is("invite"));
     }

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateServiceTest.java
@@ -1,0 +1,97 @@
+package uk.gov.pay.adminusers.resources;
+
+
+import com.google.common.collect.ImmutableMap;
+import com.jayway.restassured.http.ContentType;
+import org.junit.Test;
+import uk.gov.pay.adminusers.model.Service;
+import uk.gov.pay.adminusers.model.User;
+
+import static java.util.Arrays.asList;
+import static javax.ws.rs.core.Response.Status.*;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.text.MatchesPattern.matchesPattern;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
+
+public class InviteResourceCreateServiceTest extends IntegrationTest {
+
+    public static final String SERVICE_INVITES_CREATE_URL = "/v1/api/invites/service";
+
+    @Test
+    public void shouldSuccess_WhenAllRequiredFieldsAreProvidedAndValid() throws Exception {
+        String email = "example@example.gov.uk";
+        String telephoneNumber = "088882345689";
+        ImmutableMap<String, String> payload = ImmutableMap.of("telephone_number", telephoneNumber, "email", email, "password", "plain_text_password");
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(payload))
+                .contentType(ContentType.JSON)
+                .post(SERVICE_INVITES_CREATE_URL)
+                .then()
+                .statusCode(CREATED.getStatusCode())
+                .body("email", is(email.toLowerCase()))
+                .body("telephone_number", is(telephoneNumber))
+                .body("_links", hasSize(1))
+                .body("_links[0].href", matchesPattern("^http://selfservice/invites/[0-9a-z]{32}$"))
+                .body("_links[0].method", is("GET"))
+                .body("_links[0].rel", is("invite"));
+    }
+
+    @Test
+    public void shouldFail_WhenMandatoryFieldsAreMissing() throws Exception {
+        String telephoneNumber = "088882345689";
+        ImmutableMap<String, String> payload = ImmutableMap.of("telephone_number", telephoneNumber, "password", "plain_text_password");
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(payload))
+                .contentType(ContentType.JSON)
+                .post(SERVICE_INVITES_CREATE_URL)
+                .then()
+                .statusCode(BAD_REQUEST.getStatusCode())
+                .body("errors", hasSize(1))
+                .body("errors", hasItems("Field [email] is required"));
+    }
+
+    @Test
+    public void shouldFail_WhenEmailIsNotPublicSectorDomain() throws Exception {
+        String email = "example@example.co.uk";
+        String telephoneNumber = "088882345689";
+        ImmutableMap<String, String> payload = ImmutableMap.of("telephone_number", telephoneNumber, "email", email, "password", "plain_text_password");
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(payload))
+                .contentType(ContentType.JSON)
+                .post(SERVICE_INVITES_CREATE_URL)
+                .then()
+                .statusCode(FORBIDDEN.getStatusCode())
+                .body("errors", hasSize(1))
+                .body("errors", hasItems("Email [example@example.co.uk] is not a valid public sector email"));
+    }
+
+    @Test
+    public void shouldFail_WhenEmailIsAlreadyRegistered() throws Exception {
+        String email = "example@example.gov.uk";
+        Service service = Service.from();
+        databaseHelper.addService(service,"1");
+        databaseHelper.add(User.from(randomInt(),randomUuid(),randomUuid(),randomUuid(),email,asList("1"),asList(service),randomUuid(),"12345678909"),2);
+        String telephoneNumber = "088882345689";
+        ImmutableMap<String, String> payload = ImmutableMap.of("telephone_number", telephoneNumber, "email", email, "password", "plain_text_password");
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(payload))
+                .contentType(ContentType.JSON)
+                .post(SERVICE_INVITES_CREATE_URL)
+                .then()
+                .statusCode(CONFLICT.getStatusCode())
+                .body("errors", hasSize(1))
+                .body("errors", hasItems("email [example@example.gov.uk] already exists"));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateTest.java
@@ -59,7 +59,7 @@ public class InviteResourceCreateTest extends IntegrationTest {
                 .body("email", is(email.toLowerCase()))
                 .body("telephone_number", is(nullValue()))
                 .body("_links", hasSize(1))
-                .body("_links[0].href", matchesPattern("^http://selfservice/invites/[0-9a-z]{32}$"))
+                .body("_links[0].href", matchesPattern("^https://selfservice.pymnt.localdomain/invites/[0-9a-z]{32}$"))
                 .body("_links[0].method", is("GET"))
                 .body("_links[0].rel", is("invite"));
     }

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGetTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGetTest.java
@@ -27,7 +27,7 @@ public class InviteResourceGetTest extends IntegrationTest {
                 .body("email", is(email))
                 .body("telephone_number", is(nullValue()))
                 .body("disabled", is(false))
-                .body("login_counter", is(0));
+                .body("attempt_counter", is(0));
     }
 
     @Test
@@ -54,7 +54,7 @@ public class InviteResourceGetTest extends IntegrationTest {
                 .body("email", is(email))
                 .body("telephone_number", is(telephoneNumber))
                 .body("disabled", is(false))
-                .body("login_counter", is(0));
+                .body("attempt_counter", is(0));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGetTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGetTest.java
@@ -3,10 +3,8 @@ package uk.gov.pay.adminusers.resources;
 import org.junit.Test;
 
 import static com.jayway.restassured.http.ContentType.JSON;
-import static javax.ws.rs.core.Response.Status.GONE;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
-import static javax.ws.rs.core.Response.Status.OK;
-import static org.hamcrest.Matchers.*;
+import static javax.ws.rs.core.Response.Status.*;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.adminusers.fixtures.InviteDbFixture.inviteDbFixture;
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteUserRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteUserRequestValidatorTest.java
@@ -318,8 +318,19 @@ public class InviteUserRequestValidatorTest {
     }
 
     @Test
-    public void shouldFail_ifInvalidTelephoneNumber() throws Exception {
+    public void shouldFail_ifTelephoneNumberIsNonNumeric() throws Exception {
         ImmutableMap<String, String> payload = ImmutableMap.of( "email", "example@example.gov.uk","telephone_number", "A800001066", "password", "super-secure-password");
+        JsonNode payloadNode = objectMapper.valueToTree(payload);
+        Optional<Errors> errors = validator.validateCreateServiceRequest(payloadNode);
+
+        assertTrue(errors.isPresent());
+        assertThat(errors.get().getErrors(),hasItems("Field [telephone_number] must be a valid telephone number"));
+        assertThat(errors.get().getErrors().size(),is(1));
+    }
+
+    @Test
+    public void shouldFail_ifTelephoneNumberTooShort() throws Exception {
+        ImmutableMap<String, String> payload = ImmutableMap.of( "email", "example@example.gov.uk","telephone_number", "12345678", "password", "super-secure-password");
         JsonNode payloadNode = objectMapper.valueToTree(payload);
         Optional<Errors> errors = validator.validateCreateServiceRequest(payloadNode);
 

--- a/src/test/java/uk/gov/pay/adminusers/service/InviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/InviteCreatorTest.java
@@ -1,0 +1,128 @@
+package uk.gov.pay.adminusers.service;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import uk.gov.pay.adminusers.model.Invite;
+import uk.gov.pay.adminusers.model.InviteServiceRequest;
+import uk.gov.pay.adminusers.model.Role;
+import uk.gov.pay.adminusers.persistence.dao.InviteDao;
+import uk.gov.pay.adminusers.persistence.dao.RoleDao;
+import uk.gov.pay.adminusers.persistence.dao.UserDao;
+import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
+import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
+import uk.gov.pay.adminusers.persistence.entity.UserEntity;
+
+import javax.ws.rs.WebApplicationException;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.text.MatchesPattern.matchesPattern;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+public class InviteCreatorTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+    private NotificationService notificationService = mock(NotificationService.class);
+    private InviteDao inviteDao = mock(InviteDao.class);
+    private UserDao userDao = mock(UserDao.class);
+    private RoleDao roleDao = mock(RoleDao.class);
+    private ArgumentCaptor<InviteEntity> persistedInviteEntity = ArgumentCaptor.forClass(InviteEntity.class);
+    private InviteCreator inviteCreator;
+
+    @Before
+    public void before() throws Exception {
+        inviteCreator = new InviteCreator(inviteDao, userDao, roleDao, new LinksBuilder("http://localhost/"), "http://selfservice/", notificationService);
+    }
+
+    @Test
+    public void shouldSuccess_serviceInvite_IfEmailDoesNotConflict() throws Exception {
+        String email = "email@example.gov.uk";
+        InviteServiceRequest request = new InviteServiceRequest("password", email, "08976543215");
+        when(userDao.findByEmail(email)).thenReturn(Optional.empty());
+        when(inviteDao.findByEmail(email)).thenReturn(Optional.empty());
+        RoleEntity roleEntity = new RoleEntity(Role.role(2, "admin", "Adminstrator"));
+        when(roleDao.findByRoleName("admin")).thenReturn(Optional.of(roleEntity));
+        when(notificationService.sendServiceInviteEmail(eq(email), anyString())).thenReturn(CompletableFuture.completedFuture("done"));
+        Invite invite = inviteCreator.doCreate(request);
+
+        verify(inviteDao, times(1)).persist(persistedInviteEntity.capture());
+        assertThat(invite.getEmail(), is(request.getEmail()));
+        assertThat(invite.getTelephoneNumber(), is(request.getTelephoneNumber()));
+        assertThat(invite.getType(), is("service"));
+        assertThat(invite.getLinks().get(0).getHref(), matchesPattern("^http://selfservice/invites/[0-9a-z]{32}$"));
+
+    }
+
+    @Test
+    public void shouldSuccess_serviceInvite_evenIfNotifyThrowsAnError() throws Exception {
+        String email = "email@example.gov.uk";
+        InviteServiceRequest request = new InviteServiceRequest("password", email, "08976543215");
+        when(userDao.findByEmail(email)).thenReturn(Optional.empty());
+        when(inviteDao.findByEmail(email)).thenReturn(Optional.empty());
+        RoleEntity roleEntity = new RoleEntity(Role.role(2, "admin", "Adminstrator"));
+        when(roleDao.findByRoleName("admin")).thenReturn(Optional.of(roleEntity));
+        when(notificationService.sendServiceInviteEmail(eq(email), anyString())).thenReturn(CompletableFuture.supplyAsync(() -> {
+            throw new RuntimeException("done");
+        }));
+        Invite invite = inviteCreator.doCreate(request);
+
+        verify(inviteDao, times(1)).persist(persistedInviteEntity.capture());
+        assertThat(invite.getEmail(), is(request.getEmail()));
+        assertThat(invite.getTelephoneNumber(), is(request.getTelephoneNumber()));
+        assertThat(invite.getType(), is("service"));
+        assertThat(invite.getLinks().get(0).getHref(), matchesPattern("^http://selfservice/invites/[0-9a-z]{32}$"));
+
+    }
+
+    @Test
+    public void shouldError_ifUserAlreadyExistsWithGivenEmail() throws Exception {
+        String email = "email@example.gov.uk";
+        InviteServiceRequest request = new InviteServiceRequest("password", email, "08976543215");
+        UserEntity existingUserEntity = new UserEntity();
+        when(userDao.findByEmail(email)).thenReturn(Optional.of(existingUserEntity));
+
+        thrown.expect(WebApplicationException.class);
+        thrown.expectMessage("HTTP 409 Conflict");
+
+        inviteCreator.doCreate(request);
+
+    }
+
+    @Test
+    public void shouldError_ifUserAlreadyHasAValidInvitationWithGivenEmail() throws Exception {
+        String email = "email@example.gov.uk";
+        InviteServiceRequest request = new InviteServiceRequest("password", email, "08976543215");
+        when(userDao.findByEmail(email)).thenReturn(Optional.empty());
+        InviteEntity validInvite = mock(InviteEntity.class);
+        when(validInvite.isExpired()).thenReturn(false);
+        when(validInvite.isDisabled()).thenReturn(false);
+        when(inviteDao.findByEmail(email)).thenReturn(Optional.of(validInvite));
+
+        thrown.expect(WebApplicationException.class);
+        thrown.expectMessage("HTTP 409 Conflict");
+
+        inviteCreator.doCreate(request);
+    }
+
+    @Test
+    public void shouldError_ifRoleDoesNotExists() throws Exception {
+        String email = "email@example.gov.uk";
+        InviteServiceRequest request = new InviteServiceRequest("password", email, "08976543215");
+        when(userDao.findByEmail(email)).thenReturn(Optional.empty());
+        when(inviteDao.findByEmail(email)).thenReturn(Optional.empty());
+        when(roleDao.findByRoleName("admin")).thenReturn(Optional.empty());
+
+        thrown.expect(WebApplicationException.class);
+        thrown.expectMessage("HTTP 500 Internal Server Error");
+
+        inviteCreator.doCreate(request);
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/service/InviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/InviteCreatorTest.java
@@ -53,6 +53,7 @@ public class InviteCreatorTest {
         RoleEntity roleEntity = new RoleEntity(Role.role(2, "admin", "Adminstrator"));
         when(roleDao.findByRoleName("admin")).thenReturn(Optional.of(roleEntity));
         when(notificationService.sendServiceInviteEmail(eq(email), anyString())).thenReturn(CompletableFuture.completedFuture("done"));
+        when(linksConfig.getSelfserviceInvitesUrl()).thenReturn("http://selfservice/invites");
         when(linksConfig.getSelfserviceUrl()).thenReturn("http://selfservice");
 
         Invite invite = inviteCreator.doCreate(request);
@@ -77,6 +78,7 @@ public class InviteCreatorTest {
             throw new RuntimeException("done");
         }));
         when(linksConfig.getSelfserviceUrl()).thenReturn("http://selfservice");
+        when(linksConfig.getSelfserviceInvitesUrl()).thenReturn("http://selfservice/invites");
         Invite invite = inviteCreator.doCreate(request);
 
         verify(inviteDao, times(1)).persist(persistedInviteEntity.capture());
@@ -93,7 +95,10 @@ public class InviteCreatorTest {
         InviteServiceRequest request = new InviteServiceRequest("password", email, "08976543215");
         UserEntity existingUserEntity = new UserEntity();
         when(userDao.findByEmail(email)).thenReturn(Optional.of(existingUserEntity));
-        when(linksConfig.getFrontendUrl()).thenReturn("http://frontend");
+        when(linksConfig.getSupportUrl()).thenReturn("http://frontend");
+        when(linksConfig.getSelfserviceForgottenPasswordUrl()).thenReturn("http://selfservice/forgotten-password");
+        when(linksConfig.getSelfserviceInvitesUrl()).thenReturn("http://selfservice/invites");
+        when(linksConfig.getSelfserviceLoginUrl()).thenReturn("http://selfservice/login");
         when(linksConfig.getSelfserviceUrl()).thenReturn("http://selfservice");
         when(notificationService.sendServiceInviteUserExistsEmail(eq(email), anyString(),anyString(),anyString()))
                 .thenReturn(CompletableFuture.completedFuture("done"));

--- a/src/test/java/uk/gov/pay/adminusers/service/InviteServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/InviteServiceTest.java
@@ -17,10 +17,8 @@ import uk.gov.pay.adminusers.persistence.dao.RoleDao;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
 import uk.gov.pay.adminusers.persistence.entity.*;
-import uk.gov.pay.adminusers.persistence.entity.Role;
 
 import javax.ws.rs.WebApplicationException;
-import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -40,7 +38,7 @@ import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.model.InviteOtpRequest.FIELD_CODE;
 import static uk.gov.pay.adminusers.model.InviteOtpRequest.FIELD_PASSWORD;
 import static uk.gov.pay.adminusers.model.InviteOtpRequest.FIELD_TELEPHONE_NUMBER;
-import static uk.gov.pay.adminusers.model.InviteRequest.*;
+import static uk.gov.pay.adminusers.model.InviteUserRequest.*;
 import static uk.gov.pay.adminusers.model.Role.role;
 import static uk.gov.pay.adminusers.persistence.entity.Role.ADMIN;
 
@@ -174,9 +172,9 @@ public class InviteServiceTest {
         User existingUser = aUser(existingUserEmail);
         when(mockUserDao.findByEmail(existingUserEmail)).thenReturn(Optional.of(UserEntity.from(existingUser)));
 
-        InviteRequest inviteRequest = inviteRequestFrom(senderEmail, existingUserEmail, roleName);
+        InviteUserRequest inviteUserRequest = inviteRequestFrom(senderEmail, existingUserEmail, roleName);
         try {
-            inviteService.create(inviteRequest, serviceId);
+            inviteService.create(inviteUserRequest, serviceId);
             fail();
         } catch (WebApplicationException e) {
             MatcherAssert.assertThat(e.getResponse().getStatus(), is(CONFLICT.getStatusCode()));
@@ -189,9 +187,9 @@ public class InviteServiceTest {
         InviteEntity anInvite = mocksCreateInvite();
         when(mockInviteDao.findByEmail(email)).thenReturn(Optional.of(anInvite));
 
-        InviteRequest inviteRequest = inviteRequestFrom(senderEmail, email, roleName);
+        InviteUserRequest inviteUserRequest = inviteRequestFrom(senderEmail, email, roleName);
         try {
-            inviteService.create(inviteRequest, serviceId);
+            inviteService.create(inviteUserRequest, serviceId);
             fail();
         } catch (WebApplicationException e) {
             MatcherAssert.assertThat(e.getResponse().getStatus(), is(CONFLICT.getStatusCode()));
@@ -373,12 +371,12 @@ public class InviteServiceTest {
         assertThat(notifyPromise.isDone(), is(true));
     }
 
-    private InviteRequest inviteRequestFrom(String sender, String email, String roleName) {
+    private InviteUserRequest inviteRequestFrom(String sender, String email, String roleName) {
         ObjectNode json = JsonNodeFactory.instance.objectNode();
         json.put(FIELD_SENDER, sender);
         json.put(FIELD_EMAIL, email);
         json.put(FIELD_ROLE_NAME, roleName);
-        return InviteRequest.from(json);
+        return InviteUserRequest.from(json);
     }
 
     private InviteOtpRequest inviteOtpRequestFrom(String code, String telephoneNumber, String password) {

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -63,10 +63,10 @@ notify:
   apiKey: ${NOTIFY_API_KEY:-api_key-pay-notify-service-id-pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs}
   notificationBaseURL: ${NOTIFY_BASE_URL:-https://stubs.pymnt.localdomain/notify}
   secondFactorSmsTemplateId: ${NOTIFY_2FA_TEMPLATE_ID:-pay-notify-two-factor-template-id}
-  inviteEmailTemplateId: ${NOTIFY_INVITE_EMAIL_TEMPLATE_ID:-pay-notify-invite-email-template-id}
-  createServiceInvitationEmailTemplateId: ${NOTIFY_INVITE_EMAIL_TEMPLATE_ID:-pay-notify-create-service-invitation-email-template-id}
+  inviteUserEmailTemplateId: ${NOTIFY_INVITE_USER_EMAIL_TEMPLATE_ID:-pay-notify-invite-user-email-template-id}
   forgottenPasswordEmailTemplateId: ${NOTIFY_FORGOTTEN_PASSWORD_EMAIL_TEMPLATE_ID:-pay-notify-forgotten-password-email-template-id}
-  createServiceInvitationUserExistsEmailTemplateId: ${NOTIFY_SERVICE_INVITE_USER_EXITS_EMAIL_TEMPLATE_ID:-pay-notify-create-service-invitation-user-exists-email-template-id}
+  inviteServiceEmailTemplateId: ${NOTIFY_INVITE_SERVICE_EMAIL_TEMPLATE_ID:-pay-notify-invite-service-email-template-id}
+  inviteServiceUserExistsEmailTemplateId: ${NOTIFY_INVITE_SERVICE_USER_EXITS_EMAIL_TEMPLATE_ID:-pay-notify-invite-service-user-exists-email-template-id}
 
 forgottenPasswordExpiryMinutes: ${FORGOTTEN_PASSWORD_EXPIRY_MINUTES:-90}
 

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -74,8 +74,11 @@ graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}
 
 links:
-  selfserviceUrl: ${SELFSERVICE_URL:-http://selfservice}
-  frontendUrl: ${FRONTEND_URL:-http://frontend}
+  selfserviceUrl: ${SELFSERVICE_URL:-https://selfservice.pymnt.localdomain}
+  selfserviceInvitesUrl: ${SELFSERVICE_INVITES_URL:-https://selfservice.pymnt.localdomain/invites}
+  selfserviceLoginUrl: ${SELFSERVICE_LOGIN_URL:-https://selfservice.pymnt.localdomain/login}
+  selfserviceForgottenPasswordUrl: ${SELFSERVICE_FORGOTTEN_PASSWORD_URL:-https://selfservice.pymnt.localdomain/reset-password}
+  supportUrl: ${SUPPORT_URL:-https://frontend.pymnt.localdomain/support.html}
 
 baseUrl: ${BASE_URL:-http://localhost:8080}
 loginAttemptCap: ${LOGIN_ATTEMPT_CAP:-10}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -60,9 +60,13 @@ proxy:
   port: 1234
 
 notify:
-  apiKey: ${NOTIFY_API_KEY:-pay-notify-api-key}
+  apiKey: ${NOTIFY_API_KEY:-api_key-pay-notify-service-id-pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs}
   notificationBaseURL: ${NOTIFY_BASE_URL:-https://stubs.pymnt.localdomain/notify}
   secondFactorSmsTemplateId: ${NOTIFY_2FA_TEMPLATE_ID:-pay-notify-two-factor-template-id}
+  inviteEmailTemplateId: ${NOTIFY_INVITE_EMAIL_TEMPLATE_ID:-pay-notify-invite-email-template-id}
+  createServiceInvitationEmailTemplateId: ${NOTIFY_INVITE_EMAIL_TEMPLATE_ID:-pay-notify-create-service-invitation-email-template-id}
+  forgottenPasswordEmailTemplateId: ${NOTIFY_FORGOTTEN_PASSWORD_EMAIL_TEMPLATE_ID:-pay-notify-forgotten-password-email-template-id}
+  createServiceInvitationUserExistsEmailTemplateId: ${NOTIFY_SERVICE_INVITE_USER_EXITS_EMAIL_TEMPLATE_ID:-pay-notify-create-service-invitation-user-exists-email-template-id}
 
 forgottenPasswordExpiryMinutes: ${FORGOTTEN_PASSWORD_EXPIRY_MINUTES:-90}
 
@@ -71,6 +75,7 @@ graphitePort: ${METRICS_PORT:-8092}
 
 links:
   selfserviceUrl: ${SELFSERVICE_URL:-http://selfservice}
+  frontendUrl: ${FRONTEND_URL:-http://frontend}
 
 baseUrl: ${BASE_URL:-http://localhost:8080}
 loginAttemptCap: ${LOGIN_ATTEMPT_CAP:-10}


### PR DESCRIPTION
- Introduced `InviteServiceFactory`
- Created a abstract `InviteRequest` class, with child classes for user and service invite requests.
- Added generic email validator to `EmailValidator` to validate email inputs.
- Extracted the links config as a injectable object as it could be injected in services instead of the whole configuration object.
- Feedback link in the email template currently directs to the `support` page in our product page (frontend). We may need to change this in future.

TODO:
There are couple of edge cases which we still need to discuss with @stephenmc.