### PR TITLE
PP-1608 Remove user from a Service.

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/persistence/dao/ServiceRoleDao.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/dao/ServiceRoleDao.java
@@ -1,0 +1,17 @@
+package uk.gov.pay.adminusers.persistence.dao;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.persist.Transactional;
+import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
+
+import javax.persistence.EntityManager;
+
+@Transactional
+public class ServiceRoleDao extends JpaDao<ServiceRoleEntity> {
+
+    @Inject
+    ServiceRoleDao(Provider<EntityManager> entityManager) {
+        super(entityManager, ServiceRoleEntity.class);
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/persistence/dao/UserDao.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/dao/UserDao.java
@@ -49,7 +49,7 @@ public class UserDao extends JpaDao<UserEntity> {
                 .getResultList().stream().findFirst();
     }
 
-    public List<UserEntity> findByServiceId(Integer serviceId){
+    public List<UserEntity> findByServiceId(Integer serviceId) {
 
         String query = "SELECT s FROM ServiceRoleEntity s " +
                 "WHERE s.service.id = :serviceId ORDER BY s.user.username";

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
@@ -233,10 +233,18 @@ public class UserEntity extends AbstractEntity {
         return servicesRoles.stream().filter(serviceRoleEntity -> serviceId.equals(serviceRoleEntity.getService().getId())).findFirst();
     }
 
+    public Optional<ServiceRoleEntity> getServicesRole(String serviceExternalId) {
+        return servicesRoles.stream().filter(serviceRoleEntity -> serviceExternalId.equals(serviceRoleEntity.getService().getExternalId())).findFirst();
+    }
+
     public boolean canInviteUsersTo(Integer serviceId) {
         Optional<ServiceRoleEntity> serviceRole = this.getServicesRole(serviceId);
         return serviceRole.isPresent() &&
                 serviceRole.get().getRole().isAdmin() &&
                 serviceRole.get().getService().getId().equals(serviceId);
+    }
+
+    public void remove(ServiceRoleEntity serviceRole) {
+        servicesRoles.remove(serviceRole);
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
@@ -73,8 +73,8 @@ public class AdminUsersExceptions {
         return buildWebApplicationException(error, UNAUTHORIZED.getStatusCode());
     }
 
-    public static WebApplicationException forbiddenOperationException(String externalId, String operation, int serviceId) {
-        String error = format("user [%s] not authorised to perform operation [%s] in service [%d]", externalId, operation, serviceId);
+    public static WebApplicationException forbiddenOperationException(String externalId, String operation, String externalServiceId) {
+        String error = format("user [%s] not authorised to perform operation [%s] in service [%s]", externalId, operation, externalServiceId);
         return buildWebApplicationException(error, FORBIDDEN.getStatusCode());
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteService.java
@@ -165,7 +165,7 @@ public class InviteService {
                 sendInviteNotification(inviteEntity, inviteUrl);
                 return Optional.of(inviteEntity.toInvite(inviteUrl));
             } else {
-                throw forbiddenOperationException(invite.getSender(), "invite", serviceEntity.getId());
+                throw forbiddenOperationException(invite.getSender(), "invite", serviceEntity.getExternalId());
             }
         };
     }

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceCreator.java
@@ -22,7 +22,6 @@ public class ServiceCreator {
         this.linksBuilder = linksBuilder;
     }
 
-
     @Transactional
     public Service doCreate(Optional<String> serviceName, Optional<List<String>> gatewayAccountIdsOptional) {
         Service service = serviceName

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceServicesFactory.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceServicesFactory.java
@@ -5,4 +5,6 @@ public interface ServiceServicesFactory {
     ServiceCreator serviceCreator();
 
     ServiceUpdater serviceUpdater();
+
+    ServiceUserRemover serviceUserRemover();
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceUserRemover.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceUserRemover.java
@@ -1,0 +1,46 @@
+package uk.gov.pay.adminusers.service;
+
+import org.slf4j.Logger;
+import uk.gov.pay.adminusers.logger.PayLoggerFactory;
+import uk.gov.pay.adminusers.persistence.dao.ServiceRoleDao;
+import uk.gov.pay.adminusers.persistence.dao.UserDao;
+import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
+
+import javax.inject.Inject;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import static uk.gov.pay.adminusers.service.AdminUsersExceptions.forbiddenOperationException;
+
+public class ServiceUserRemover {
+
+    private static final Logger LOGGER = PayLoggerFactory.getLogger(ServiceUserRemover.class);
+    private static final String OPERATION = "remove user";
+
+    private final UserDao userDao;
+    private final ServiceRoleDao serviceRoleDao;
+
+    @Inject
+    public ServiceUserRemover(UserDao userDao, ServiceRoleDao serviceRoleDao) {
+        this.userDao = userDao;
+        this.serviceRoleDao = serviceRoleDao;
+    }
+
+    public void remove(String userExternalId, String removerExternalId, String serviceExternalId) {
+        LOGGER.info("User remove from service requested - serviceId={}, removerId={}, userId={}", serviceExternalId, removerExternalId, userExternalId);
+        userDao.findByExternalId(userExternalId)
+                .flatMap(userEntity -> userEntity.getServicesRole(serviceExternalId)
+                        .map(serviceUserRole -> userDao.findByExternalId(removerExternalId)
+                                .map(removerEntity -> removerEntity.getServicesRole(serviceExternalId)
+                                        .filter(isRoleAdmin())
+                                        .map(serviceRemoverRole -> Optional.of(serviceUserRole))
+                                        .orElseThrow(() -> forbiddenOperationException(userExternalId, OPERATION, serviceExternalId)))
+                                .orElseThrow(() -> forbiddenOperationException(userExternalId, OPERATION, serviceExternalId))))
+                .orElseThrow(AdminUsersExceptions::notFoundException)
+                .ifPresent(serviceRoleDao::remove);
+    }
+
+    private Predicate<ServiceRoleEntity> isRoleAdmin() {
+        return serviceRoleEntity -> serviceRoleEntity.getRole().isAdmin();
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/service/UserInviteCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserInviteCreator.java
@@ -81,7 +81,7 @@ public class UserInviteCreator {
                         invite.setInviteLink(inviteUrl);
                         return Optional.of(invite);
                     } else {
-                        throw forbiddenOperationException(inviteUserRequest.getSender(), "invite", serviceEntity.getId());
+                        throw forbiddenOperationException(inviteUserRequest.getSender(), "invite", serviceEntity.getExternalId());
                     }
                 })
                 .orElseThrow(() -> undefinedRoleException(inviteUserRequest.getRoleName()));

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
@@ -16,8 +16,6 @@ public class UserDbFixture {
 
     private final DatabaseTestHelper databaseTestHelper;
     private Service service;
-    private Integer serviceId;
-    private String serviceExternalId;
     private Integer roleId;
     private String externalId = randomUuid();
     private String username = RandomStringUtils.randomAlphabetic(10);
@@ -36,9 +34,8 @@ public class UserDbFixture {
     }
 
     public User insertUser() {
-        if (serviceId == null) {
+        if (service == null) {
             service = ServiceDbFixture.serviceDbFixture(databaseTestHelper).insertService();
-            serviceId = service.getId();
             roleId = RoleDbFixture.roleDbFixture(databaseTestHelper).insertRole().getId();
         }
         User user = User.from(randomInt(), externalId, username, password, email, gatewayAccountIds, asList(service), otpKey, telephoneNumber);
@@ -48,17 +45,13 @@ public class UserDbFixture {
 
     @Deprecated // May be removed when all moved to using serviceExternalId instead of serviceId
     public UserDbFixture withServiceRole(int serviceId, int roleId) {
-        this.serviceExternalId = randomUuid();
-        this.service = Service.from(serviceId, serviceExternalId, Service.DEFAULT_NAME_VALUE);
-        this.serviceId = serviceId;
+        this.service = Service.from(serviceId, randomUuid(), Service.DEFAULT_NAME_VALUE);
         this.roleId = roleId;
         return this;
     }
 
-    public UserDbFixture withServiceRole(String serviceExternalId, int roleId) {
-        this.serviceExternalId = serviceExternalId;
-        this.serviceId = randomInt();
-        this.service = Service.from(serviceId, serviceExternalId, Service.DEFAULT_NAME_VALUE);
+    public UserDbFixture withServiceRole(Service service, int roleId) {
+        this.service = service;
         this.roleId = roleId;
         return this;
     }

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceRoleDaoTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceRoleDaoTest.java
@@ -1,0 +1,44 @@
+package uk.gov.pay.adminusers.persistence.dao;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.adminusers.fixtures.UserDbFixture;
+import uk.gov.pay.adminusers.model.User;
+import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
+import uk.gov.pay.adminusers.persistence.entity.UserServiceId;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class ServiceRoleDaoTest extends DaoTestBase {
+
+    private ServiceRoleDao serviceRoleDao;
+
+    @Before
+    public void before() throws Exception {
+        serviceRoleDao = env.getInstance(ServiceRoleDao.class);
+    }
+
+    @Test
+    public void shouldRemoveAServiceRoleOfAUserSuccessfully() throws Exception {
+
+        User user = UserDbFixture.userDbFixture(databaseHelper).insertUser();
+        UserServiceId userServiceId = new UserServiceId();
+        userServiceId.setServiceId(user.getServices().get(0).getId());
+        userServiceId.setUserId(user.getId());
+
+        List<Map<String, Object>> serviceRoles = databaseHelper.findServiceRoleForUser(user.getId());
+        assertThat(serviceRoles.size(), is(1));
+
+        ServiceRoleEntity serviceRoleOfUser = serviceRoleDao.findById(userServiceId).get();
+
+        serviceRoleDao.remove(serviceRoleOfUser);
+
+        List<Map<String, Object>> serviceRolesAfterRemove = databaseHelper.findServiceRoleForUser(user.getId());
+
+        assertThat(serviceRolesAfterRemove.size(), is(0));
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceTest.java
@@ -1,11 +1,16 @@
 package uk.gov.pay.adminusers.resources;
 
+import com.google.common.collect.ImmutableMap;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.Role;
+import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.User;
 
 import static com.jayway.restassured.http.ContentType.JSON;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.adminusers.fixtures.RoleDbFixture.roleDbFixture;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
@@ -13,62 +18,125 @@ import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
 
 public class ServiceResourceTest extends IntegrationTest {
 
+    private int serviceId;
+    private String serviceExternalId;
+    private User userWithRoleAdminInService1;
+    private User user1WithRoleViewInService1;
+    private User user2WithRoleViewInService1;
+
+    @Before
+    public void setup() {
+
+        Role roleAdmin = roleDbFixture(databaseHelper).insertAdmin();
+        Role roleView = roleDbFixture(databaseHelper)
+                .withName("roleView")
+                .insertRole();
+        Service service = serviceDbFixture(databaseHelper).insertService();
+        serviceExternalId = service.getExternalId();
+        serviceId = service.getId();
+
+        userWithRoleAdminInService1 = userDbFixture(databaseHelper)
+                .withServiceRole(service, roleAdmin.getId())
+                .withUsername("c" + RandomStringUtils.random(10))
+                .insertUser();
+
+        user1WithRoleViewInService1 = userDbFixture(databaseHelper)
+                .withServiceRole(service, roleView.getId())
+                .withUsername("b" + RandomStringUtils.random(10))
+                .insertUser();
+
+        user2WithRoleViewInService1 = userDbFixture(databaseHelper)
+                .withServiceRole(service, roleView.getId())
+                .withUsername("a" + RandomStringUtils.random(10))
+                .insertUser();
+    }
+
     @Test
-    public void shouldReturnListOfAllUsersWithRolesForAGivenServiceOrderedByUsername() {
-        Role role1 = roleDbFixture(databaseHelper)
-                .withName("roleB")
-                .insertRole();
-        Role role2 = roleDbFixture(databaseHelper)
-                .withName("roleA")
-                .insertRole();
-
-        int serviceId1 = serviceDbFixture(databaseHelper).insertService().getId();
-        int serviceId2 = serviceDbFixture(databaseHelper).insertService().getId();
-
-        User user1 = userDbFixture(databaseHelper)
-                .withUsername("zoe")
-                .withServiceRole(serviceId1, role1.getId()).insertUser();
-        User user2 = userDbFixture(databaseHelper)
-                .withUsername("tim")
-                .withServiceRole(serviceId1, role2.getId()).insertUser();
-        User user3 = userDbFixture(databaseHelper)
-                .withUsername("bob")
-                .withServiceRole(serviceId1, role2.getId()).insertUser();
-
-        userDbFixture(databaseHelper)
-                .withServiceRole(serviceId2, role1.getId()).insertUser();
+    public void getUsers_shouldReturnListOfAllUsersWithRolesForAGivenServiceOrderedByUsername() {
 
         givenSetup()
                 .when()
                 .accept(JSON)
-                .get(String.format("/v1/api/services/%s/users", serviceId1))
+                .get(String.format("/v1/api/services/%s/users", serviceId))
                 .then()
                 .statusCode(200)
                 .body("$", hasSize(3))
-                .body("[0].username", is(user3.getUsername()))
+                .body("[0].username", is(user2WithRoleViewInService1.getUsername()))
                 .body("[0]._links", hasSize(1))
-                .body("[0]._links[0].href", is("http://localhost:8080/v1/api/users/" + user3.getExternalId()))
+                .body("[0]._links[0].href", is("http://localhost:8080/v1/api/users/" + user2WithRoleViewInService1.getExternalId()))
                 .body("[0]._links[0].method", is("GET"))
                 .body("[0]._links[0].rel", is("self"))
-                .body("[1].username", is(user2.getUsername()))
+                .body("[1].username", is(user1WithRoleViewInService1.getUsername()))
                 .body("[1]._links", hasSize(1))
-                .body("[1]._links[0].href", is("http://localhost:8080/v1/api/users/" + user2.getExternalId()))
+                .body("[1]._links[0].href", is("http://localhost:8080/v1/api/users/" + user1WithRoleViewInService1.getExternalId()))
                 .body("[1]._links[0].method", is("GET"))
                 .body("[1]._links[0].rel", is("self"))
-                .body("[2].username", is(user1.getUsername()))
+                .body("[2].username", is(userWithRoleAdminInService1.getUsername()))
                 .body("[2]._links", hasSize(1))
-                .body("[2]._links[0].href", is("http://localhost:8080/v1/api/users/" + user1.getExternalId()))
+                .body("[2]._links[0].href", is("http://localhost:8080/v1/api/users/" + userWithRoleAdminInService1.getExternalId()))
                 .body("[2]._links[0].method", is("GET"))
                 .body("[2]._links[0].rel", is("self"));
     }
 
     @Test
-    public void shouldReturn404WhenServiceDoesNotExist() {
+    public void getServiceUsers_shouldReturn404WhenServiceDoesNotExist() {
+
         givenSetup()
                 .when()
                 .accept(JSON)
                 .get("/v1/api/services/999/users")
                 .then()
                 .statusCode(404);
+    }
+
+    @Test
+    public void removeServiceUser_shouldRemoveAnUserFromAService() {
+
+        ImmutableMap<Object, Object> userRemoverPayload = ImmutableMap.builder()
+                .put("remover_id", userWithRoleAdminInService1.getExternalId())
+                .build();
+
+        givenSetup()
+                .when()
+                .accept(JSON)
+                .body(userRemoverPayload)
+                .delete(String.format("/v1/api/services/%s/users/%s", serviceExternalId, user1WithRoleViewInService1.getExternalId()))
+                .then()
+                .statusCode(204)
+                .body(isEmptyString());
+    }
+
+    @Test
+    public void removeServiceUser_shouldNotBeAbleToRemoveAnUserItself() {
+
+        ImmutableMap<Object, Object> userRemoverPayload = ImmutableMap.builder()
+                .put("remover_id", userWithRoleAdminInService1.getExternalId())
+                .build();
+
+        givenSetup()
+                .when()
+                .accept(JSON)
+                .body(userRemoverPayload)
+                .delete(String.format("/v1/api/services/%s/users/%s", serviceExternalId, userWithRoleAdminInService1.getExternalId()))
+                .then()
+                .statusCode(409)
+                .body(isEmptyString());
+    }
+
+    @Test
+    public void removeServiceUser_shouldReturnBadRequestWhenRemoverIsMissing() {
+
+        ImmutableMap<Object, Object> userRemoverPayload = ImmutableMap.builder()
+                .put("remover_id", " ")
+                .build();
+
+        givenSetup()
+                .when()
+                .accept(JSON)
+                .body(userRemoverPayload)
+                .delete(String.format("/v1/api/services/%s/users/%s", serviceExternalId, userWithRoleAdminInService1.getExternalId()))
+                .then()
+                .statusCode(400)
+                .body(isEmptyString());
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceUserRemoverTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceUserRemoverTest.java
@@ -1,0 +1,177 @@
+package uk.gov.pay.adminusers.service;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.pay.adminusers.persistence.dao.ServiceRoleDao;
+import uk.gov.pay.adminusers.persistence.dao.UserDao;
+import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
+import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
+import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
+import uk.gov.pay.adminusers.persistence.entity.UserEntity;
+
+import javax.ws.rs.WebApplicationException;
+import java.util.Optional;
+
+import static org.apache.commons.lang3.RandomStringUtils.random;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.*;
+import static uk.gov.pay.adminusers.persistence.entity.Role.ADMIN;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ServiceUserRemoverTest {
+
+    private ServiceUserRemover service;
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    @Mock
+    private UserDao mockUserDao;
+
+    @Mock
+    private ServiceRoleDao mockServiceRoleDao;
+
+    @Before
+    public void setupServiceUserRemover() {
+        service = new ServiceUserRemover(mockUserDao, mockServiceRoleDao);
+    }
+
+    @Test
+    public void remove_shouldRemoveAUserFromAService() throws Exception {
+
+        String serviceExternalId = "service-external-id-1";
+        String removerExternalId = "user-admin-of-service-1";
+        String userExternalId = "user-to-be-removed-from-service-1";
+
+        ServiceRoleEntity userServiceRole = aServiceRole(serviceExternalId, 666);
+        UserEntity userToBeRemoved = createUser(userExternalId, userServiceRole);
+        UserEntity removerAsAdminOfService = createUser(removerExternalId, aServiceRole(serviceExternalId, ADMIN.getId()));
+
+        when(mockUserDao.findByExternalId(userExternalId)).thenReturn(Optional.of(userToBeRemoved));
+        when(mockUserDao.findByExternalId(removerExternalId)).thenReturn(Optional.of(removerAsAdminOfService));
+
+        service.remove(userExternalId, removerExternalId, serviceExternalId);
+
+        verify(mockServiceRoleDao).remove(userServiceRole);
+    }
+
+    @Test
+    public void remove_shouldThrowNotFoundWebApplicationException_whenUserToBeRemovedDoesNotExist() throws Exception {
+
+        String serviceExternalId = "service-external-id-1";
+        String userExternalId = "user-to-be-removed-from-a-service";
+
+        when(mockUserDao.findByExternalId(userExternalId)).thenReturn(Optional.empty());
+
+        expectedException.expect(WebApplicationException.class);
+        expectedException.expectMessage(is("HTTP 404 Not Found"));
+
+        service.remove(userExternalId, "any-remover-ext-id", serviceExternalId);
+
+        verifyZeroInteractions(mockServiceRoleDao);
+        verifyNoMoreInteractions(mockUserDao);
+    }
+
+    @Test
+    public void remove_shouldThrowNotFoundWebApplicationException_whenUserDoesNotBelongToTheGivenService() throws Exception {
+
+        String serviceExternalId = "service-external-id-1";
+        String otherServiceExternalId = "service-external-id-2";
+        String aRemoverExternalId = "user-admin-of-service-1";
+        String userExternalId = "user-to-be-removed-from-service-1";
+
+        UserEntity userToRemoveBelongsToOtherService = createUser(userExternalId, aServiceRole(otherServiceExternalId, 666));
+
+        when(mockUserDao.findByExternalId(userExternalId)).thenReturn(Optional.of(userToRemoveBelongsToOtherService));
+
+        expectedException.expect(WebApplicationException.class);
+        expectedException.expectMessage(is("HTTP 404 Not Found"));
+
+        service.remove(userExternalId, aRemoverExternalId, serviceExternalId);
+
+        verifyZeroInteractions(mockServiceRoleDao);
+        verifyNoMoreInteractions(mockUserDao);
+    }
+
+    @Test
+    public void remove_shouldThrowForbiddenWebApplicationException_whenRemoverDoesNotExist() throws Exception {
+
+        String serviceExternalId = "service-external-id-1";
+        String removerExternalId = "non-existing-remover";
+        String userExternalId = "user-to-be-removed-from-service-1";
+
+        UserEntity userToBeRemoved = createUser(userExternalId, aServiceRole(serviceExternalId, 666));
+
+        when(mockUserDao.findByExternalId(userExternalId)).thenReturn(Optional.of(userToBeRemoved));
+        when(mockUserDao.findByExternalId(removerExternalId)).thenReturn(Optional.empty());
+
+        expectedException.expect(WebApplicationException.class);
+        expectedException.expectMessage(is("HTTP 403 Forbidden"));
+
+        service.remove(userExternalId, removerExternalId, serviceExternalId);
+
+        verifyZeroInteractions(mockServiceRoleDao);
+    }
+
+    @Test
+    public void remove_shouldThrowForbiddenWebApplicationException_whenRemoverDoesNotBelongToService() throws Exception {
+
+        String serviceExternalId = "service-external-id-1";
+        String otherServiceExternalId = "service-external-id-2";
+        String removerExternalId = "user-admin-of-service-1";
+        String userExternalId = "user-to-be-removed-from-service-1";
+
+        UserEntity userToBeRemoved = createUser(userExternalId, aServiceRole(serviceExternalId, 666));
+        UserEntity removerAsAdminOfOtherService = createUser(removerExternalId, aServiceRole(otherServiceExternalId, ADMIN.getId()));
+
+        when(mockUserDao.findByExternalId(userExternalId)).thenReturn(Optional.of(userToBeRemoved));
+        when(mockUserDao.findByExternalId(removerExternalId)).thenReturn(Optional.of(removerAsAdminOfOtherService));
+
+        expectedException.expect(WebApplicationException.class);
+        expectedException.expectMessage(is("HTTP 403 Forbidden"));
+
+        service.remove(userExternalId, removerExternalId, serviceExternalId);
+
+        verifyZeroInteractions(mockServiceRoleDao);
+    }
+
+    @Test
+    public void remove_shouldThrowForbiddenWebApplicationException_whenRemoverHasNotAdminRoleForTheGivenService() throws Exception {
+
+        String serviceExternalId = "service-external-id-1";
+        String removerExternalId = "user-admin-of-service-1";
+        String userExternalId = "user-to-be-removed-from-service-1";
+
+        UserEntity userToBeRemoved = createUser(userExternalId, aServiceRole(serviceExternalId, 666));
+        UserEntity removerAsNoAdminOfService = createUser(removerExternalId, aServiceRole(serviceExternalId, 999));
+
+        when(mockUserDao.findByExternalId(userExternalId)).thenReturn(Optional.of(userToBeRemoved));
+        when(mockUserDao.findByExternalId(removerExternalId)).thenReturn(Optional.of(removerAsNoAdminOfService));
+
+        expectedException.expect(WebApplicationException.class);
+        expectedException.expectMessage(is("HTTP 403 Forbidden"));
+
+        service.remove(userExternalId, removerExternalId, serviceExternalId);
+
+        verifyZeroInteractions(mockServiceRoleDao);
+    }
+
+    private UserEntity createUser(String externalId, ServiceRoleEntity serviceRole) {
+        final UserEntity user = new UserEntity();
+        user.setExternalId(externalId);
+        user.setExternalId(random(10));
+        user.setServiceRole(serviceRole);
+        return user;
+    }
+
+    private ServiceRoleEntity aServiceRole(String serviceExternalId, int roleId) {
+        ServiceEntity serviceEntity = new ServiceEntity();
+        serviceEntity.setExternalId(serviceExternalId);
+        RoleEntity role = new RoleEntity();
+        role.setId(roleId);
+        return new ServiceRoleEntity(serviceEntity, role);
+    }
+}


### PR DESCRIPTION
## WHAT
- Added resource (_DELETE_) to remove a user from a service `/v1/api/services/{serviceExternalId}/users/{userExternalId}`

- It requires a payload containing the external Id of the user performing the removal. Ie:
      `{
    	 "remover_id": "fahjd7237ebjhdadasd"
       }`

- Returns a `200 OK` when removing an user from a service succeeded

- Returns a `400 BAD REQUEST` when payload is malformed or remover is missing

- A users cannot remove themselves. Returns `409 Conflict` when user to be removed  is same as the remover

- User performing the removal must be Admin (`403 Forbidden` otherwise)

- If the userExternalId does not belong to the given service, returns`404 Not Found`.

- Remover does not belong to the same service or is not an Admin of the given service or does not exist it returns a `403 Forbidden`