### PR TITLE
PP-1608 Allow empty services for an user

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/model/User.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/User.java
@@ -141,12 +141,12 @@ public class User {
      */
     @JsonProperty("role")
     public Role getRole() {
-        return roles != null ? roles.get(0) : null;
+        return !roles.isEmpty() ? roles.get(0) : null;
     }
 
     @JsonProperty("permissions")
     public List<String> getPermissions() {
-        return roles != null ?
+        return !roles.isEmpty() ?
                 roles.stream()
                         .flatMap(role -> role.getPermissions().stream())
                         .map(Permission::getName)

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
@@ -34,12 +34,11 @@ public class UserDbFixture {
     }
 
     public User insertUser() {
-        if (service == null) {
-            service = ServiceDbFixture.serviceDbFixture(databaseTestHelper).insertService();
-            roleId = RoleDbFixture.roleDbFixture(databaseTestHelper).insertRole().getId();
+        User user = User.from(randomInt(), externalId, username, password, email, gatewayAccountIds, service != null ? asList(service) : null, otpKey, telephoneNumber);
+        databaseTestHelper.add(user);
+        if (service != null) {
+            databaseTestHelper.addUserServiceRole(user.getId(), service.getId(), roleId);
         }
-        User user = User.from(randomInt(), externalId, username, password, email, gatewayAccountIds, asList(service), otpKey, telephoneNumber);
-        databaseTestHelper.add(user, roleId);
         return user;
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceRoleDaoTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceRoleDaoTest.java
@@ -2,7 +2,10 @@ package uk.gov.pay.adminusers.persistence.dao;
 
 import org.junit.Before;
 import org.junit.Test;
+import uk.gov.pay.adminusers.fixtures.RoleDbFixture;
+import uk.gov.pay.adminusers.fixtures.ServiceDbFixture;
 import uk.gov.pay.adminusers.fixtures.UserDbFixture;
+import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserServiceId;
@@ -25,7 +28,9 @@ public class ServiceRoleDaoTest extends DaoTestBase {
     @Test
     public void shouldRemoveAServiceRoleOfAUserSuccessfully() throws Exception {
 
-        User user = UserDbFixture.userDbFixture(databaseHelper).insertUser();
+        Service service = ServiceDbFixture.serviceDbFixture(databaseHelper).insertService();
+        int roleId = RoleDbFixture.roleDbFixture(databaseHelper).insertRole().getId();
+        User user = UserDbFixture.userDbFixture(databaseHelper).withServiceRole(service, roleId).insertUser();
         UserServiceId userServiceId = new UserServiceId();
         userServiceId.setServiceId(user.getServices().get(0).getId());
         userServiceId.setUserId(user.getId());

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateServiceTest.java
@@ -4,17 +4,13 @@ package uk.gov.pay.adminusers.resources;
 import com.google.common.collect.ImmutableMap;
 import com.jayway.restassured.http.ContentType;
 import org.junit.Test;
-import uk.gov.pay.adminusers.model.Service;
-import uk.gov.pay.adminusers.model.User;
+import uk.gov.pay.adminusers.fixtures.UserDbFixture;
 
-import static java.util.Arrays.asList;
 import static javax.ws.rs.core.Response.Status.*;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
-import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
-import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 
 public class InviteResourceCreateServiceTest extends IntegrationTest {
 
@@ -76,10 +72,10 @@ public class InviteResourceCreateServiceTest extends IntegrationTest {
 
     @Test
     public void shouldFail_WhenEmailIsAlreadyRegistered() throws Exception {
+
         String email = "example@example.gov.uk";
-        Service service = Service.from();
-        databaseHelper.addService(service,"1");
-        databaseHelper.add(User.from(randomInt(),randomUuid(),randomUuid(),randomUuid(),email,asList("1"),asList(service),randomUuid(),"12345678909"),2);
+        UserDbFixture.userDbFixture(databaseHelper).withEmail(email).insertUser();
+
         String telephoneNumber = "088882345689";
         ImmutableMap<String, String> payload = ImmutableMap.of("telephone_number", telephoneNumber, "email", email, "password", "plain_text_password");
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceTest.java
@@ -8,10 +8,14 @@ import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.User;
 
+import java.util.List;
+import java.util.Map;
+
 import static com.jayway.restassured.http.ContentType.JSON;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 import static uk.gov.pay.adminusers.fixtures.RoleDbFixture.roleDbFixture;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
@@ -96,6 +100,9 @@ public class ServiceResourceTest extends IntegrationTest {
                 .put("remover_id", userWithRoleAdminInService1.getExternalId())
                 .build();
 
+        List<Map<String, Object>> serviceRoleForUserBefore = databaseHelper.findServiceRoleForUser(user1WithRoleViewInService1.getId());
+        assertThat(serviceRoleForUserBefore.size(), is(1));
+
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -104,6 +111,9 @@ public class ServiceResourceTest extends IntegrationTest {
                 .then()
                 .statusCode(204)
                 .body(isEmptyString());
+
+        List<Map<String, Object>> serviceRoleForUserAfter = databaseHelper.findServiceRoleForUser(user1WithRoleViewInService1.getId());
+        assertThat(serviceRoleForUserAfter.isEmpty(), is(true));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
@@ -89,7 +89,7 @@ public class DatabaseTestHelper {
         return this;
     }
 
-    public DatabaseTestHelper add(User user, int roleId) {
+    public DatabaseTestHelper add(User user) {
         Timestamp now = from(ZonedDateTime.now(ZoneId.of("UTC")).toInstant());
         jdbi.withHandle(handle ->
                 handle
@@ -111,14 +111,16 @@ public class DatabaseTestHelper {
                         .bind("updatedAt", now)
                         .execute()
         );
+        return this;
+    }
 
+    public DatabaseTestHelper addUserToAServiceRole(int userId, int serviceId, int roleId) {
         jdbi.withHandle(handle -> handle
                 .createStatement("INSERT INTO user_services_roleS(user_id, service_id, role_id) VALUES(:userId, :serviceId, :roleId)")
-                .bind("userId", user.getId())
-                .bind("serviceId", Integer.valueOf(user.getServiceIds().get(0)))
+                .bind("userId", userId)
+                .bind("serviceId", serviceId)
                 .bind("roleId", roleId)
                 .execute());
-
         return this;
     }
 


### PR DESCRIPTION
## WHAT
- Since users can be removed from all their services all the resources should not rely on users belonging to services.

- Services returns as empty for user not belonging to a service therefore happens the same with its permissions / role.