### PR TITLE
PP-2147 Fix service invite email couple of scenarios

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -492,7 +492,9 @@ Content-Type: application/json
 
 ## PATCH /v1/api/services/{serviceExternalId}
 
-This endpoint creates an invitation to allow self provisioning new service with Pay.
+This endpoint modifies updatable attributes of a Service. Currently supports
+ - Update the name of a service
+ - Add new gateway account(s) to a service.
 
 ### Request example
 

--- a/src/main/java/uk/gov/pay/adminusers/app/config/NotifyConfiguration.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/NotifyConfiguration.java
@@ -35,6 +35,10 @@ public class NotifyConfiguration extends Configuration {
     @NotNull
     private String inviteServiceUserExistsEmailTemplateId;
 
+    @Valid
+    @NotNull
+    private String inviteServiceUserDisabledEmailTemplateId;
+
     public String getApiKey() {
         return apiKey;
     }
@@ -61,5 +65,9 @@ public class NotifyConfiguration extends Configuration {
 
     public String getInviteServiceUserExistsEmailTemplateId() {
         return inviteServiceUserExistsEmailTemplateId;
+    }
+
+    public String getInviteServiceUserDisabledEmailTemplateId() {
+        return inviteServiceUserDisabledEmailTemplateId;
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteCreator.java
@@ -51,7 +51,7 @@ public class InviteCreator {
             if (!user.isDisabled()) {
                 sendUserExitsNotification(requestEmail, user.getExternalId());
             } else {
-                //TODO: what should we do here: Discuss with stephen m ??
+                sendUserDisabledNotification(requestEmail, user.getExternalId());
             }
             throw conflictingEmail(requestEmail);
         }
@@ -77,6 +77,16 @@ public class InviteCreator {
                 })
                 .orElseThrow(() -> internalServerError(format("Role [%s] not a valid role for creating a invite service request", inviteServiceRequest.getRoleName())));
 
+    }
+
+    private void sendUserDisabledNotification(String email, String userExternalId) {
+        notificationService.sendServiceInviteUserDisabledEmail(email, linksConfig.getSupportUrl())
+                .thenAcceptAsync(notificationId -> LOGGER.info("sent create service, user account disabled email successfully, notification id [{}]", notificationId))
+                .exceptionally(exception -> {
+                    LOGGER.error("error sending service creation, user account disabled email", exception);
+                    return null;
+                });
+        LOGGER.info("Disabled existing user tried to create a service - user_id={}", userExternalId);
     }
 
     private void sendUserExitsNotification(String email, String userExternalId) {

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteCreator.java
@@ -16,6 +16,7 @@ import javax.inject.Inject;
 import java.util.Optional;
 
 import static java.lang.String.format;
+import static javax.ws.rs.core.UriBuilder.fromUri;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.model.InviteType.SERVICE;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.*;
@@ -60,7 +61,7 @@ public class InviteCreator {
         if (inviteOptional.isPresent()) {
             InviteEntity foundInvite = inviteOptional.get();
             if (!foundInvite.isExpired() && !foundInvite.isDisabled()) {
-                //TODO: what should we do here: Discuss with stephen m ??
+                sendUserInviteNotification(foundInvite);
                 throw conflictingInvite(requestEmail);
             }
         }
@@ -77,6 +78,18 @@ public class InviteCreator {
                 })
                 .orElseThrow(() -> internalServerError(format("Role [%s] not a valid role for creating a invite service request", inviteServiceRequest.getRoleName())));
 
+    }
+
+    private void sendUserInviteNotification(InviteEntity invite) {
+        String inviteUrl = fromUri(linksConfig.getSelfserviceInvitesUrl()).path(invite.getCode()).build().toString();
+        UserEntity sender = invite.getSender();
+        notificationService.sendInviteEmail(sender.getEmail(), invite.getEmail(), inviteUrl)
+                .thenAcceptAsync(notificationId -> LOGGER.info("invite resent successfully to user, notification id [{}]", notificationId))
+                .exceptionally(exception -> {
+                    LOGGER.error("error resending invite email to user for invite [{}]", invite.getCode(), exception);
+                    return null;
+                });
+        LOGGER.info("Invitation resent [{}]", invite.getCode());
     }
 
     private void sendUserDisabledNotification(String email, String userExternalId) {

--- a/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
@@ -87,6 +87,12 @@ public class NotificationService {
         return sendEmailAsync(notifyConfiguration.getInviteServiceUserExistsEmailTemplateId(), email, personalisation);
     }
 
+    CompletableFuture<String> sendServiceInviteUserDisabledEmail(String email, String supportUrl) {
+        HashMap<String, String> personalisation = newHashMap();
+        personalisation.put("feedback_link", supportUrl);
+        return sendEmailAsync(notifyConfiguration.getInviteServiceUserDisabledEmailTemplateId(), email, personalisation);
+    }
+
     private CompletableFuture<String> sendEmailAsync(final String templateId, final String email, final Map<String, String> personalisation) {
         return CompletableFuture.supplyAsync(() -> {
             Stopwatch responseTimeStopwatch = Stopwatch.createStarted();

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -67,6 +67,7 @@ notify:
   forgottenPasswordEmailTemplateId: ${NOTIFY_FORGOTTEN_PASSWORD_EMAIL_TEMPLATE_ID:-pay-notify-forgotten-password-email-template-id}
   inviteServiceEmailTemplateId: ${NOTIFY_INVITE_SERVICE_EMAIL_TEMPLATE_ID:-pay-notify-invite-service-email-template-id}
   inviteServiceUserExistsEmailTemplateId: ${NOTIFY_INVITE_SERVICE_USER_EXITS_EMAIL_TEMPLATE_ID:-pay-notify-invite-service-user-exists-email-template-id}
+  inviteServiceUserDisabledEmailTemplateId: ${NOTIFY_INVITE_SERVICE_USER_DISABLED_EMAIL_TEMPLATE_ID:-pay-notify-invite-service-user-disabled-email-template-id}
 
 forgottenPasswordExpiryMinutes: ${FORGOTTEN_PASSWORD_EXPIRY_MINUTES:-90}
 

--- a/src/test/java/uk/gov/pay/adminusers/service/InviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/InviteCreatorTest.java
@@ -111,6 +111,24 @@ public class InviteCreatorTest {
     }
 
     @Test
+    public void shouldError_ifUserAlreadyExistsAndDisabledWithGivenEmail() throws Exception {
+        String email = "email@example.gov.uk";
+        InviteServiceRequest request = new InviteServiceRequest("password", email, "08976543215");
+        UserEntity existingUserEntity = new UserEntity();
+        existingUserEntity.setDisabled(true);
+        when(userDao.findByEmail(email)).thenReturn(Optional.of(existingUserEntity));
+        when(linksConfig.getSupportUrl()).thenReturn("http://frontend");
+        when(notificationService.sendServiceInviteUserDisabledEmail(eq(email), anyString()))
+                .thenReturn(CompletableFuture.completedFuture("done"));
+
+        thrown.expect(WebApplicationException.class);
+        thrown.expectMessage("HTTP 409 Conflict");
+
+        inviteCreator.doCreate(request);
+
+    }
+
+    @Test
     public void shouldError_ifUserAlreadyHasAValidInvitationWithGivenEmail() throws Exception {
         String email = "email@example.gov.uk";
         InviteServiceRequest request = new InviteServiceRequest("password", email, "08976543215");

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -67,6 +67,7 @@ notify:
   forgottenPasswordEmailTemplateId: ${NOTIFY_FORGOTTEN_PASSWORD_EMAIL_TEMPLATE_ID:-pay-notify-forgotten-password-email-template-id}
   inviteServiceEmailTemplateId: ${NOTIFY_INVITE_SERVICE_EMAIL_TEMPLATE_ID:-pay-notify-invite-service-email-template-id}
   inviteServiceUserExistsEmailTemplateId: ${NOTIFY_INVITE_SERVICE_USER_EXITS_EMAIL_TEMPLATE_ID:-pay-notify-invite-service-user-exists-email-template-id}
+  inviteServiceUserDisabledEmailTemplateId: ${NOTIFY_INVITE_SERVICE_USER_DISABLED_EMAIL_TEMPLATE_ID:-pay-notify-invite-service-user-disabled-email-template-id}
 
 forgottenPasswordExpiryMinutes: ${FORGOTTEN_PASSWORD_EXPIRY_MINUTES:-90}
 


### PR DESCRIPTION
As per discussion with Tim macavoy and Stephen M., adding extra notifications during unhappy paths.

1. self service creation, user exists and disabled scenario.
2. if a valid invite exits during self service creation, resend the invite.

with @maxcbc 