### PR TITLE
Pp 1615 self create service 1

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
@@ -12,6 +12,8 @@ import uk.gov.pay.adminusers.service.ValidateOtpAndCreateUserResult;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 
+import java.util.Optional;
+
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.*;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -130,6 +132,21 @@ public class InviteResource {
                     }
                     return handleValidateOtpAndCreateUserException(validateOtpAndCreateUserResult.getError());
                 });
+    }
+
+    @POST
+    @Path("/otp/validate/service")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    public Response validateOtpKeyForService(JsonNode payload){
+
+        LOGGER.info("Invite POST request for validating otp for service create");
+
+        return  inviteValidator.validateOtpValidationRequest(payload)
+                .map(errors -> Response.status((BAD_REQUEST)).entity(errors).build())
+                .orElseGet(() -> inviteService.validateOtp(InviteValidateOtpRequest.from(payload))
+                            .map(error -> handleValidateOtpAndCreateUserException(error))
+                            .orElseGet(() -> Response.status(OK).build()));
     }
 
     private Response handleValidateOtpAndCreateUserException(WebApplicationException error) {

--- a/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
@@ -22,6 +22,8 @@ public class IntegrationTest {
     static final String INVITES_GENERATE_OTP_RESOURCE_URL = "/v1/api/invites/otp/generate";
     static final String INVITES_RESEND_OTP_RESOURCE_URL = "/v1/api/invites/otp/resend";
     static final String INVITES_VALIDATE_OTP_RESOURCE_URL = "/v1/api/invites/otp/validate";
+
+    static final String SERVICE_INVITES_VALIDATE_OTP_RESOURCE_URL = "/v1/api/invites/otp/validate/service";
     @Deprecated
     static final String SERVICE_INVITES_RESOURCE_URL = "/v1/api/services/%d/invites";
     static final String INVITE_USER_RESOURCE_URL = "/v1/api/invites/user";

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpTest.java
@@ -291,4 +291,48 @@ public class InviteResourceOtpTest extends IntegrationTest {
                 .then()
                 .statusCode(BAD_REQUEST.getStatusCode());
     }
+
+    @Test
+    public void validateServiceOtpKey_shouldSucceed_whenValidOtp() throws Exception {
+
+        code = InviteDbFixture.inviteDbFixture(databaseHelper)
+                .withOtpKey(OTP_KEY)
+                .insertInvite();
+
+        ImmutableMap<Object, Object> sendRequest = ImmutableMap.builder()
+                .put("code", code)
+                .put("otp", PASSCODE)
+                .build();
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(sendRequest))
+                .contentType(ContentType.JSON)
+                .post(SERVICE_INVITES_VALIDATE_OTP_RESOURCE_URL)
+                .then()
+                .statusCode(OK.getStatusCode());
+    }
+
+    @Test
+    public void validateServiceOtpKey_shouldFailWith401_whenInvalidOtp() throws Exception {
+
+        code = InviteDbFixture.inviteDbFixture(databaseHelper)
+                .withOtpKey(OTP_KEY)
+                .insertInvite();
+
+        int invalidOtp = 111111;
+
+        ImmutableMap<Object, Object> sendRequest = ImmutableMap.builder()
+                .put("code", code)
+                .put("otp", invalidOtp)
+                .build();
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(sendRequest))
+                .contentType(ContentType.JSON)
+                .post(SERVICE_INVITES_VALIDATE_OTP_RESOURCE_URL)
+                .then()
+                .statusCode(UNAUTHORIZED.getStatusCode());
+    }
 }


### PR DESCRIPTION
We have an otp/validate endpoint. However, this also creates a user.
When we have a service invite otp to validate, we do not want to create a user.
This commit adds a new endpoint otp/validate/service which just does the otp
validation with no side effects. Ideally we will move over to using this for user
invites as well, with a secondary request to create user.