### PR TITLE
PP-1611 User to posses knowledge of ServiceRole

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/model/ServiceRole.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/ServiceRole.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.adminusers.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class ServiceRole {
+
+    private Service Service;
+    private Role role;
+
+    public static ServiceRole from(Service service, Role role) {
+        return new ServiceRole(service, role);
+    }
+
+    private ServiceRole(@JsonProperty("service") Service service, @JsonProperty("role") Role role) {
+        Service = service;
+        this.role = role;
+    }
+
+    public Service getService() {
+        return Service;
+    }
+
+    public Role getRole() {
+        return role;
+    }
+
+    @Override
+    public String toString() {
+        return "ServiceRole{" +
+                "Service=" + Service +
+                ", role=" + role +
+                '}';
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/model/User.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/User.java
@@ -29,22 +29,26 @@ public class User {
     private String email;
     private List<String> gatewayAccountIds = new ArrayList<>();
     private String telephoneNumber;
+    @Deprecated // Use serviceRoles instead
     private List<Service> services = new ArrayList<>();
     private String otpKey;
     private Boolean disabled = Boolean.FALSE;
     private Integer loginCounter = 0;
+    private List<ServiceRole> serviceRoles = new ArrayList<>();
+    @Deprecated // Use serviceRoles instead
     private List<Role> roles = new ArrayList<>();
     private List<Link> links = new ArrayList<>();
     private Integer sessionVersion = 0;
 
     public static User from(Integer id, String externalId, String username, String password, String email,
-                            List<String> gatewayAccountIds, List<Service> services, String otpKey, String telephoneNumber) {
-        return new User(id, externalId, username, password, email, gatewayAccountIds, services, otpKey, telephoneNumber);
+                            List<String> gatewayAccountIds, List<Service> services, String otpKey, String telephoneNumber, List<ServiceRole> serviceRoles) {
+        return new User(id, externalId, username, password, email, gatewayAccountIds, services, otpKey, telephoneNumber, serviceRoles);
     }
 
     private User(Integer id, @JsonProperty("external_id") String externalId, @JsonProperty("username") String username, @JsonProperty("password") String password,
                  @JsonProperty("email") String email, @JsonProperty("gateway_account_ids") List<String> gatewayAccountIds,
-                 List<Service> services, @JsonProperty("otp_key") String otpKey, @JsonProperty("telephone_number") String telephoneNumber) {
+                 List<Service> services, @JsonProperty("otp_key") String otpKey, @JsonProperty("telephone_number") String telephoneNumber,
+                 @JsonProperty("service_roles") List<ServiceRole> serviceRoles) {
         this.id = id;
         this.externalId = externalId;
         this.username = username;
@@ -54,6 +58,7 @@ public class User {
         this.services = services;
         this.otpKey = otpKey;
         this.telephoneNumber = telephoneNumber;
+        this.serviceRoles = serviceRoles;
     }
 
     @JsonIgnore
@@ -179,7 +184,11 @@ public class User {
                 "externalId=" + externalId +
                 ", gatewayAccountIds=[" + String.join(", ", gatewayAccountIds) + ']' +
                 ", disabled=" + disabled +
-                ", roles=" + roles +
+                ", serviceRoles=" + serviceRoles +
                 '}';
+    }
+
+    public List<ServiceRole> getServiceRoles() {
+        return serviceRoles;
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceRoleEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceRoleEntity.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.adminusers.persistence.entity;
 
+import uk.gov.pay.adminusers.model.ServiceRole;
+
 import javax.persistence.*;
 
 @Entity
@@ -62,5 +64,9 @@ public class ServiceRoleEntity {
 
     public void setUser(UserEntity userEntity) {
         this.user = userEntity;
+    }
+
+    public ServiceRole toServiceRole() {
+        return ServiceRole.from(getService().toService(), getRole().toRole());
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
@@ -3,17 +3,20 @@ package uk.gov.pay.adminusers.persistence.entity;
 import uk.gov.pay.adminusers.app.util.RandomIdGenerator;
 import uk.gov.pay.adminusers.model.CreateUserRequest;
 import uk.gov.pay.adminusers.model.Service;
+import uk.gov.pay.adminusers.model.ServiceRole;
 import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.utils.Comparators;
 
 import javax.persistence.*;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static java.util.Collections.*;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
 
 @Entity
 @Table(name = "users")
@@ -209,22 +212,24 @@ public class UserEntity extends AbstractEntity {
 
         List<String> gatewayAccountIds = newArrayList();
         List<Service> services = newArrayList();
+        List<ServiceRole> serviceRoles = newArrayList();
 
         if (!this.servicesRoles.isEmpty()) {
             services = this.servicesRoles.stream()
-                    .map(serviceRole -> serviceRole.getService().toService()).collect(Collectors.toList());
+                    .map(serviceRole -> serviceRole.getService().toService()).collect(toList());
+            serviceRoles = this.servicesRoles.stream().map(serviceRoleEntity -> serviceRoleEntity.toServiceRole()).collect(toList());
             gatewayAccountIds = services.stream()
                     .flatMap(service -> service.getGatewayAccountIds().stream())
                     .distinct()
                     .sorted(Comparators.usingNumericComparator())
-                    .collect(Collectors.toList());
+                    .collect(toList());
         }
 
-        User user = User.from(getId(), externalId, username, password, email, gatewayAccountIds, services, otpKey, telephoneNumber);
+        User user = User.from(getId(), externalId, username, password, email, gatewayAccountIds, services, otpKey, telephoneNumber, serviceRoles);
         user.setLoginCounter(loginCounter);
         user.setDisabled(disabled);
         user.setSessionVersion(sessionVersion);
-        user.setRoles(this.getRoles().stream().map(RoleEntity::toRole).collect(Collectors.toList()));
+        user.setRoles(this.getRoles().stream().map(RoleEntity::toRole).collect(toList()));
 
         return user;
     }

--- a/src/test/java/uk/gov/pay/adminusers/model/UserTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/UserTest.java
@@ -3,19 +3,23 @@ package uk.gov.pay.adminusers.model;
 import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.List;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
+import static uk.gov.pay.adminusers.model.Role.role;
+import static uk.gov.pay.adminusers.persistence.entity.Role.ADMIN;
 
 public class UserTest {
 
     @Test
     public void shouldFlatten_permissionsOfAUser() throws Exception {
-        User user = User.from(randomInt(), randomUuid(), "name", "password", "email@example.com", Arrays.asList("1"), Arrays.asList(Service.from(1, "3487347gb67",Service.DEFAULT_NAME_VALUE)), "ewrew", "453453");
+        Service service = Service.from(1, "3487347gb67", Service.DEFAULT_NAME_VALUE);
+        User user = User.from(randomInt(), randomUuid(), "name", "password", "email@example.com", asList("1"), asList(service), "ewrew", "453453",
+                asList(ServiceRole.from(service, role(ADMIN.getId(), "Admin", "Administrator"))));
         Role role1 = Role.role(1, "role1", "role1 description");
         Role role2 = Role.role(2, "role2", "role2 description");
         role1.setPermissions(ImmutableList.of(aPermission(), aPermission(), aPermission()));

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoTest.java
@@ -17,12 +17,9 @@ import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.String.valueOf;
-import static java.util.Arrays.asList;
 import static org.apache.commons.lang3.RandomUtils.nextInt;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertTrue;
@@ -128,7 +125,7 @@ public class UserDaoTest extends DaoTestBase {
         assertThat(foundUser.getLoginCounter(), is(0));
         assertThat(foundUser.getSessionVersion(), is(0));
         assertThat(foundUser.getRoles().size(), is(1));
-        assertThat(foundUser.toUser().getServices().size(), is(2));
+        assertThat(foundUser.toUser().getServiceRoles().size(), is(2));
         assertThat(foundUser.getRoles().get(0).getId(), is(role.getId()));
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateAndGetTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateAndGetTest.java
@@ -29,7 +29,9 @@ public class UserResourceCreateAndGetTest extends IntegrationTest {
     @Test
     public void shouldCreateAUserWithSortedGatewayAccountIdsArraySuccessfully() throws Exception {
         String [] gatewayAccountIds = new String[]{"111111", "222"};
-        serviceDbFixture(databaseHelper).withGatewayAccountIds(gatewayAccountIds).insertService();
+        String serviceExternalId = serviceDbFixture(databaseHelper)
+                .withGatewayAccountIds(gatewayAccountIds)
+                .insertService().getExternalId();
 
         String username = randomAlphanumeric(10) + randomUUID().toString();
         ImmutableMap<Object, Object> userPayload = ImmutableMap.builder()
@@ -62,9 +64,10 @@ public class UserResourceCreateAndGetTest extends IntegrationTest {
                 .body("gateway_account_ids[1]", is("111111"))
                 .body("service_ids", hasSize(1))
                 .body("service_ids[0]", is(notNullValue()))
-                .body("services", hasSize(1))
-                .body("services[0].id", is(notNullValue()))
-                .body("services[0].name", is(notNullValue()))
+                .body("service_roles", hasSize(1))
+                .body("service_roles[0].service.external_id", is(serviceExternalId))
+                .body("service_roles[0].service.name", is("System Generated"))
+                .body("service_roles[0].role.name", is("admin"))
                 .body("telephone_number", is("45334534634"))
                 .body("otp_key", is("34f34"))
                 .body("login_counter", is(0))

--- a/src/test/java/uk/gov/pay/adminusers/service/InviteServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/InviteServiceTest.java
@@ -439,6 +439,8 @@ public class InviteServiceTest {
     }
 
     private User aUser(String email) {
-        return User.from(randomInt(), randomUuid(), "a-username", "random-password", email, asList("1"), asList(Service.from(serviceId, serviceExternalId, Service.DEFAULT_NAME_VALUE)), "784rh", "8948924");
+        Service service = Service.from(serviceId, serviceExternalId, Service.DEFAULT_NAME_VALUE);
+        return User.from(randomInt(), randomUuid(), "a-username", "random-password", email, asList("1"), asList(service), "784rh", "8948924",
+                asList(ServiceRole.from(service, role(ADMIN.getId(), "Admin", "Administrator"))));
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/service/LinksBuilderTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/LinksBuilderTest.java
@@ -2,13 +2,11 @@ package uk.gov.pay.adminusers.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
-import uk.gov.pay.adminusers.model.ForgottenPassword;
-import uk.gov.pay.adminusers.model.Service;
-import uk.gov.pay.adminusers.model.User;
+import uk.gov.pay.adminusers.model.*;
 
 import java.time.ZonedDateTime;
-import java.util.Arrays;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
@@ -20,7 +18,10 @@ public class LinksBuilderTest {
 
     @Test
     public void shouldConstruct_userSelfLinkCorrectly() throws Exception {
-        User user = User.from(randomInt(), randomUuid(), "a-username", "a-password", "email@example.com", Arrays.asList("1"), Arrays.asList(Service.from(2, "34783g87ebg764r",Service.DEFAULT_NAME_VALUE)), "4wrwef", "123435");
+        Service service = Service.from(2, "34783g87ebg764r", Service.DEFAULT_NAME_VALUE);
+        Role role = Role.role(2, "blah", "blah");
+        User user = User.from(randomInt(), randomUuid(), "a-username", "a-password", "email@example.com",
+                asList("1"), asList(service), "4wrwef", "123435", asList(ServiceRole.from(service, role)));
         User decoratedUser = linksBuilder.decorate(user);
 
         String linkJson = new ObjectMapper().writeValueAsString(decoratedUser.getLinks().get(0));

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceRoleUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceRoleUpdaterTest.java
@@ -128,6 +128,6 @@ public class ServiceRoleUpdaterTest {
     }
 
     private User aUser(String externalId) {
-        return User.from(randomInt(), externalId, "random-name", "random-password", "random@example.com", asList("1"), newArrayList(), "784rh", "8948924");
+        return User.from(randomInt(), externalId, "random-name", "random-password", "random@example.com", asList("1"), newArrayList(), "784rh", "8948924", newArrayList());
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
@@ -10,10 +10,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import uk.gov.pay.adminusers.app.config.AdminUsersConfig;
 import uk.gov.pay.adminusers.app.config.LinksConfig;
-import uk.gov.pay.adminusers.model.Invite;
-import uk.gov.pay.adminusers.model.InviteUserRequest;
-import uk.gov.pay.adminusers.model.Service;
-import uk.gov.pay.adminusers.model.User;
+import uk.gov.pay.adminusers.model.*;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.dao.RoleDao;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
@@ -200,7 +197,9 @@ public class UserInviteCreatorTest {
     }
 
     private User aUser(String email) {
-        return User.from(randomInt(), randomUuid(), "a-username", "random-password", email, asList("1"), asList(Service.from(serviceId, serviceExternalId, Service.DEFAULT_NAME_VALUE)), "784rh", "8948924");
+        Service service = Service.from(serviceId, serviceExternalId, Service.DEFAULT_NAME_VALUE);
+        return User.from(randomInt(), randomUuid(), "a-username", "random-password", email, asList("1"),
+                asList(service), "784rh", "8948924", asList(ServiceRole.from(service, role(ADMIN.getId(), "Admin", "Administrator"))));
     }
 
 }

--- a/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
@@ -30,7 +30,8 @@ import static org.exparity.hamcrest.date.ZonedDateTimeMatchers.within;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
@@ -572,7 +573,7 @@ public class UserServicesTest {
     }
 
     private User aUser() {
-        return User.from(randomInt(), USER_EXTERNAL_ID, USER_USERNAME, "random-password", "email@example.com", asList("1"), newArrayList(), "784rh", "8948924");
+        return User.from(randomInt(), USER_EXTERNAL_ID, USER_USERNAME, "random-password", "email@example.com", asList("1"), newArrayList(), "784rh", "8948924", newArrayList());
     }
 
     private Role aRole() {


### PR DESCRIPTION
Introducing concept of role per service. 
This means a user can have different roles per service. Deprecating top level `Service` and `Role` to leave support for backward compatibility. Need to remove them once selfservice is migrated to consume `service_roles`.

with @maxcbc