### PR TITLE
PP-2147 Refactor Invitation Logic

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/model/InviteUserRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/InviteUserRequest.java
@@ -2,26 +2,47 @@ package uk.gov.pay.adminusers.model;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
-import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
-
 public class InviteUserRequest extends InviteRequest {
 
     public static final String FIELD_SENDER = "sender";
+    public static final String FIELD_SERVICE_EXTERNAL_ID = "service_external_id";
 
     private final String sender;
 
-    private InviteUserRequest(String sender, String email, String roleName, String otpKey) {
+    private String serviceExternalId;
+
+    private InviteUserRequest(String sender, String email, String roleName, String otpKey, String serviceExternalId) {
         super(roleName, email, otpKey);
         this.sender = sender;
+        this.serviceExternalId = serviceExternalId;
     }
 
     public static InviteUserRequest from(JsonNode jsonNode) {
-        return new InviteUserRequest(jsonNode.get(FIELD_SENDER).asText(), jsonNode.get(FIELD_EMAIL).asText(), jsonNode.get(FIELD_ROLE_NAME).asText(), getOrElseRandom(jsonNode.get(FIELD_OTP_KEY)));
+        return new InviteUserRequest(
+                jsonNode.get(FIELD_SENDER).asText(),
+                jsonNode.get(FIELD_EMAIL).asText(),
+                jsonNode.get(FIELD_ROLE_NAME).asText(),
+                getOrElseRandom(jsonNode.get(FIELD_OTP_KEY)),
+                jsonNode.get(FIELD_SERVICE_EXTERNAL_ID).asText()
+        );
+    }
+
+    @Deprecated
+    public static InviteUserRequest from(JsonNode jsonNode, String serviceExternalId) {
+        return new InviteUserRequest(jsonNode.get(FIELD_SENDER).asText(),
+                jsonNode.get(FIELD_EMAIL).asText(),
+                jsonNode.get(FIELD_ROLE_NAME).asText(),
+                getOrElseRandom(jsonNode.get(FIELD_OTP_KEY)),
+                serviceExternalId
+        );
     }
 
     public String getSender() {
         return sender;
+    }
+
+    public String getServiceExternalId() {
+        return serviceExternalId;
     }
 
 }

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
@@ -200,6 +200,7 @@ public class InviteEntity extends AbstractEntity {
         this.type = type.getType();
     }
 
+    @Deprecated //use toInvite() instead
     public Invite toInvite(String inviteUrl) {
         Invite invite = toInvite();
         invite.setInviteLink(inviteUrl);

--- a/src/main/java/uk/gov/pay/adminusers/resources/InviteRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InviteRequestValidator.java
@@ -30,8 +30,14 @@ public class InviteRequestValidator {
         this.requestValidations = requestValidations;
     }
 
+    @Deprecated // Use the validateCreateUserRequest method instead
     public Optional<Errors> validateCreateRequest(JsonNode payload) {
         Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExists(payload, FIELD_EMAIL, FIELD_ROLE_NAME, FIELD_SENDER);
+        return missingMandatoryFields.map(Errors::from);
+    }
+
+    public Optional<Errors> validateCreateUserRequest(JsonNode payload) {
+        Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExists(payload, FIELD_SERVICE_EXTERNAL_ID, FIELD_EMAIL, FIELD_ROLE_NAME, FIELD_SENDER);
         return missingMandatoryFields.map(Errors::from);
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
@@ -60,9 +60,23 @@ public class InviteResource {
         return inviteValidator.validateCreateServiceRequest(payload)
                 .map(errors -> Response.status(BAD_REQUEST).entity(errors).build())
                 .orElseGet(() -> {
-                    Invite invite = inviteServiceFactory.serviceInvite().doCreate(InviteServiceRequest.from(payload));
+                    Invite invite = inviteServiceFactory.serviceInvite().doInvite(InviteServiceRequest.from(payload));
                     return Response.status(CREATED).entity(invite).build();
                 });
+    }
+
+    @POST
+    @Path("/user")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    public Response createUserInvite(JsonNode payload) {
+        LOGGER.info("Initiating user invitation request");
+        return inviteValidator.validateCreateUserRequest(payload)
+                .map(errors -> Response.status(BAD_REQUEST).entity(errors).build())
+                .orElseGet(() -> inviteServiceFactory.userInvite().doInvite(InviteUserRequest.from(payload))
+                        .map(invite -> Response.status(CREATED).entity(invite).build())
+                        .orElseGet(() -> Response.status(NOT_FOUND).build())
+                );
     }
 
     @POST

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
@@ -127,13 +127,14 @@ public class ServiceResource {
     @Path("/{serviceId}/invites")
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
+    @Deprecated
     public Response createServiceInvite(@PathParam("serviceId") Integer serviceId, JsonNode payload) {
 
         LOGGER.info("Invite CREATE request for service - [ {} ]", serviceId);
 
         return inviteValidator.validateCreateRequest(payload)
                 .map(errors -> Response.status(BAD_REQUEST).entity(errors).build())
-                .orElseGet(() -> inviteService.create(InviteUserRequest.from(payload), serviceId)
+                .orElseGet(() -> inviteService.create(InviteUserRequest.from(payload, "deprecated method does not use external id"), serviceId)
                         .map(invite -> Response.status(CREATED).entity(invite).build())
                         .orElseGet(() -> Response.status(NOT_FOUND).build()));
     }

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteServiceFactory.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteServiceFactory.java
@@ -3,5 +3,7 @@ package uk.gov.pay.adminusers.service;
 
 public interface InviteServiceFactory {
 
-    InviteCreator serviceInvite();
+    ServiceInviteCreator serviceInvite();
+
+    UserInviteCreator userInvite();
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/UserInviteCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserInviteCreator.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import static java.lang.String.format;
 import static javax.ws.rs.core.UriBuilder.fromUri;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
+import static uk.gov.pay.adminusers.model.InviteType.USER;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.*;
 
 public class UserInviteCreator {
@@ -72,6 +73,7 @@ public class UserInviteCreator {
                     Optional<UserEntity> userSender = userDao.findByExternalId(inviteUserRequest.getSender());
                     if (userSender.isPresent() && userSender.get().canInviteUsersTo(serviceEntity.getId())) {
                         InviteEntity inviteEntity = new InviteEntity(inviteUserRequest.getEmail(), randomUuid(), inviteUserRequest.getOtpKey(), userSender.get(), serviceEntity, role);
+                        inviteEntity.setType(USER);
                         inviteDao.persist(inviteEntity);
                         String inviteUrl = fromUri(linksConfig.getSelfserviceInvitesUrl()).path(inviteEntity.getCode()).build().toString();
                         sendUserInviteNotification(inviteEntity, inviteUrl);

--- a/src/main/java/uk/gov/pay/adminusers/service/UserInviteCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserInviteCreator.java
@@ -1,0 +1,98 @@
+package uk.gov.pay.adminusers.service;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+import org.slf4j.Logger;
+import uk.gov.pay.adminusers.app.config.LinksConfig;
+import uk.gov.pay.adminusers.logger.PayLoggerFactory;
+import uk.gov.pay.adminusers.model.Invite;
+import uk.gov.pay.adminusers.model.InviteUserRequest;
+import uk.gov.pay.adminusers.persistence.dao.InviteDao;
+import uk.gov.pay.adminusers.persistence.dao.RoleDao;
+import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
+import uk.gov.pay.adminusers.persistence.dao.UserDao;
+import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
+import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
+import uk.gov.pay.adminusers.persistence.entity.UserEntity;
+
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static javax.ws.rs.core.UriBuilder.fromUri;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
+import static uk.gov.pay.adminusers.service.AdminUsersExceptions.*;
+
+public class UserInviteCreator {
+
+    private static final Logger LOGGER = PayLoggerFactory.getLogger(UserInviteCreator.class);
+
+    private final InviteDao inviteDao;
+    private final UserDao userDao;
+    private final RoleDao roleDao;
+    private final LinksConfig linksConfig;
+    private final NotificationService notificationService;
+    private final ServiceDao serviceDao;
+
+    @Inject
+    public UserInviteCreator(InviteDao inviteDao, UserDao userDao, RoleDao roleDao, LinksConfig linksConfig, NotificationService notificationService, ServiceDao serviceDao) {
+        this.inviteDao = inviteDao;
+        this.userDao = userDao;
+        this.roleDao = roleDao;
+        this.linksConfig = linksConfig;
+        this.notificationService = notificationService;
+        this.serviceDao = serviceDao;
+    }
+
+    @Transactional
+    public Optional<Invite> doInvite(InviteUserRequest inviteUserRequest) {
+
+        if (userDao.findByEmail(inviteUserRequest.getEmail()).isPresent()) {
+            throw conflictingEmail(inviteUserRequest.getEmail());
+        }
+
+        Optional<InviteEntity> inviteOptional = inviteDao.findByEmail(inviteUserRequest.getEmail());
+        if (inviteOptional.isPresent()) {
+            // When multiple services support is implemented
+            // then this should include serviceId
+            InviteEntity foundInvite = inviteOptional.get();
+            if (Boolean.FALSE.equals(foundInvite.isExpired()) &&
+                    Boolean.FALSE.equals(foundInvite.isDisabled())) {
+                throw conflictingInvite(inviteUserRequest.getEmail());
+            }
+        }
+
+        Optional<ServiceEntity> serviceEntityOptional = serviceDao.findByExternalId(inviteUserRequest.getServiceExternalId());
+        if(!serviceEntityOptional.isPresent()) {
+            return Optional.empty();
+        }
+
+        ServiceEntity serviceEntity = serviceEntityOptional.get();
+        return roleDao.findByRoleName(inviteUserRequest.getRoleName())
+                .map(role -> {
+                    Optional<UserEntity> userSender = userDao.findByExternalId(inviteUserRequest.getSender());
+                    if (userSender.isPresent() && userSender.get().canInviteUsersTo(serviceEntity.getId())) {
+                        InviteEntity inviteEntity = new InviteEntity(inviteUserRequest.getEmail(), randomUuid(), inviteUserRequest.getOtpKey(), userSender.get(), serviceEntity, role);
+                        inviteDao.persist(inviteEntity);
+                        String inviteUrl = fromUri(linksConfig.getSelfserviceInvitesUrl()).path(inviteEntity.getCode()).build().toString();
+                        sendUserInviteNotification(inviteEntity, inviteUrl);
+                        Invite invite = inviteEntity.toInvite();
+                        invite.setInviteLink(inviteUrl);
+                        return Optional.of(invite);
+                    } else {
+                        throw forbiddenOperationException(inviteUserRequest.getSender(), "invite", serviceEntity.getId());
+                    }
+                })
+                .orElseThrow(() -> undefinedRoleException(inviteUserRequest.getRoleName()));
+    }
+
+    private void sendUserInviteNotification(InviteEntity inviteEntity, String inviteUrl) {
+        UserEntity sender = inviteEntity.getSender();
+        notificationService.sendInviteEmail(inviteEntity.getSender().getEmail(), inviteEntity.getEmail(), inviteUrl)
+                .thenAcceptAsync(notificationId -> LOGGER.info("sent invite email successfully by user [{}], notification id [{}]", sender.getExternalId(), notificationId))
+                .exceptionally(exception -> {
+                    LOGGER.error(format("error sending email by user [%s]", sender.getExternalId()), exception);
+                    return null;
+                });
+        LOGGER.info("New invite created by User [{}]", sender.getExternalId());
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
@@ -17,6 +17,7 @@ public class UserDbFixture {
     private final DatabaseTestHelper databaseTestHelper;
     private Service service;
     private Integer serviceId;
+    private String serviceExternalId;
     private Integer roleId;
     private String externalId = randomUuid();
     private String username = RandomStringUtils.randomAlphabetic(10);
@@ -45,9 +46,19 @@ public class UserDbFixture {
         return user;
     }
 
+    @Deprecated // May be removed when all moved to using serviceExternalId instead of serviceId
     public UserDbFixture withServiceRole(int serviceId, int roleId) {
-        this.service = Service.from(serviceId, randomUuid(), Service.DEFAULT_NAME_VALUE);
+        this.serviceExternalId = randomUuid();
+        this.service = Service.from(serviceId, serviceExternalId, Service.DEFAULT_NAME_VALUE);
         this.serviceId = serviceId;
+        this.roleId = roleId;
+        return this;
+    }
+
+    public UserDbFixture withServiceRole(String serviceExternalId, int roleId) {
+        this.serviceExternalId = serviceExternalId;
+        this.serviceId = randomInt();
+        this.service = Service.from(serviceId, serviceExternalId, Service.DEFAULT_NAME_VALUE);
         this.roleId = roleId;
         return this;
     }

--- a/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
@@ -22,7 +22,10 @@ public class IntegrationTest {
     static final String INVITES_GENERATE_OTP_RESOURCE_URL = "/v1/api/invites/otp/generate";
     static final String INVITES_RESEND_OTP_RESOURCE_URL = "/v1/api/invites/otp/resend";
     static final String INVITES_VALIDATE_OTP_RESOURCE_URL = "/v1/api/invites/otp/validate";
+    @Deprecated
     static final String SERVICE_INVITES_RESOURCE_URL = "/v1/api/services/%d/invites";
+    static final String INVITE_USER_RESOURCE_URL = "/v1/api/invites/user";
+    static final String INVITE_SERVICE_RESOURCE_URL = "/v1/api/invites/service";
 
     @ClassRule
     public static DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule();

--- a/src/test/java/uk/gov/pay/adminusers/service/InviteServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/InviteServiceTest.java
@@ -376,7 +376,7 @@ public class InviteServiceTest {
         json.put(FIELD_SENDER, sender);
         json.put(FIELD_EMAIL, email);
         json.put(FIELD_ROLE_NAME, roleName);
-        return InviteUserRequest.from(json);
+        return InviteUserRequest.from(json, randomUuid());
     }
 
     private InviteOtpRequest inviteOtpRequestFrom(String code, String telephoneNumber, String password) {

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCreatorTest.java
@@ -11,6 +11,7 @@ import uk.gov.pay.adminusers.model.InviteServiceRequest;
 import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.dao.RoleDao;
+import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
 import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
@@ -29,7 +30,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
-public class InviteCreatorTest {
+public class ServiceInviteCreatorTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
     private NotificationService notificationService = mock(NotificationService.class);
@@ -38,11 +39,11 @@ public class InviteCreatorTest {
     private UserDao userDao = mock(UserDao.class);
     private RoleDao roleDao = mock(RoleDao.class);
     private ArgumentCaptor<InviteEntity> persistedInviteEntity = ArgumentCaptor.forClass(InviteEntity.class);
-    private InviteCreator inviteCreator;
+    private ServiceInviteCreator serviceInviteCreator;
 
     @Before
     public void before() throws Exception {
-        inviteCreator = new InviteCreator(inviteDao, userDao, roleDao, new LinksBuilder("http://localhost/"), linksConfig, notificationService);
+        serviceInviteCreator = new ServiceInviteCreator(inviteDao, userDao, roleDao, new LinksBuilder("http://localhost/"), linksConfig, notificationService);
     }
 
     @Test
@@ -57,7 +58,7 @@ public class InviteCreatorTest {
         when(linksConfig.getSelfserviceInvitesUrl()).thenReturn("http://selfservice/invites");
         when(linksConfig.getSelfserviceUrl()).thenReturn("http://selfservice");
 
-        Invite invite = inviteCreator.doCreate(request);
+        Invite invite = serviceInviteCreator.doInvite(request);
 
         verify(inviteDao, times(1)).persist(persistedInviteEntity.capture());
         assertThat(invite.getEmail(), is(request.getEmail()));
@@ -80,7 +81,7 @@ public class InviteCreatorTest {
         }));
         when(linksConfig.getSelfserviceUrl()).thenReturn("http://selfservice");
         when(linksConfig.getSelfserviceInvitesUrl()).thenReturn("http://selfservice/invites");
-        Invite invite = inviteCreator.doCreate(request);
+        Invite invite = serviceInviteCreator.doInvite(request);
 
         verify(inviteDao, times(1)).persist(persistedInviteEntity.capture());
         assertThat(invite.getEmail(), is(request.getEmail()));
@@ -107,7 +108,7 @@ public class InviteCreatorTest {
         thrown.expect(WebApplicationException.class);
         thrown.expectMessage("HTTP 409 Conflict");
 
-        inviteCreator.doCreate(request);
+        serviceInviteCreator.doInvite(request);
 
     }
 
@@ -125,7 +126,7 @@ public class InviteCreatorTest {
         thrown.expect(WebApplicationException.class);
         thrown.expectMessage("HTTP 409 Conflict");
 
-        inviteCreator.doCreate(request);
+        serviceInviteCreator.doInvite(request);
 
     }
 
@@ -149,7 +150,7 @@ public class InviteCreatorTest {
         thrown.expect(WebApplicationException.class);
         thrown.expectMessage("HTTP 409 Conflict");
 
-        inviteCreator.doCreate(request);
+        serviceInviteCreator.doInvite(request);
     }
 
     @Test
@@ -163,6 +164,6 @@ public class InviteCreatorTest {
         thrown.expect(WebApplicationException.class);
         thrown.expectMessage("HTTP 500 Internal Server Error");
 
-        inviteCreator.doCreate(request);
+        serviceInviteCreator.doInvite(request);
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCreatorTest.java
@@ -38,12 +38,13 @@ public class ServiceInviteCreatorTest {
     private InviteDao inviteDao = mock(InviteDao.class);
     private UserDao userDao = mock(UserDao.class);
     private RoleDao roleDao = mock(RoleDao.class);
+    private PasswordHasher passwordHasher = mock(PasswordHasher.class);
     private ArgumentCaptor<InviteEntity> persistedInviteEntity = ArgumentCaptor.forClass(InviteEntity.class);
     private ServiceInviteCreator serviceInviteCreator;
 
     @Before
     public void before() throws Exception {
-        serviceInviteCreator = new ServiceInviteCreator(inviteDao, userDao, roleDao, new LinksBuilder("http://localhost/"), linksConfig, notificationService);
+        serviceInviteCreator = new ServiceInviteCreator(inviteDao, userDao, roleDao, new LinksBuilder("http://localhost/"), linksConfig, notificationService, passwordHasher);
     }
 
     @Test
@@ -57,6 +58,7 @@ public class ServiceInviteCreatorTest {
         when(notificationService.sendServiceInviteEmail(eq(email), anyString())).thenReturn(CompletableFuture.completedFuture("done"));
         when(linksConfig.getSelfserviceInvitesUrl()).thenReturn("http://selfservice/invites");
         when(linksConfig.getSelfserviceUrl()).thenReturn("http://selfservice");
+        when(passwordHasher.hash("password")).thenReturn("encrypted-password");
 
         Invite invite = serviceInviteCreator.doInvite(request);
 
@@ -66,6 +68,7 @@ public class ServiceInviteCreatorTest {
         assertThat(invite.getType(), is("service"));
         assertThat(invite.getLinks().get(0).getHref(), matchesPattern("^http://selfservice/invites/[0-9a-z]{32}$"));
 
+        assertThat(persistedInviteEntity.getValue().getPassword(), is("encrypted-password"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
@@ -1,0 +1,206 @@
+package uk.gov.pay.adminusers.service;
+
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import uk.gov.pay.adminusers.app.config.AdminUsersConfig;
+import uk.gov.pay.adminusers.app.config.LinksConfig;
+import uk.gov.pay.adminusers.model.Invite;
+import uk.gov.pay.adminusers.model.InviteUserRequest;
+import uk.gov.pay.adminusers.model.Service;
+import uk.gov.pay.adminusers.model.User;
+import uk.gov.pay.adminusers.persistence.dao.InviteDao;
+import uk.gov.pay.adminusers.persistence.dao.RoleDao;
+import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
+import uk.gov.pay.adminusers.persistence.dao.UserDao;
+import uk.gov.pay.adminusers.persistence.entity.*;
+
+import javax.ws.rs.WebApplicationException;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.matches;
+import static org.mockito.Mockito.*;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
+import static uk.gov.pay.adminusers.model.InviteRequest.FIELD_EMAIL;
+import static uk.gov.pay.adminusers.model.InviteRequest.FIELD_ROLE_NAME;
+import static uk.gov.pay.adminusers.model.InviteUserRequest.FIELD_SENDER;
+import static uk.gov.pay.adminusers.model.InviteUserRequest.FIELD_SERVICE_EXTERNAL_ID;
+import static uk.gov.pay.adminusers.model.Role.role;
+import static uk.gov.pay.adminusers.persistence.entity.Role.ADMIN;
+
+public class UserInviteCreatorTest {
+
+    private static final String SELFSERVICE_URL = "http://selfservice";
+
+    private RoleDao mockRoleDao = mock(RoleDao.class);
+    private ServiceDao mockServiceDao = mock(ServiceDao.class);
+    private UserDao mockUserDao = mock(UserDao.class);
+    private InviteDao mockInviteDao = mock(InviteDao.class);
+    private AdminUsersConfig mockConfig = mock(AdminUsersConfig.class);
+    private NotificationService mockNotificationService = mock(NotificationService.class);
+    private LinksConfig linksConfig = mock(LinksConfig.class);
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private UserInviteCreator userInviteCreator;
+    private ArgumentCaptor<InviteEntity> expectedInvite = ArgumentCaptor.forClass(InviteEntity.class);
+    private String senderEmail = "sender@example.com";
+    private String email = "invited@example.com";
+    private int serviceId = 1;
+    private String serviceExternalId = "3453rmeuty87t";
+    private String senderExternalId = "12345";
+    private String roleName = "view-only";
+
+    @Before
+    public void setup() {
+        LinksConfig mockLinks = mock(LinksConfig.class);
+        when(mockLinks.getSelfserviceUrl()).thenReturn(SELFSERVICE_URL);
+        when(mockConfig.getLinks()).thenReturn(mockLinks);
+        userInviteCreator = new UserInviteCreator(mockInviteDao, mockUserDao, mockRoleDao, linksConfig, mockNotificationService, mockServiceDao);
+    }
+
+    @Test
+    public void create_shouldSendNotificationOnSuccessfulInvite() throws Exception {
+
+        mocksCreateInvite();
+
+        CompletableFuture<String> notifyPromise = CompletableFuture.completedFuture("random-notify-id");
+
+        when(mockNotificationService.sendInviteEmail(eq(senderEmail), eq(email), matches("^http://selfservice/invites/[0-9a-z]{32}$")))
+                .thenReturn(notifyPromise);
+
+        userInviteCreator.doInvite(inviteRequestFrom(senderExternalId, email, roleName));
+
+        verify(mockInviteDao).persist(expectedInvite.capture());
+        InviteEntity savedInvite = expectedInvite.getValue();
+
+        assertThat(savedInvite.getEmail(), is(email));
+        assertThat(savedInvite.getOtpKey(), is(notNullValue()));
+        assertThat(savedInvite.getCode(), is(notNullValue()));
+        assertThat(notifyPromise.isDone(), is(true));
+    }
+
+    @Test
+    public void create_shouldStillCreateTheInviteFailingOnSendingEmail() throws Exception {
+
+        mocksCreateInvite();
+
+        CompletableFuture<String> errorPromise = CompletableFuture.supplyAsync(() -> {
+            throw new RuntimeException("some error from notify");
+        });
+
+        when(mockNotificationService.sendInviteEmail(eq(senderEmail), eq(email), matches("^http://selfservice/invites/[0-9a-z]{32}$")))
+                .thenReturn(errorPromise);
+
+        userInviteCreator.doInvite(inviteRequestFrom(senderExternalId, email, roleName));
+
+        verify(mockInviteDao).persist(expectedInvite.capture());
+        InviteEntity savedInvite = expectedInvite.getValue();
+
+        assertThat(savedInvite.getEmail(), is(email));
+        assertThat(savedInvite.getOtpKey(), is(notNullValue()));
+        assertThat(savedInvite.getCode(), is(notNullValue()));
+        assertThat(errorPromise.isCompletedExceptionally(), is(true));
+    }
+
+    @Test
+    public void create_shouldFailWithConflictWhenUserExists() throws Exception {
+        String existingUserEmail = "existing-user@example.com";
+        User existingUser = aUser(existingUserEmail);
+        when(mockUserDao.findByEmail(existingUserEmail)).thenReturn(Optional.of(UserEntity.from(existingUser)));
+
+        InviteUserRequest inviteUserRequest = inviteRequestFrom(senderEmail, existingUserEmail, roleName);
+
+        thrown.expect(WebApplicationException.class);
+        thrown.expectMessage("HTTP 409 Conflict");
+
+        userInviteCreator.doInvite(inviteUserRequest);
+
+    }
+
+    @Test
+    public void create_shouldFailWithConflictWhenInviteExistsAndNotExpiredAndNotDisabled() throws Exception {
+
+        InviteEntity anInvite = mocksCreateInvite();
+        when(mockInviteDao.findByEmail(email)).thenReturn(Optional.of(anInvite));
+
+        InviteUserRequest inviteUserRequest = inviteRequestFrom(senderEmail, email, roleName);
+        thrown.expect(WebApplicationException.class);
+        thrown.expectMessage("HTTP 409 Conflict");
+
+        userInviteCreator.doInvite(inviteUserRequest);
+    }
+
+    @Test
+    public void shouldReturnEmpty_ifServiceNotFound() throws Exception {
+        when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
+        when(mockServiceDao.findByExternalId(serviceExternalId)).thenReturn(Optional.empty());
+        when(mockInviteDao.findByEmail(email)).thenReturn(Optional.empty());
+        InviteUserRequest inviteUserRequest = inviteRequestFrom(senderEmail, email, roleName);
+        Optional<Invite> invite = userInviteCreator.doInvite(inviteUserRequest);
+
+        assertFalse(invite.isPresent());
+
+    }
+
+    private InviteEntity mocksCreateInvite() {
+
+        ServiceEntity service = new ServiceEntity();
+        service.setId(serviceId);
+        service.setExternalId(serviceExternalId);
+
+        when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
+        when(mockInviteDao.findByEmail(email)).thenReturn(Optional.empty());
+        when(mockServiceDao.findByExternalId(serviceExternalId)).thenReturn(Optional.of(service));
+        when(mockRoleDao.findByRoleName(roleName)).thenReturn(Optional.of(new RoleEntity()));
+        when(linksConfig.getSelfserviceInvitesUrl()).thenReturn("http://selfservice/invites");
+
+        UserEntity senderUser = new UserEntity();
+        senderUser.setExternalId(senderExternalId);
+        senderUser.setEmail(senderEmail);
+        RoleEntity role = new RoleEntity(role(ADMIN.getId(), "admin", "Admin Role"));
+        senderUser.setServiceRole(new ServiceRoleEntity(service, role));
+        when(mockUserDao.findByExternalId(senderExternalId)).thenReturn(Optional.of(senderUser));
+
+        String inviteCode = "code";
+        InviteEntity anInvite = anInvite(email, inviteCode, "otpKey", senderUser, service, role);
+        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
+
+        doNothing().when(mockInviteDao).persist(any(InviteEntity.class));
+
+        return anInvite;
+    }
+
+    private InviteEntity anInvite(String email, String code, String otpKey, UserEntity userEntity, ServiceEntity serviceEntity, RoleEntity roleEntity) {
+        return new InviteEntity(email, code, otpKey, userEntity, serviceEntity, roleEntity);
+    }
+
+    private InviteUserRequest inviteRequestFrom(String sender, String email, String roleName) {
+        ObjectNode json = JsonNodeFactory.instance.objectNode();
+        json.put(FIELD_SENDER, sender);
+        json.put(FIELD_EMAIL, email);
+        json.put(FIELD_ROLE_NAME, roleName);
+        json.put(FIELD_SERVICE_EXTERNAL_ID, serviceExternalId);
+        return InviteUserRequest.from(json);
+    }
+
+    private User aUser(String email) {
+        return User.from(randomInt(), randomUuid(), "a-username", "random-password", email, asList("1"), asList(Service.from(serviceId, serviceExternalId, Service.DEFAULT_NAME_VALUE)), "784rh", "8948924");
+    }
+
+}


### PR DESCRIPTION
This PR contains the following changes.

1. Refactored out User invitation creation to its own creator supported by InviteServicesFactory.
   (Still leaving the old resource for backward compatibility. We need to remove it after selfservice consumes the new resource)
2. Marked the old resource (and related classes/methods) as deprecated so that they can be identified and removed later on.
3. Handling service invite password
4. Handling the scenario where a user has a valid service invite but attempts another service invite creation.

with @maxcbc 