### PR TITLE
PP 1608 Delete user API - Introducing GovUkPay-User-Context

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
@@ -135,17 +135,15 @@ public class ServiceResource {
                                           @HeaderParam(HEADER_USER_CONTEXT) String userContext) {
         LOGGER.info("Service users DELETE request - serviceId={}, userId={}", serviceId, userId);
         if (isBlank(userContext)) {
-            return Response.status(Status.UNAUTHORIZED).build();
-        } else {
-            if (userId.equals(userContext)) {
-                LOGGER.info("Failed Service users DELETE request. User and Remover cannot be the same - " +
-                        "serviceId={}, removerId={}, userId={}", serviceId, userContext, userId);
-                return Response.status(CONFLICT).build();
-            }
-            serviceServicesFactory.serviceUserRemover().remove(userId, userContext, serviceId);
-            LOGGER.info("Succeeded Service users DELETE request - serviceId={}, removerId={}, userId={}", serviceId, userContext, userId);
-            return Response.status(NO_CONTENT).build();
+            return Response.status(Status.FORBIDDEN).build();
+        } else if (userId.equals(userContext)) {
+            LOGGER.info("Failed Service users DELETE request. User and Remover cannot be the same - " +
+                    "serviceId={}, removerId={}, userId={}", serviceId, userContext, userId);
+            return Response.status(CONFLICT).build();
         }
+        serviceServicesFactory.serviceUserRemover().remove(userId, userContext, serviceId);
+        LOGGER.info("Succeeded Service users DELETE request - serviceId={}, removerId={}, userId={}", serviceId, userContext, userId);
+        return Response.status(NO_CONTENT).build();
     }
 
     @POST

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
@@ -3,7 +3,6 @@ package uk.gov.pay.adminusers.resources;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.inject.Inject;
 import io.dropwizard.jersey.PATCH;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import uk.gov.pay.adminusers.logger.PayLoggerFactory;
 import uk.gov.pay.adminusers.model.InviteUserRequest;
@@ -25,6 +24,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status;
 import static javax.ws.rs.core.Response.Status.*;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static uk.gov.pay.adminusers.resources.ServiceRequestValidator.FIELD_GATEWAY_ACCOUNT_IDS;
 import static uk.gov.pay.adminusers.resources.ServiceRequestValidator.FIELD_SERVICE_NAME;
 import static uk.gov.pay.adminusers.resources.ServiceResource.SERVICES_RESOURCE;
@@ -33,8 +33,8 @@ import static uk.gov.pay.adminusers.resources.ServiceResource.SERVICES_RESOURCE;
 public class ServiceResource {
 
     private static final Logger LOGGER = PayLoggerFactory.getLogger(ServiceResource.class);
+    public static final String HEADER_USER_CONTEXT = "GovUkPay-User-Context";
     public static final String SERVICES_RESOURCE = "/v1/api/services";
-    private static final String FIELD_REMOVER = "remover_id";
 
     private final UserDao userDao;
     private final ServiceDao serviceDao;
@@ -90,17 +90,10 @@ public class ServiceResource {
     }
 
     private Optional<String> extractServiceName(JsonNode payload) {
-        if (payload == null || payload.get(FIELD_SERVICE_NAME) == null || StringUtils.isBlank(payload.get(FIELD_SERVICE_NAME).textValue())) {
+        if (payload == null || payload.get(FIELD_SERVICE_NAME) == null || isBlank(payload.get(FIELD_SERVICE_NAME).textValue())) {
             return Optional.empty();
         }
         return Optional.of(payload.get(FIELD_SERVICE_NAME).textValue());
-    }
-
-    private Optional<String> extractRemover(JsonNode payload) {
-        if (payload == null || payload.get(FIELD_REMOVER) == null || StringUtils.isBlank(payload.get(FIELD_REMOVER).textValue())) {
-            return Optional.empty();
-        }
-        return Optional.of(payload.get(FIELD_REMOVER).textValue());
     }
 
     @Path("/{serviceExternalId}")
@@ -131,23 +124,28 @@ public class ServiceResource {
                 .orElseGet(() -> Response.status(NOT_FOUND).build());
     }
 
+    // To consider for all the operations add @HeaderParam("GovUkPay-User-Context") and creating a filter
+    // so we could map permissions with Regex URLs and Http method passed on to this filter.
     @Path("/{serviceExternalId}/users/{userExternalId}")
     @DELETE
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
-    public Response removeUserFromService(@PathParam("serviceExternalId") String serviceId, @PathParam("userExternalId") String userId, JsonNode payload) {
+    public Response removeUserFromService(@PathParam("serviceExternalId") String serviceId,
+                                          @PathParam("userExternalId") String userId,
+                                          @HeaderParam(HEADER_USER_CONTEXT) String userContext) {
         LOGGER.info("Service users DELETE request - serviceId={}, userId={}", serviceId, userId);
-        return extractRemover(payload)
-                .map(remover -> {
-                    if (remover.equals(userId)) {
-                        LOGGER.info("Failed Service users DELETE request. User and Remover cannot be the same - serviceId={}, removerId={}, userId={}", serviceId, remover, userId);
-                        return Response.status(CONFLICT).build();
-                    }
-                    serviceServicesFactory.serviceUserRemover().remove(userId, remover, serviceId);
-                    LOGGER.info("Succeeded Service users DELETE request - serviceId={}, removerId={}, userId={}", serviceId, remover, userId);
-                    return Response.status(NO_CONTENT).build();
-                })
-                .orElseGet(() -> Response.status(Status.BAD_REQUEST).build());
+        if (isBlank(userContext)) {
+            return Response.status(Status.UNAUTHORIZED).build();
+        } else {
+            if (userId.equals(userContext)) {
+                LOGGER.info("Failed Service users DELETE request. User and Remover cannot be the same - " +
+                        "serviceId={}, removerId={}, userId={}", serviceId, userContext, userId);
+                return Response.status(CONFLICT).build();
+            }
+            serviceServicesFactory.serviceUserRemover().remove(userId, userContext, serviceId);
+            LOGGER.info("Succeeded Service users DELETE request - serviceId={}, removerId={}, userId={}", serviceId, userContext, userId);
+            return Response.status(NO_CONTENT).build();
+        }
     }
 
     @POST

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceTest.java
@@ -126,7 +126,7 @@ public class ServiceResourceTest extends IntegrationTest {
     }
 
     @Test
-    public void removeServiceUser_shouldReturnUnAuthorizeWhenRemoverIsMissing() {
+    public void removeServiceUser_shouldReturnForbiddenWhenRemoverIsMissing() {
 
         givenSetup()
                 .when()
@@ -134,19 +134,19 @@ public class ServiceResourceTest extends IntegrationTest {
                 .header(HEADER_USER_CONTEXT, " ")
                 .delete(String.format("/v1/api/services/%s/users/%s", serviceExternalId, userWithRoleAdminInService1.getExternalId()))
                 .then()
-                .statusCode(401)
+                .statusCode(403)
                 .body(isEmptyString());
     }
 
     @Test
-    public void removeServiceUser_shouldReturnUnAuthorizeWhenUserContextHeaderIsMissing() {
+    public void removeServiceUser_shouldReturnForbiddenWhenUserContextHeaderIsMissing() {
 
         givenSetup()
                 .when()
                 .accept(JSON)
                 .delete(String.format("/v1/api/services/%s/users/%s", serviceExternalId, userWithRoleAdminInService1.getExternalId()))
                 .then()
-                .statusCode(401)
+                .statusCode(403)
                 .body(isEmptyString());
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.adminusers.resources;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,6 +18,7 @@ import static org.junit.Assert.assertThat;
 import static uk.gov.pay.adminusers.fixtures.RoleDbFixture.roleDbFixture;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
+import static uk.gov.pay.adminusers.resources.ServiceResource.HEADER_USER_CONTEXT;
 
 public class ServiceResourceTest extends IntegrationTest {
 
@@ -96,17 +96,13 @@ public class ServiceResourceTest extends IntegrationTest {
     @Test
     public void removeServiceUser_shouldRemoveAnUserFromAService() {
 
-        ImmutableMap<Object, Object> userRemoverPayload = ImmutableMap.builder()
-                .put("remover_id", userWithRoleAdminInService1.getExternalId())
-                .build();
-
         List<Map<String, Object>> serviceRoleForUserBefore = databaseHelper.findServiceRoleForUser(user1WithRoleViewInService1.getId());
         assertThat(serviceRoleForUserBefore.size(), is(1));
 
         givenSetup()
                 .when()
                 .accept(JSON)
-                .body(userRemoverPayload)
+                .header(HEADER_USER_CONTEXT, userWithRoleAdminInService1.getExternalId())
                 .delete(String.format("/v1/api/services/%s/users/%s", serviceExternalId, user1WithRoleViewInService1.getExternalId()))
                 .then()
                 .statusCode(204)
@@ -119,14 +115,10 @@ public class ServiceResourceTest extends IntegrationTest {
     @Test
     public void removeServiceUser_shouldNotBeAbleToRemoveAnUserItself() {
 
-        ImmutableMap<Object, Object> userRemoverPayload = ImmutableMap.builder()
-                .put("remover_id", userWithRoleAdminInService1.getExternalId())
-                .build();
-
         givenSetup()
                 .when()
                 .accept(JSON)
-                .body(userRemoverPayload)
+                .header(HEADER_USER_CONTEXT, userWithRoleAdminInService1.getExternalId())
                 .delete(String.format("/v1/api/services/%s/users/%s", serviceExternalId, userWithRoleAdminInService1.getExternalId()))
                 .then()
                 .statusCode(409)
@@ -134,19 +126,27 @@ public class ServiceResourceTest extends IntegrationTest {
     }
 
     @Test
-    public void removeServiceUser_shouldReturnBadRequestWhenRemoverIsMissing() {
-
-        ImmutableMap<Object, Object> userRemoverPayload = ImmutableMap.builder()
-                .put("remover_id", " ")
-                .build();
+    public void removeServiceUser_shouldReturnUnAuthorizeWhenRemoverIsMissing() {
 
         givenSetup()
                 .when()
                 .accept(JSON)
-                .body(userRemoverPayload)
+                .header(HEADER_USER_CONTEXT, " ")
                 .delete(String.format("/v1/api/services/%s/users/%s", serviceExternalId, userWithRoleAdminInService1.getExternalId()))
                 .then()
-                .statusCode(400)
+                .statusCode(401)
+                .body(isEmptyString());
+    }
+
+    @Test
+    public void removeServiceUser_shouldReturnUnAuthorizeWhenUserContextHeaderIsMissing() {
+
+        givenSetup()
+                .when()
+                .accept(JSON)
+                .delete(String.format("/v1/api/services/%s/users/%s", serviceExternalId, userWithRoleAdminInService1.getExternalId()))
+                .then()
+                .statusCode(401)
                 .body(isEmptyString());
     }
 }

--- a/src/test/resources/pacts/selfservice-delete-user-adminusers.json
+++ b/src/test/resources/pacts/selfservice-delete-user-adminusers.json
@@ -1,0 +1,81 @@
+{
+  "consumer": {
+    "name": "Selfservice-delete-user"
+  },
+  "provider": {
+    "name": "adminusers"
+  },
+  "interactions": [
+    {
+      "description": "a valid delete user from service request",
+      "provider_state": "a user and user admin exists in service with the given ids before a delete operation",
+      "request": {
+        "method": "DELETE",
+        "path": "/v1/api/services/pact-delete-service-id/users/pact-delete-user-id",
+        "headers": {
+          "Accept": "application/json",
+          "GovUkPay-User-Context": "pact-delete-remover-id"
+        }
+      },
+      "response": {
+        "status": 204,
+        "headers": {
+        }
+      }
+    },
+    {
+      "description": "a valid delete user from service request but remover is equal to user to be removed",
+      "provider_state": "default",
+      "request": {
+        "method": "DELETE",
+        "path": "/v1/api/services/pact-delete-service-id/users/pact-delete-remover-id",
+        "headers": {
+          "Accept": "application/json",
+          "GovUkPay-User-Context": "pact-delete-remover-id"
+        }
+      },
+      "response": {
+        "status": 409,
+        "headers": {
+        }
+      }
+    },
+    {
+      "description": "an invalid delete user from service request as user does not exist",
+      "provider_state": "default",
+      "request": {
+        "method": "DELETE",
+        "path": "/v1/api/services/pact-delete-service-id/users/user-does-not-exist",
+        "headers": {
+          "Accept": "application/json",
+          "GovUkPay-User-Context": "pact-delete-remover-id"
+        }
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+        }
+      }
+    },
+    {
+      "description": "a non existent user context",
+      "provider_state": "a user exists but not the remover before a delete operation",
+      "request": {
+        "method": "DELETE",
+        "path": "/v1/api/services/pact-service-no-remover-test/users/pact-user-no-remover-test",
+        "headers": {
+          "Accept": "application/json",
+          "GovUkPay-User-Context": "user-does-not-exist"
+        }
+      },
+      "response": {
+        "status": 403,
+        "headers": {
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pactSpecificationVersion": "2.0.0"
+  }
+}


### PR DESCRIPTION
## WHAT
- Add new Header `GovUkPay-User-Context`. This represents the user performing the operation. At the moment only for one resource (_Delete user_) but eventually will be in a filter mapping URL's with specific permissions. Pending discussion.

- Add delete user API pact tests using new approach using `GovUkPay-User-Context` Header.