### PR TITLE
PP-2147 Update service attribute resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The GOV.UK Pay Admin Users Module in Java (Dropwizard)
 | [```/v1/api/forgotten-passwords```](/docs/api_specification.md#post-v1apiforgottenpasswords)              | POST    |  Create a new forgotten password request            |
 | [```/v1/api/forgotten-passwords/{code}```](/docs/api_specification.md#get-v1apiforgottenpasswordscode)              | GET    |  GETs a forgotten password record by code            |
 | [```/v1/api/services```](/docs/api_specification.md#post-v1apiservices)              | POST   |  Creates a new service           |
+| [```/v1/api/invites/service```](/docs/api_specification.md#post-v1apiinvitesservice)               | POST   |  Creates a invitation for a new service     |
+| [```/v1/api/service/{externalId}```](/docs/api_specification.md#patch-v1apisservicesexternalId)               | PATCH   |  Updates the value of a service attribute     |
 
 
 -----------------------------------------------------------------------------------------------------------

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -434,3 +434,101 @@ Content-Type: application/json
     
 }
 ```
+
+-----------------------------------------------------------------------------------------------------------
+
+## POST /v1/api/invites/service
+
+This endpoint creates an invitation to allow self provisioning new service with Pay.
+
+### Request example
+
+```
+POST /v1/api/invites/service
+Content-Type: application/json
+{
+"telephone_number":"088882345689",
+"email": "example@example.gov.uk",
+"password" : "plain-txt-passsword"
+}
+
+```
+
+#### Request body description
+
+| Field                    | required | Description                                                      | Supported Values     |
+| ------------------------ |:--------:| ---------------------------------------------------------------- |----------------------|
+| `telephone_number`       |   X      | the phone number of the user                                     |   |
+| `email`                  |   X      | the email (mut be a public sector email)                         | |
+| `password`               |   X      | password for the new user                                        | |
+
+### Response example
+
+```
+201 OK
+Content-Type: application/json
+{  
+   "type":"service",
+   "email":"example@example.gov.uk",
+   "telephone_number":"088882345689",
+   "disabled":false,
+   "attempt_counter":0,
+   "_links":[  
+      {  
+         "rel":"invite",
+         "method":"GET",
+         "href":"https://selfservice.pymnt.localdomain/invites/04f431f18c3243f5bb29d10c01659e9c"
+      },
+      {  
+         "rel":"self",
+         "method":"GET",
+         "href":"http://localhost:8080/v1/api/invites/04f431f18c3243f5bb29d10c01659e9c"
+      }
+   ]
+}
+```
+
+-----------------------------------------------------------------------------------------------------------
+
+## PATCH /v1/api/services/{serviceExternalId}
+
+This endpoint creates an invitation to allow self provisioning new service with Pay.
+
+### Request example
+
+```
+PATCH /v1/api/services/7d19aff33f8948deb97ed16b2912dcd3
+Content-Type: application/json
+{
+ "op": "replace",
+ "path": "name", 
+ "value": "updated-service-name" 
+}
+
+```
+
+#### Request body description
+
+| Field                    | required | Description                                                      | Supported Values     |
+| ------------------------ |:--------:| ---------------------------------------------------------------- |----------------------|
+| `op`                     |   X      | operation to perform on attribute                                | `replace`, `add`     |
+| `path`                   |   X      | attribute that is affecting                                      | `gateway_account_ids` , `name` |
+| `value`                  |   X         | value to be replaced                                             |                      |
+
+### Response example
+
+```
+200 OK
+Content-Type: application/json
+{
+    "id": 123
+    "external_id": "7d19aff33f8948deb97ed16b2912dcd3",
+    "name": "updated-service-name",
+    "_links": [{
+        "href": "http://adminusers.service/v1/api/services/123",
+        "rel" : "self",
+        "method" : "GET"
+    }]
+    
+}
+```

--- a/src/main/java/uk/gov/pay/adminusers/model/ServiceUpdateRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/ServiceUpdateRequest.java
@@ -2,12 +2,19 @@ package uk.gov.pay.adminusers.model;
 
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
-import static java.util.Arrays.asList;
+import static com.google.common.collect.Lists.newArrayList;
 
 public class ServiceUpdateRequest {
+
+    public static final String FIELD_OP = "op";
+    public static final String FIELD_PATH = "path";
+    public static final String FIELD_VALUE = "value";
+
     private String op;
     private String path;
     private List<String> value;
@@ -31,10 +38,20 @@ public class ServiceUpdateRequest {
     }
 
     public static ServiceUpdateRequest from(JsonNode payload) {
-        String op = payload.get("op").asText();
-        String path = payload.get("path").asText();
-        List<String> value = asList(payload.get("value").asText());
+        List<String> value = newArrayList();
+        if (payload.get(FIELD_VALUE).getClass().equals(ArrayNode.class)) {
+            List<JsonNode> gatewayAccountIdNodes = newArrayList(payload.get(FIELD_VALUE).elements());
+            value.addAll(gatewayAccountIdNodes.stream()
+                    .map(node -> node.textValue())
+                    .collect(Collectors.toList()));
+        } else {
+            value.add(payload.get(FIELD_VALUE).asText());
+        }
 
-        return new ServiceUpdateRequest(op, path, value);
+        return new ServiceUpdateRequest(
+                payload.get(FIELD_OP).asText(),
+                payload.get(FIELD_PATH).asText(),
+                value);
+
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/model/ServiceUpdateRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/ServiceUpdateRequest.java
@@ -1,0 +1,40 @@
+package uk.gov.pay.adminusers.model;
+
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+
+public class ServiceUpdateRequest {
+    private String op;
+    private String path;
+    private List<String> value;
+
+    public String getOp() {
+        return op;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public List<String> getValue() {
+        return value;
+    }
+
+    private ServiceUpdateRequest(String op, String path, List<String> value) {
+        this.op = op;
+        this.path = path;
+        this.value = value;
+    }
+
+    public static ServiceUpdateRequest from(JsonNode payload) {
+        String op = payload.get("op").asText();
+        String path = payload.get("path").asText();
+        List<String> value = asList(payload.get("value").asText());
+
+        return new ServiceUpdateRequest(op, path, value);
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/persistence/dao/ServiceDao.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/dao/ServiceDao.java
@@ -52,4 +52,14 @@ public class ServiceDao extends JpaDao<ServiceEntity> {
                 .getSingleResult();
         return count > 0;
     }
+
+    public Optional<ServiceEntity> findByExternalId(String serviceExternalId) {
+        String query = "SELECT s FROM ServiceEntity as s WHERE s.externalId = :externalId";
+        return entityManager.get()
+                .createQuery(query, ServiceEntity.class)
+                .setParameter("externalId", serviceExternalId)
+                .getResultList()
+                .stream()
+                .findFirst();
+    }
 }

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
@@ -7,15 +7,27 @@ import uk.gov.pay.adminusers.utils.Errors;
 import uk.gov.pay.adminusers.validations.RequestValidations;
 
 import javax.inject.Inject;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
 
 
 public class ServiceRequestValidator {
 
     public static final String FIELD_SERVICE_NAME = "name";
     public static final String FIELD_GATEWAY_ACCOUNT_IDS = "gateway_account_ids";
+    private static final String FIELD_OP = "op";
+    private static final String FIELD_PATH = "path";
+    private static final String FIELD_VALUE = "value";
     private final RequestValidations requestValidations;
+    private static final Map<String, List<String>> VALID_ATTRIBUTE_UPDATE_OPERATIONS = new HashMap<String, List<String>>(){{
+        put(FIELD_SERVICE_NAME, asList("replace"));
+        put(FIELD_GATEWAY_ACCOUNT_IDS, asList("add"));
+    }};
 
     @Inject
     public ServiceRequestValidator(RequestValidations requestValidations) {
@@ -30,7 +42,7 @@ public class ServiceRequestValidator {
 
         if (!requestValidations.notExistOrEmptyArray().apply(payload.get(FIELD_GATEWAY_ACCOUNT_IDS))) {
             if (nonNumericGatewayAccountIds(payload.get(FIELD_GATEWAY_ACCOUNT_IDS))) {
-                return Optional.of(Errors.from(String.format("Field [%s] must contain numeric values", FIELD_GATEWAY_ACCOUNT_IDS)));
+                return Optional.of(Errors.from(format("Field [%s] must contain numeric values", FIELD_GATEWAY_ACCOUNT_IDS)));
             }
         }
         return Optional.empty();
@@ -39,5 +51,28 @@ public class ServiceRequestValidator {
     private boolean nonNumericGatewayAccountIds(JsonNode gatewayAccountNode) {
         List<JsonNode> accountIds = Lists.newArrayList(gatewayAccountNode.elements());
         return accountIds.stream().filter(idNode -> !NumberUtils.isDigits(idNode.asText())).count() > 0;
+    }
+
+    public Optional<Errors> validateUpdateAttributeRequest(JsonNode payload) {
+        Optional<List<String>> errors = requestValidations.checkIfExists(payload, FIELD_OP, FIELD_PATH, FIELD_VALUE);
+
+        if(errors.isPresent()) {
+            return Optional.of(Errors.from(errors.get()));
+        }
+        String path = payload.get("path").asText();
+        if (!VALID_ATTRIBUTE_UPDATE_OPERATIONS.keySet().contains(path)) {
+            return Optional.of(Errors.from(format("Path [%s] is invalid", path)));
+        }
+
+
+        String op = payload.get("op").asText();
+
+        if (!VALID_ATTRIBUTE_UPDATE_OPERATIONS.get(path).contains(op)) {
+            return Optional.of(Errors.from(format("Operation [%s] is invalid for path [%s]", op, path)));
+        }
+
+
+        return Optional.empty();
+
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
@@ -14,15 +14,14 @@ import java.util.Optional;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static uk.gov.pay.adminusers.model.ServiceUpdateRequest.*;
 
 
 public class ServiceRequestValidator {
 
     public static final String FIELD_SERVICE_NAME = "name";
     public static final String FIELD_GATEWAY_ACCOUNT_IDS = "gateway_account_ids";
-    private static final String FIELD_OP = "op";
-    private static final String FIELD_PATH = "path";
-    private static final String FIELD_VALUE = "value";
+
     private final RequestValidations requestValidations;
     private static final Map<String, List<String>> VALID_ATTRIBUTE_UPDATE_OPERATIONS = new HashMap<String, List<String>>(){{
         put(FIELD_SERVICE_NAME, asList("replace"));
@@ -64,15 +63,11 @@ public class ServiceRequestValidator {
             return Optional.of(Errors.from(format("Path [%s] is invalid", path)));
         }
 
-
         String op = payload.get("op").asText();
-
         if (!VALID_ATTRIBUTE_UPDATE_OPERATIONS.get(path).contains(op)) {
             return Optional.of(Errors.from(format("Operation [%s] is invalid for path [%s]", op, path)));
         }
 
-
         return Optional.empty();
-
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceServicesFactory.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceServicesFactory.java
@@ -3,4 +3,6 @@ package uk.gov.pay.adminusers.service;
 public interface ServiceServicesFactory {
 
     ServiceCreator serviceCreator();
+
+    ServiceUpdater serviceUpdater();
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.adminusers.service;
+
+
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+import uk.gov.pay.adminusers.model.Service;
+import uk.gov.pay.adminusers.model.ServiceUpdateRequest;
+import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
+
+import java.util.Optional;
+
+public class ServiceUpdater {
+
+    private final ServiceDao serviceDao;
+
+    @Inject
+    public ServiceUpdater(ServiceDao serviceDao) {
+        this.serviceDao = serviceDao;
+    }
+
+    @Transactional
+    public Optional<Service> doUpdate(String serviceExternalId, ServiceUpdateRequest serviceUpdateRequest) {
+        return serviceDao.findByExternalId(serviceExternalId)
+                .map(serviceEntity -> {
+                    serviceEntity.setName(serviceUpdateRequest.getValue().get(0));
+                    serviceDao.merge(serviceEntity);
+                    return Optional.of(serviceEntity.toService());
+                }).orElseGet(() -> Optional.empty());
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
@@ -6,8 +6,16 @@ import com.google.inject.persist.Transactional;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.ServiceUpdateRequest;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
+import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 
+import java.util.List;
 import java.util.Optional;
+
+import static java.lang.String.format;
+import static uk.gov.pay.adminusers.resources.ServiceRequestValidator.FIELD_GATEWAY_ACCOUNT_IDS;
+import static uk.gov.pay.adminusers.resources.ServiceRequestValidator.FIELD_SERVICE_NAME;
+import static uk.gov.pay.adminusers.service.AdminUsersExceptions.conflictingServiceGatewayAccounts;
+import static uk.gov.pay.adminusers.service.AdminUsersExceptions.internalServerError;
 
 public class ServiceUpdater {
 
@@ -22,9 +30,35 @@ public class ServiceUpdater {
     public Optional<Service> doUpdate(String serviceExternalId, ServiceUpdateRequest serviceUpdateRequest) {
         return serviceDao.findByExternalId(serviceExternalId)
                 .map(serviceEntity -> {
-                    serviceEntity.setName(serviceUpdateRequest.getValue().get(0));
+                    List<String> value = serviceUpdateRequest.getValue();
+                    updateAttribute(serviceUpdateRequest, serviceEntity, value);
                     serviceDao.merge(serviceEntity);
                     return Optional.of(serviceEntity.toService());
                 }).orElseGet(() -> Optional.empty());
+    }
+
+    private void updateAttribute(ServiceUpdateRequest serviceUpdateRequest, ServiceEntity serviceEntity, List<String> value) {
+        String path = serviceUpdateRequest.getPath();
+        if (path.equals(FIELD_SERVICE_NAME)) {
+            updateServiceName(serviceEntity, value.get(0));
+        } else {
+            if(path.equals(FIELD_GATEWAY_ACCOUNT_IDS)) {
+                assignGatewayAccounts(serviceEntity, value);
+            } else {
+                throw internalServerError(format("Invalid path value for updating service attribute: [%s]", path));
+            }
+        }
+    }
+
+    private void assignGatewayAccounts(ServiceEntity serviceEntity, List<String> gatewayAccountIds) {
+        if (serviceDao.checkIfGatewayAccountsUsed(gatewayAccountIds)) {
+            throw conflictingServiceGatewayAccounts(gatewayAccountIds);
+        } else {
+            serviceEntity.addGatewayAccountIds(gatewayAccountIds.toArray(new String[0]));
+        }
+    }
+
+    private void updateServiceName(ServiceEntity serviceEntity, String nameToUpdate) {
+        serviceEntity.setName(nameToUpdate);
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
@@ -204,7 +204,7 @@ public class UserServices {
                         if (userEntity.isDisabled()) {
                             logger.warn("Failed OTP attempt - user_id={}, login_counter={}. Invalid second factor in an account currently locked", userEntity.getExternalId(), userEntity.getLoginCounter());
                         } else {
-                            logger.warn("Failed OTP attempt - user_id={}, login_counter={}. Invalid second factor attempt.", userEntity.getExternalId(), userEntity.getLoginCounter());
+                            logger.info("Failed OTP attempt - user_id={}, login_counter={}. Invalid second factor attempt.", userEntity.getExternalId(), userEntity.getLoginCounter());
                         }
                         return Optional.<User>empty();
                     }

--- a/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
@@ -49,7 +49,14 @@ public class EmailValidator {
                 Pattern.compile("^" + regExDomainsOnlyPart +  "|" + regExSubdomainsPart + "$");
     }
 
-    public static final boolean isValid(String email) {
+    /**
+     * <p>Checks if a field has a valid e-mail address.</p>
+     *
+     * @param email The value validation is being performed on.  A <code>null</code>
+     *              value is considered invalid.
+     * @return true if the email address is valid.
+     */
+    public static boolean isValid(String email) {
         return commonsEmailValidator.isValid(email);
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoTest.java
@@ -15,6 +15,7 @@ import static java.util.Arrays.asList;
 import static java.util.stream.IntStream.range;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertTrue;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.model.Role.role;
@@ -27,6 +28,18 @@ public class ServiceDaoTest extends DaoTestBase {
     public void before() throws Exception {
         serviceDao = env.getInstance(ServiceDao.class);
     }
+
+
+    @Test
+    public void shouldFindByServiceExternalId() throws Exception {
+        String serviceExternalId = randomUuid();
+        databaseHelper.addService(Service.from(randomInt(),serviceExternalId, "name"), randomInt().toString());
+
+        Optional<ServiceEntity> serviceEntity = serviceDao.findByExternalId(serviceExternalId);
+
+        assertTrue(serviceEntity.isPresent());
+    }
+
 
     @Test
     public void shouldFindByGatewayAccountId() throws Exception {

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceRequestValidatorTest.java
@@ -2,13 +2,19 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import org.hamcrest.core.Is;
 import org.junit.Test;
 import uk.gov.pay.adminusers.utils.Errors;
 import uk.gov.pay.adminusers.validations.RequestValidations;
 
+import java.util.List;
 import java.util.Optional;
 
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ServiceRequestValidatorTest {
 
@@ -55,6 +61,52 @@ public class ServiceRequestValidatorTest {
         Optional<Errors> errors = serviceRequestValidator.validateCreateRequest(mapper.valueToTree(payload));
         assertFalse(errors.isPresent());
 
+    }
+
+    @Test
+    public void shouldSuccess_whenUpdate_whenAllFieldPresentAndValid() throws Exception {
+        ImmutableMap<String, String> payload = ImmutableMap.of("path", "name", "op", "replace", "value", "example-name");
+
+        Optional<Errors> errors = serviceRequestValidator.validateUpdateAttributeRequest(mapper.valueToTree(payload));
+
+        assertFalse(errors.isPresent());
+    }
+
+    @Test
+    public void shouldFail_whenUpdate_whenMissingRequiredField() throws Exception {
+        ImmutableMap<String, String> payload = ImmutableMap.of( "value", "example-name");
+
+        Optional<Errors> errors = serviceRequestValidator.validateUpdateAttributeRequest(mapper.valueToTree(payload));
+
+        assertTrue(errors.isPresent());
+        List<String> errorsList = errors.get().getErrors();
+        assertThat(errorsList.size(), is(2));
+        assertThat(errorsList, hasItem("Field [path] is required"));
+        assertThat(errorsList, hasItem("Field [op] is required"));
+    }
+
+    @Test
+    public void shouldFail_whenUpdate_whenInvalidPath() throws Exception {
+        ImmutableMap<String, String> payload = ImmutableMap.of("path", "xyz", "op", "replace", "value", "example-name");
+
+        Optional<Errors> errors = serviceRequestValidator.validateUpdateAttributeRequest(mapper.valueToTree(payload));
+
+        assertTrue(errors.isPresent());
+        List<String> errorsList = errors.get().getErrors();
+        assertThat(errorsList.size(), is(1));
+        assertThat(errorsList, hasItem("Path [xyz] is invalid"));
+    }
+
+    @Test
+    public void shouldFail_whenUpdate_whenInvalidOperationForSuppliedPath() throws Exception {
+        ImmutableMap<String, String> payload = ImmutableMap.of("path", "name", "op", "add", "value", "example-name");
+
+        Optional<Errors> errors = serviceRequestValidator.validateUpdateAttributeRequest(mapper.valueToTree(payload));
+
+        assertTrue(errors.isPresent());
+        List<String> errorsList = errors.get().getErrors();
+        assertThat(errorsList.size(), is(1));
+        assertThat(errorsList, hasItem("Operation [add] is invalid for path [name]"));
     }
 
 }

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateTest.java
@@ -1,0 +1,73 @@
+package uk.gov.pay.adminusers.resources;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import uk.gov.pay.adminusers.model.Service;
+
+import java.util.Map;
+
+import static com.jayway.restassured.http.ContentType.JSON;
+import static java.lang.String.format;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
+
+public class ServiceResourceUpdateTest extends IntegrationTest {
+
+    @Test
+    public void shouldSuccess_whenReplaceServiceNameWithANewValue() throws Exception {
+
+        String serviceExternalId = randomUuid();
+        Service service = Service.from(randomInt(), serviceExternalId, "existing-name");
+        databaseHelper.addService(service, randomInt().toString());
+
+        Map<String, String> payload = ImmutableMap.of("op", "replace", "path", "name", "value", "updated-service-name");
+
+        givenSetup()
+                .when()
+                .accept(JSON)
+                .body(mapper.writeValueAsString(payload))
+                .patch(format("/v1/api/services/%s", serviceExternalId))
+                .then()
+                .statusCode(200)
+                .body("name", is("updated-service-name"));
+
+    }
+
+    @Test
+    public void shouldError404_ifServiceExternalIdDoesNotExist() throws Exception {
+        Map<String, String> payload = ImmutableMap.of("op", "replace", "path", "name", "value", "new-service-name");
+
+        givenSetup()
+                .when()
+                .accept(JSON)
+                .body(mapper.writeValueAsString(payload))
+                .patch(format("/v1/api/services/%s", "non-existent-service-id"))
+                .then()
+                .statusCode(404);
+
+    }
+
+    @Test
+    public void shouldError400_ifMandatoryFieldMissing() throws Exception {
+        String serviceExternalId = randomUuid();
+        Service service = Service.from(randomInt(), serviceExternalId, "existing-name");
+        databaseHelper.addService(service, randomInt().toString());
+
+        Map<String, String> payload = ImmutableMap.of("op", "replace", "path", "name");
+
+        givenSetup()
+                .when()
+                .accept(JSON)
+                .body(mapper.writeValueAsString(payload))
+                .patch(format("/v1/api/services/%s", "non-existent-service-id"))
+                .then()
+                .statusCode(400)
+                .body("errors", hasSize(1))
+                .body("errors", hasItems(format("Field [value] is required")));
+
+    }
+
+}

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateTest.java
@@ -4,10 +4,14 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.Service;
 
+import java.util.List;
 import java.util.Map;
 
 import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
@@ -16,6 +20,7 @@ import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 
 public class ServiceResourceUpdateTest extends IntegrationTest {
 
+    //Update service name
     @Test
     public void shouldSuccess_whenReplaceServiceNameWithANewValue() throws Exception {
 
@@ -70,4 +75,60 @@ public class ServiceResourceUpdateTest extends IntegrationTest {
 
     }
 
+    //Assign gateway accounts
+    @Test
+    public void shouldSuccess_whenAddGatewayAccountIds() throws Exception {
+        String existingGatewayAccountId = randomInt().toString();
+        String serviceExternalId = randomUuid();
+        Service service = Service.from(randomInt(), serviceExternalId, "existing-name");
+        databaseHelper.addService(service, existingGatewayAccountId);
+
+        String newGatewayAccountId = randomInt().toString();
+        ImmutableMap<Object, Object> payload = ImmutableMap.builder()
+                .put("op", "add")
+                .put("path", "gateway_account_ids")
+                .put("value", asList(newGatewayAccountId))
+                .build();
+
+        givenSetup()
+                .when()
+                .accept(JSON)
+                .body(mapper.writeValueAsString(payload))
+                .patch(format("/v1/api/services/%s", serviceExternalId))
+                .then()
+                .statusCode(200);
+
+        List<String> gatewayAccounts = databaseHelper.findGatewayAccountsByService(serviceExternalId).stream()
+                .map(row -> row.get("gateway_account_id").toString()).collect(toList());
+        assertThat(gatewayAccounts.size(), is(2));
+        assertThat(gatewayAccounts, hasItems(existingGatewayAccountId, newGatewayAccountId));
+
+    }
+
+    @Test
+    public void shouldError409_whenAddGatewayAccountIds_ifGatewayAccountIdAlreadyUsedByAnotherService() throws Exception {
+        String service1ExternalId = randomUuid();
+        String service2GatewayAccountId = randomInt().toString();
+        Service service1 = Service.from(randomInt(), service1ExternalId, "service-1-name");
+        Service service2 = Service.from(randomInt(), randomUuid(), "service-2-name");
+        databaseHelper
+                .addService(service1, randomInt().toString())
+                .addService(service2, service2GatewayAccountId);
+
+        ImmutableMap<Object, Object> payload = ImmutableMap.builder()
+                .put("op", "add")
+                .put("path", "gateway_account_ids")
+                .put("value", asList(service2GatewayAccountId))
+                .build();
+
+        givenSetup()
+                .when()
+                .accept(JSON)
+                .body(mapper.writeValueAsString(payload))
+                .patch(format("/v1/api/services/%s", service1ExternalId))
+                .then()
+                .body("errors", hasSize(1))
+                .body("errors", hasItems(format("One or more of the following gateway account ids has already assigned to another service: [%s]", service2GatewayAccountId)));
+
+    }
 }

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceUpdaterTest.java
@@ -1,0 +1,104 @@
+package uk.gov.pay.adminusers.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.adminusers.model.Service;
+import uk.gov.pay.adminusers.model.ServiceUpdateRequest;
+import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
+import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
+
+import javax.ws.rs.WebApplicationException;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.mockito.Mockito.*;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
+
+public class ServiceUpdaterTest {
+
+    ServiceDao serviceDao = mock(ServiceDao.class);
+    ServiceUpdater updater;
+
+    @Before
+    public void before() throws Exception {
+        updater = new ServiceUpdater(serviceDao);
+    }
+
+    @Test
+    public void shouldUpdateNameSuccessfully() throws Exception {
+
+        String serviceId = randomUuid();
+        ServiceUpdateRequest request = mock(ServiceUpdateRequest.class);
+        ServiceEntity serviceEntity = mock(ServiceEntity.class);
+        String nameToUpdate = "new-name";
+
+        when(request.getPath()).thenReturn("name");
+        when(request.getValue()).thenReturn(singletonList(nameToUpdate));
+        when(serviceDao.findByExternalId(serviceId)).thenReturn(Optional.of(serviceEntity));
+        when(serviceEntity.toService()).thenReturn(Service.from());
+
+        updater.doUpdate(serviceId, request);
+
+        verify(serviceEntity,times(1)).setName(nameToUpdate);
+        verify(serviceDao, times(1)).merge(serviceEntity);
+    }
+
+    @Test
+    public void shouldSuccess_whenAddGatewayAccountToService() throws Exception {
+        String serviceId = randomUuid();
+        ServiceUpdateRequest request = mock(ServiceUpdateRequest.class);
+        ServiceEntity serviceEntity = mock(ServiceEntity.class);
+        List<String> gatewayAccountIdsToUpdate = asList("1", "2");
+
+        when(request.getPath()).thenReturn("gateway_account_ids");
+        when(request.getValue()).thenReturn(gatewayAccountIdsToUpdate);
+        when(serviceDao.findByExternalId(serviceId)).thenReturn(Optional.of(serviceEntity));
+        when(serviceDao.checkIfGatewayAccountsUsed(gatewayAccountIdsToUpdate)).thenReturn(false);
+        when(serviceEntity.toService()).thenReturn(Service.from());
+
+        updater.doUpdate(serviceId, request);
+
+        verify(serviceEntity,times(1)).addGatewayAccountIds(gatewayAccountIdsToUpdate.toArray(new String[0]));
+        verify(serviceDao, times(1)).merge(serviceEntity);
+    }
+
+
+    @Test(expected = WebApplicationException.class)
+    public void shouldError_IfAGatewayAccountAlreadyAssignedToAService() throws Exception {
+        String serviceId = randomUuid();
+        ServiceUpdateRequest request = mock(ServiceUpdateRequest.class);
+        ServiceEntity serviceEntity = mock(ServiceEntity.class);
+        List<String> gatewayAccountIdsToUpdate = asList("1", "2");
+
+        when(request.getPath()).thenReturn("gateway_account_ids");
+        when(request.getValue()).thenReturn(gatewayAccountIdsToUpdate);
+        when(serviceDao.findByExternalId(serviceId)).thenReturn(Optional.of(serviceEntity));
+        when(serviceDao.checkIfGatewayAccountsUsed(gatewayAccountIdsToUpdate)).thenReturn(true);
+
+        updater.doUpdate(serviceId, request);
+
+        verify(serviceEntity,times(0)).addGatewayAccountIds(gatewayAccountIdsToUpdate.toArray(new String[0]));
+        verify(serviceDao, times(0)).merge(serviceEntity);
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void shouldError_IfInvalidPathIsSuppliedForUpdate() throws Exception {
+        String serviceId = randomUuid();
+        ServiceUpdateRequest request = mock(ServiceUpdateRequest.class);
+        ServiceEntity serviceEntity = mock(ServiceEntity.class);
+        List<String> gatewayAccountIdsToUpdate = asList("blah");
+
+        when(request.getPath()).thenReturn("blah");
+        when(serviceDao.findByExternalId(serviceId)).thenReturn(Optional.of(serviceEntity));
+
+        updater.doUpdate(serviceId, request);
+
+        verify(serviceEntity,times(0)).addGatewayAccountIds(gatewayAccountIdsToUpdate.toArray(new String[0]));
+        verify(serviceEntity,times(0)).setName("blah");
+        verify(serviceDao, times(0)).merge(serviceEntity);
+    }
+
+
+}


### PR DESCRIPTION
Currently supported operation are 

 - to update service name (`op`=`replace` and `path`=`name`)
 - to update assign new gateway account ids (`op`=`add` and `path`=`gateway_account_ids`)

Updated tests case and readme