### PR TITLE
PP-1608 Add user service delete permission

### DIFF
--- a/src/main/resources/migrations/00027_add_delete_users_permission.sql
+++ b/src/main/resources/migrations/00027_add_delete_users_permission.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:insert_users-service_delete_permission
+INSERT INTO  permissions(id, name, description) VALUES (32, 'users-service:delete', 'Remove user from a service');
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'super-admin'), (SELECT id FROM permissions  WHERE name = 'users-service:delete'), NOW(), NOW());
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'admin'), (SELECT id FROM permissions  WHERE name = 'users-service:delete'), NOW(), NOW());

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationTest.java
@@ -52,7 +52,7 @@ public class UserResourceAuthenticationTest extends IntegrationTest {
                 .body("disabled", is(false))
                 .body("_links", hasSize(1))
                 .body("role.name", is("admin"))
-                .body("permissions", hasSize(30)); //we could consider removing this assertion if the permissions constantly changing
+                .body("permissions", hasSize(31)); //we could consider removing this assertion if the permissions constantly changing
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateAndGetTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateAndGetTest.java
@@ -71,7 +71,7 @@ public class UserResourceCreateAndGetTest extends IntegrationTest {
                 .body("disabled", is(false))
                 .body("role.name", is("admin"))
                 .body("role.description", is("Administrator"))
-                .body("permissions", hasSize(30)); //we could consider removing this assertion if the permissions constantly changing
+                .body("permissions", hasSize(31)); //we could consider removing this assertion if the permissions constantly changing
         response
                 .body("_links", hasSize(1))
                 .body("_links[0].href", is("http://localhost:8080/v1/api/users/" + externalId))
@@ -132,7 +132,7 @@ public class UserResourceCreateAndGetTest extends IntegrationTest {
                 .body("disabled", is(false))
                 .body("role.name", is("admin"))
                 .body("role.description", is("Administrator"))
-                .body("permissions", hasSize(30)); //we could consider removing this assertion if the permissions constantly changing
+                .body("permissions", hasSize(31)); //we could consider removing this assertion if the permissions constantly changing
         response
                 .body("_links", hasSize(1))
                 .body("_links[0].href", is("http://localhost:8080/v1/api/users/" + externalId))


### PR DESCRIPTION
## WHAT

- Create permission `users-service:delete` permission.

- Add this permission to `admin` and `super-admin` roles.

- Many operations in adminusers relies on Roles rather than permissions (for Admin operations), this needs to be changed to rely only on permissions when `super-admin` role gets used.