### PR TITLE
PP-1611 including gateway account id's in to the service

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/model/Service.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Service.java
@@ -19,6 +19,7 @@ public class Service {
     private String externalId;
     private String name = DEFAULT_NAME_VALUE;
     private List<Link> links = new ArrayList<>();
+    private List<String> gatewayAccountIds = new ArrayList<>();
 
     public static Service from() {
         return from(DEFAULT_NAME_VALUE);
@@ -71,5 +72,13 @@ public class Service {
 
     public void setLinks(List<Link> links) {
         this.links = links;
+    }
+
+    public List<String> getGatewayAccountIds() {
+        return gatewayAccountIds;
+    }
+
+    public void setGatewayAccountIds(List<String> gatewayAccountIds) {
+        this.gatewayAccountIds = gatewayAccountIds;
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
@@ -6,6 +6,7 @@ import uk.gov.pay.adminusers.model.Service;
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
@@ -76,12 +77,15 @@ public class ServiceEntity {
         return invites;
     }
 
-    public void addGatewayAccountIds(String ... gatewayAccountIds) {
+    public void addGatewayAccountIds(String... gatewayAccountIds) {
         populateGatewayAccountIds(asList(gatewayAccountIds));
     }
 
     public Service toService() {
         Service service = Service.from(id, externalId, name);
+        service.setGatewayAccountIds(gatewayAccountIds.stream()
+                .map(idEntity -> idEntity.getGatewayAccountId())
+                .collect(Collectors.toList()));
         return service;
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceCreateTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceCreateTest.java
@@ -1,17 +1,13 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.google.common.collect.ImmutableMap;
-import com.jayway.restassured.response.ValidatableResponse;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.Service;
 
-import java.util.List;
 import java.util.Map;
 
 import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
-import static java.util.stream.Collectors.toList;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
@@ -43,26 +39,19 @@ public class ServiceResourceCreateTest extends IntegrationTest {
                 .put("gateway_account_ids", new String[]{"1", "2"})
                 .build();
 
-        ValidatableResponse validatableResponse = givenSetup()
+        givenSetup()
                 .when()
                 .accept(JSON)
                 .body(mapper.writeValueAsString(payload))
                 .post("/v1/api/services")
                 .then()
-                .statusCode(201);
-
-        validatableResponse
+                .statusCode(201)
                 .body("name", is("System Generated"))
-                .body("external_id", notNullValue());
+                .body("external_id", notNullValue())
+                .body("gateway_account_ids", hasSize(2))
+                .body("gateway_account_ids[0]", is("1"))
+                .body("gateway_account_ids[1]", is("2"));
 
-        String serviceExternalId = validatableResponse.extract().jsonPath().getString("external_id");
-
-        List<Map<String, Object>> gatewayAccountsForService = databaseHelper.findGatewayAccountsByService(serviceExternalId);
-        List<String> gatewayAccountIds = gatewayAccountsForService.stream()
-                .map(gaEntry -> gaEntry.get("gateway_account_id").toString()).collect(toList());
-
-        assertThat(gatewayAccountIds.size(), is(2));
-        assertThat(gatewayAccountIds, hasItems("1","2"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceCreateTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceCreateTest.java
@@ -49,8 +49,7 @@ public class ServiceResourceCreateTest extends IntegrationTest {
                 .body("name", is("System Generated"))
                 .body("external_id", notNullValue())
                 .body("gateway_account_ids", hasSize(2))
-                .body("gateway_account_ids[0]", is("1"))
-                .body("gateway_account_ids[1]", is("2"));
+                .body("gateway_account_ids", containsInAnyOrder("1","2"));
 
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceCreatorTest.java
@@ -71,6 +71,7 @@ public class ServiceCreatorTest {
         List<String> persistedGatewayIds = persistedServiceEntity.getValue().getGatewayAccountIds().stream().map(gai -> gai.getGatewayAccountId()).collect(toList());
         assertThat(persistedGatewayIds.size(),is(2));
         assertThat(persistedGatewayIds,hasItems("1","2"));
+        assertThat(service.getGatewayAccountIds(), hasItems("1","2"));
     }
 
     @Test
@@ -83,7 +84,7 @@ public class ServiceCreatorTest {
         List<String> persistedGatewayIds = persistedServiceEntity.getValue().getGatewayAccountIds().stream().map(gai -> gai.getGatewayAccountId()).collect(toList());
         assertThat(persistedGatewayIds.size(),is(2));
         assertThat(persistedGatewayIds,hasItems("1","2"));
-
+        assertThat(service.getGatewayAccountIds(), hasItems("1","2"));
     }
 
     @Test(expected = WebApplicationException.class)


### PR DESCRIPTION
Given that this is already mapped and loaded in ServiceEntity, it makes sense to include these id's as part of the service domain model.

We can consider removing this dependency if we consider introducing a orchestration to a different layer at some point.