### PR TITLE
PP-2147 Get list of users for a service by external ID

### DIFF
--- a/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
@@ -42,7 +42,6 @@ public class UserDbFixture {
         return user;
     }
 
-    @Deprecated // May be removed when all moved to using serviceExternalId instead of serviceId
     public UserDbFixture withServiceRole(int serviceId, int roleId) {
         this.service = Service.from(serviceId, randomUuid(), Service.DEFAULT_NAME_VALUE);
         this.roleId = roleId;


### PR DESCRIPTION
Adding support for external ID based service extraction for list of users.

Leaving service Id based resource for backward compatibility. (Until selfservice is migrated) 
Need to remove later.