### PR TITLE
PP-1608 Add pact tests for DELETE user from a service

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
@@ -133,7 +133,6 @@ public class ServiceResource {
 
     @Path("/{serviceExternalId}/users/{userExternalId}")
     @DELETE
-    @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
     public Response removeUserFromService(@PathParam("serviceExternalId") String serviceId, @PathParam("userExternalId") String userId, JsonNode payload) {
         LOGGER.info("Service users DELETE request - serviceId={}, userId={}", serviceId, userId);

--- a/src/test/java/uk/gov/pay/adminusers/pact/UsersApiTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/pact/UsersApiTest.java
@@ -11,11 +11,14 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import uk.gov.pay.adminusers.app.util.RandomIdGenerator;
+import uk.gov.pay.adminusers.fixtures.RoleDbFixture;
+import uk.gov.pay.adminusers.fixtures.ServiceDbFixture;
 import uk.gov.pay.adminusers.fixtures.UserDbFixture;
 import uk.gov.pay.adminusers.infra.DropwizardAppWithPostgresRule;
 import uk.gov.pay.adminusers.model.ForgottenPassword;
 import uk.gov.pay.adminusers.model.Permission;
 import uk.gov.pay.adminusers.model.Role;
+import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.service.PasswordHasher;
 import uk.gov.pay.adminusers.utils.DatabaseTestHelper;
 
@@ -78,6 +81,20 @@ public class UsersApiTest {
         dbHelper.add(ForgottenPassword.forgottenPassword(code, existingUserExternalId), (Integer) userByName.get(0).get("id"));
     }
 
+    @State("a user and user admin exists in service with the given ids before a delete operation")
+    public void aUserAndUserAdminExistBeforeADelete() throws Exception {
+
+        String existingUserExternalId = "pact-delete-user-id";
+        String existingUserRemoverExternalId = "pact-delete-remover-id";
+        String existingServiceExternalId = "pact-delete-service-id";
+
+        Service service = ServiceDbFixture.serviceDbFixture(dbHelper).withExternalId(existingServiceExternalId).insertService();
+        Role role = RoleDbFixture.roleDbFixture(dbHelper).insertAdmin();
+
+        UserDbFixture.userDbFixture(dbHelper).withExternalId(existingUserExternalId).withServiceRole(service, role.getId()).insertUser();
+        UserDbFixture.userDbFixture(dbHelper).withExternalId(existingUserRemoverExternalId).withServiceRole(service, role.getId()).insertUser();
+    }
+
     private static void createUserWithinAService(String externalId, String username, String password) throws Exception {
         createUserWithinAService(externalId, username, nextInt(), password);
     }
@@ -98,7 +115,7 @@ public class UsersApiTest {
     })
     public void noSetUp() {
     }
-    
+
     private static void createUserWithinAService(String externalId, String username, int serviceId, String password) throws Exception {
         String gatewayAccount1 = randomNumeric(5);
         String gatewayAccount2 = randomNumeric(5);

--- a/src/test/resources/pacts/selfservice-delete-user-adminusers.json
+++ b/src/test/resources/pacts/selfservice-delete-user-adminusers.json
@@ -1,0 +1,89 @@
+{
+  "consumer": {
+    "name": "Selfservice-delete-user"
+  },
+  "provider": {
+    "name": "adminusers-delete-with-body-no-supported-by-pact"
+  },
+  "interactions": [
+    {
+      "description": "a valid delete user from service request",
+      "provider_state": "a user and user admin exists in service with the given ids before a delete operation",
+      "request": {
+        "method": "POST",
+        "path": "/v1/api/services/pact-delete-service-id/users/pact-delete-user-id",
+        "headers": {
+          "Accept": "application/json"
+        },
+        "body": {
+          "remover_id": "pact-delete-remover-id"
+        }
+      },
+      "response": {
+        "status": 204,
+        "headers": {
+        }
+      }
+    },
+    {
+      "description": "an invalid delete user from service request as remover is missing",
+      "provider_state": "default",
+      "request": {
+        "method": "DELETE",
+        "path": "/v1/api/services/pact-delete-service-id/users/pact-delete-user-id",
+        "headers": {
+          "Accept": "application/json"
+        },
+        "body": {
+          "remover_id": " "
+        }
+      },
+      "response": {
+        "status": 400,
+        "headers": {
+        }
+      }
+    },
+    {
+      "description": "a valid delete user from service request but remover is equal to user to be removed",
+      "provider_state": "default",
+      "request": {
+        "method": "DELETE",
+        "path": "/v1/api/services/pact-delete-service-id/users/pact-delete-remover-id",
+        "headers": {
+          "Accept": "application/json"
+        },
+        "body": {
+          "remover_id": "pact-delete-remover-id"
+        }
+      },
+      "response": {
+        "status": 409,
+        "headers": {
+        }
+      }
+    },
+    {
+      "description": "an invalid delete user from service request as user does not exist",
+      "provider_state": "default",
+      "request": {
+        "method": "DELETE",
+        "path": "/v1/api/services/pact-delete-service-id/users/user-does-not-exist",
+        "headers": {
+          "Accept": "application/json"
+        },
+        "body": {
+          "remover_id": "pact-delete-remover-id"
+        }
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pactSpecificationVersion": "2.0.0"
+  }
+}


### PR DESCRIPTION
## WHAT   
 - Add file for contract testing, currently will be ignored, a new issue might be needed to be raised with `pact` since it seems it doesn't support DELETE operations with request body despite the RFC seems to allow bodies on DELETE:

- See: https://stackoverflow.com/questions/14323716/restful-alternatives-to-delete-request-body