### PR TITLE
PP-1615 Add complete invite resource

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/model/Link.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Link.java
@@ -13,7 +13,8 @@ public class Link {
 
     public enum Rel {
         self,
-        invite
+        invite,
+        user
     }
 
     private Rel rel;

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
@@ -200,6 +200,14 @@ public class InviteEntity extends AbstractEntity {
         this.type = type.getType();
     }
 
+    public boolean isServiceType() {
+        return InviteType.SERVICE.equals(InviteType.from(type));
+    }
+
+    public boolean isUserType() {
+        return InviteType.USER.equals(InviteType.from(type));
+    }
+
     @Deprecated //use toInvite() instead
     public Invite toInvite(String inviteUrl) {
         Invite invite = toInvite();

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
@@ -234,7 +234,9 @@ public class InviteEntity extends AbstractEntity {
         userEntity.setLoginCounter(0);
         userEntity.setDisabled(Boolean.FALSE);
         userEntity.setSessionVersion(0);
-        userEntity.addServiceRole(new ServiceRoleEntity(service, role));
+        if (service != null) {
+            userEntity.addServiceRole(new ServiceRoleEntity(service, role));
+        }
         ZonedDateTime now = ZonedDateTime.now(ZoneId.of("UTC"));
         userEntity.setCreatedAt(now);
         userEntity.setUpdatedAt(now);

--- a/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
@@ -54,6 +54,22 @@ public class InviteResource {
     }
 
     @POST
+    @Path("/{code}/complete")
+    @Produces(APPLICATION_JSON)
+    public Response completeInvite(@PathParam("code") String inviteCode) {
+
+        LOGGER.info("Invite  complete POST request for code - [ {} ]", inviteCode);
+
+        if (isNotBlank(inviteCode) && inviteCode.length() > MAX_LENGTH_CODE) {
+            return Response.status(NOT_FOUND).build();
+        }
+
+        return inviteServiceFactory.completeInvite().complete(inviteCode)
+                .map(invite -> Response.status(OK).type(APPLICATION_JSON).entity(invite).build())
+                .orElseGet(() -> Response.status(NOT_FOUND).build());
+    }
+
+    @POST
     @Path("/service")
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteCompleter.java
@@ -1,0 +1,66 @@
+package uk.gov.pay.adminusers.service;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+import uk.gov.pay.adminusers.model.Invite;
+import uk.gov.pay.adminusers.model.Service;
+import uk.gov.pay.adminusers.persistence.dao.InviteDao;
+import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
+import uk.gov.pay.adminusers.persistence.dao.UserDao;
+import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
+import uk.gov.pay.adminusers.persistence.entity.UserEntity;
+
+import java.util.Optional;
+
+import static uk.gov.pay.adminusers.service.AdminUsersExceptions.conflictingEmail;
+import static uk.gov.pay.adminusers.service.AdminUsersExceptions.inviteLockedException;
+
+public class InviteCompleter {
+    @Inject
+    private final InviteDao inviteDao;
+    private final UserDao userDao;
+    private final ServiceDao serviceDao;
+    private final LinksBuilder linksBuilder;
+
+    @Inject
+    public InviteCompleter(InviteDao inviteDao, UserDao userDao, ServiceDao serviceDao,  LinksBuilder linksBuilder) {
+        this.inviteDao = inviteDao;
+        this.userDao = userDao;
+        this.serviceDao = serviceDao;
+        this.linksBuilder = linksBuilder;
+    }
+
+    /**
+     * Completes an invite.
+     * ie. it creates and persists a user from an invite
+     * and if it is a service invite also creates a default service.
+     * It then disables the invite.
+     */
+    @Transactional
+    public Optional<Invite> complete(String inviteCode) {
+        return inviteDao.findByCode(inviteCode)
+                .map(inviteEntity -> {
+                    if (inviteEntity.isExpired() || inviteEntity.isDisabled()) {
+                        throw inviteLockedException(inviteEntity.getCode());
+                    }
+
+                    if (userDao.findByEmail(inviteEntity.getEmail()).isPresent()) {
+                        throw conflictingEmail(inviteEntity.getEmail());
+                    }
+
+                    if (inviteEntity.isServiceType()) {
+                        ServiceEntity serviceEntity = ServiceEntity.from(Service.from());
+                        serviceDao.persist(serviceEntity);
+                        inviteEntity.setService(serviceEntity);
+                    }
+
+                    UserEntity userEntity = inviteEntity.mapToUserEntity();
+                    userDao.persist(userEntity);
+
+                    inviteEntity.setDisabled(true);
+                    inviteDao.persist(inviteEntity);
+
+                    return Optional.of(linksBuilder.addUserLink(userEntity.toUser(), inviteEntity.toInvite()));
+                }).orElseGet(Optional::empty);
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteCompleter.java
@@ -8,6 +8,7 @@ import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
+import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 
 import java.util.Optional;
@@ -48,13 +49,16 @@ public class InviteCompleter {
                         throw conflictingEmail(inviteEntity.getEmail());
                     }
 
+                    UserEntity userEntity = inviteEntity.mapToUserEntity();
+
+                    //TODO: this needs looking at again - bit icky
                     if (inviteEntity.isServiceType()) {
                         ServiceEntity serviceEntity = ServiceEntity.from(Service.from());
                         serviceDao.persist(serviceEntity);
-                        inviteEntity.setService(serviceEntity);
+                        ServiceRoleEntity serviceRoleEntity = new ServiceRoleEntity(serviceEntity, inviteEntity.getRole());
+                        userEntity.addServiceRole(serviceRoleEntity);
                     }
 
-                    UserEntity userEntity = inviteEntity.mapToUserEntity();
                     userDao.persist(userEntity);
 
                     inviteEntity.setDisabled(true);

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteServiceFactory.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteServiceFactory.java
@@ -6,4 +6,6 @@ public interface InviteServiceFactory {
     ServiceInviteCreator serviceInvite();
 
     UserInviteCreator userInvite();
+
+    InviteCompleter completeInvite();
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/LinksBuilder.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/LinksBuilder.java
@@ -52,4 +52,12 @@ public class LinksBuilder {
         invite.getLinks().add(selfLink);
         return invite;
     }
+
+    public Invite addUserLink(User user, Invite invite) {
+        URI uri = fromUri(baseUrl).path(USERS_RESOURCE).path(user.getExternalId())
+                .build();
+        Link userLink = Link.from(Rel.user, "GET", uri.toString());
+        invite.getLinks().add(userLink);
+        return invite;
+    }
 }

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/InviteDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/InviteDbFixture.java
@@ -43,6 +43,17 @@ public class InviteDbFixture {
         return code;
     }
 
+    public String insertServiceInvite() {
+        int roleId = RoleDbFixture.roleDbFixture(databaseTestHelper).insertRole().getId();
+        int userId = UserDbFixture.userDbFixture(databaseTestHelper).insertUser().getId();
+        databaseTestHelper.addServiceInvite(
+                nextInt(), userId, roleId,
+                email, code, otpKey, date, expiryDate, telephoneNumber, password,
+                disabled, loginCounter
+        );
+        return code;
+    }
+
     public InviteDbFixture expired() {
         this.expiryDate = this.date.minus(1, SECONDS);
         return this;

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCompleteTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCompleteTest.java
@@ -2,11 +2,14 @@ package uk.gov.pay.adminusers.resources;
 
 import org.junit.Test;
 
+import java.util.Map;
+
 import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.Status.GONE;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static uk.gov.pay.adminusers.fixtures.InviteDbFixture.inviteDbFixture;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
@@ -35,6 +38,17 @@ public class InviteResourceCompleteTest extends IntegrationTest {
                 .body("_links[0].href", matchesPattern("^http://localhost:8080/v1/api/users/[0-9a-z]{32}$"))
                 .body("_links[0].rel", is("user"))
                 .body("disabled", is(true));
+
+        Map<String, Object> createdUser = databaseHelper.findUserByUsername(email).stream().findFirst().get();
+        Map<String, Object> role = databaseHelper.findServiceRoleForUser((Integer) createdUser.get("id")).stream().findFirst().get();
+        Map<String, Object> invite = databaseHelper.findInviteByCode(inviteCode).stream().findFirst().get();
+
+        assertThat(role.get("id"), is(invite.get("role_id")));
+        assertThat(role.get("service_id"), is(invite.get("service_id")));
+
+        assertThat(createdUser.get("password"), is(password));
+        assertThat(createdUser.get("email"), is(email));
+        assertThat(createdUser.get("telephone_number"), is(telephoneNumber));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCompleteTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCompleteTest.java
@@ -44,7 +44,6 @@ public class InviteResourceCompleteTest extends IntegrationTest {
         Map<String, Object> invite = databaseHelper.findInviteByCode(inviteCode).stream().findFirst().get();
 
         assertThat(role.get("id"), is(invite.get("role_id")));
-        assertThat(role.get("service_id"), is(invite.get("service_id")));
 
         assertThat(createdUser.get("password"), is(password));
         assertThat(createdUser.get("email"), is(email));

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCompleteTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCompleteTest.java
@@ -1,0 +1,110 @@
+package uk.gov.pay.adminusers.resources;
+
+import org.junit.Test;
+
+import static javax.ws.rs.core.Response.Status.CONFLICT;
+import static javax.ws.rs.core.Response.Status.GONE;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.text.MatchesPattern.matchesPattern;
+import static uk.gov.pay.adminusers.fixtures.InviteDbFixture.inviteDbFixture;
+import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
+
+public class InviteResourceCompleteTest extends IntegrationTest {
+    public static final String INVITES_RESOURCE_URL = "/v1/api/invites";
+
+    @Test
+    public void shouldReturn200withDisabledInviteLinkingToCreatedUser_WhenPassedAValidInviteCode() {
+        String email = "example1@example.gov.uk";
+        String telephoneNumber = "088882345689";
+        String password = "valid_password";
+
+        String inviteCode = inviteDbFixture(databaseHelper)
+                .withTelephoneNumber(telephoneNumber)
+                .withEmail(email)
+                .withPassword(password)
+                .insertServiceInvite();
+
+        givenSetup()
+                .when()
+                .post(INVITES_RESOURCE_URL + "/" + inviteCode + "/complete")
+                .then()
+                .statusCode(OK.getStatusCode())
+                .body("_links", hasSize(1))
+                .body("_links[0].href", matchesPattern("^http://localhost:8080/v1/api/users/[0-9a-z]{32}$"))
+                .body("_links[0].rel", is("user"))
+                .body("disabled", is(true));
+    }
+
+    @Test
+    public void shouldReturn410_WhenSameInviteCodeCompletedTwice() {
+        String email = "example2@example.gov.uk";
+        String telephoneNumber = "088882345689";
+        String password = "valid_password";
+
+        String inviteCode = inviteDbFixture(databaseHelper)
+                .withTelephoneNumber(telephoneNumber)
+                .withEmail(email)
+                .withPassword(password)
+                .insertServiceInvite();
+
+        givenSetup()
+                .when()
+                .post(INVITES_RESOURCE_URL + "/" + inviteCode + "/complete")
+                .then()
+                .statusCode(OK.getStatusCode());
+
+        givenSetup()
+                .when()
+                .post(INVITES_RESOURCE_URL + "/" + inviteCode + "/complete")
+                .then()
+                .statusCode(GONE.getStatusCode());
+    }
+
+    @Test
+    public void shouldReturn409_WhenUserWithSameEmailExists() {
+        String email = "example3@example.gov.uk";
+        String telephoneNumber = "088882345689";
+        String password = "valid_password";
+
+
+        userDbFixture(databaseHelper)
+                .withTelephoneNumber(telephoneNumber)
+                .withEmail(email)
+                .withPassword(password)
+                .insertUser();
+
+        String inviteCode = inviteDbFixture(databaseHelper)
+                .withTelephoneNumber(telephoneNumber)
+                .withEmail(email)
+                .withPassword(password)
+                .insertServiceInvite();
+
+        givenSetup()
+                .when()
+                .post(INVITES_RESOURCE_URL + "/" + inviteCode + "/complete")
+                .then()
+                .statusCode(CONFLICT.getStatusCode());
+    }
+
+    @Test
+    public void shouldReturn410_WheninviteIsDisabled() {
+        String email = "example4@example.gov.uk";
+        String telephoneNumber = "088882345689";
+        String password = "valid_password";
+
+        String inviteCode = inviteDbFixture(databaseHelper)
+                .withTelephoneNumber(telephoneNumber)
+                .withEmail(email)
+                .withPassword(password)
+                .disabled()
+                .insertServiceInvite();
+
+        givenSetup()
+                .when()
+                .post(INVITES_RESOURCE_URL + "/" + inviteCode + "/complete")
+                .then()
+                .statusCode(GONE.getStatusCode());
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/service/InviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/InviteCompleterTest.java
@@ -168,7 +168,7 @@ public class InviteCompleterTest {
         senderUser.setExternalId(senderExternalId);
         senderUser.setEmail(senderEmail);
         RoleEntity role = new RoleEntity(role(ADMIN.getId(), "admin", "Admin Role"));
-        senderUser.setServiceRole(new ServiceRoleEntity(service, role));
+        senderUser.addServiceRole(new ServiceRoleEntity(service, role));
 
         InviteEntity anInvite = anInvite(email, inviteCode, otpKey, senderUser, service, role);
 

--- a/src/test/java/uk/gov/pay/adminusers/service/InviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/InviteCompleterTest.java
@@ -1,0 +1,188 @@
+package uk.gov.pay.adminusers.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.pay.adminusers.app.config.AdminUsersConfig;
+import uk.gov.pay.adminusers.model.*;
+import uk.gov.pay.adminusers.persistence.dao.InviteDao;
+import uk.gov.pay.adminusers.persistence.dao.RoleDao;
+import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
+import uk.gov.pay.adminusers.persistence.dao.UserDao;
+import uk.gov.pay.adminusers.persistence.entity.*;
+
+import javax.ws.rs.WebApplicationException;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.text.MatchesPattern.matchesPattern;
+
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
+import static uk.gov.pay.adminusers.model.Role.role;
+import static uk.gov.pay.adminusers.persistence.entity.Role.ADMIN;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InviteCompleterTest {
+    @Mock
+    private RoleDao mockRoleDao;
+    @Mock
+    private ServiceDao mockServiceDao;
+    @Mock
+    private UserDao mockUserDao;
+    @Mock
+    private InviteDao mockInviteDao;
+    @Mock
+    private AdminUsersConfig mockConfig;
+
+    private InviteCompleter inviteCompleter;
+    private ArgumentCaptor<UserEntity> expectedInvitedUser = ArgumentCaptor.forClass(UserEntity.class);
+    private ArgumentCaptor<InviteEntity> expectedInvite = ArgumentCaptor.forClass(InviteEntity.class);
+    private ArgumentCaptor<ServiceEntity> expectedService = ArgumentCaptor.forClass(ServiceEntity.class);
+
+    private String otpKey = "otpKey";
+    private String inviteCode = "code";
+    private String senderEmail = "sender@example.com";
+    private String email = "invited@example.com";
+    private int serviceId = 1;
+    private String serviceExternalId = "3453rmeuty87t";
+    private String senderExternalId = "12345";
+    private String roleName = "view-only";
+    private String baseUrl = "http://localhost";
+
+    @Before
+    public void setup() {
+        inviteCompleter = new InviteCompleter(
+                mockInviteDao,
+                mockUserDao,
+                mockServiceDao,
+                new LinksBuilder(baseUrl)
+        );
+    }
+
+    @Test
+    public void shouldCreateServiceAndUser_whenPassedValidServiceInviteCode() {
+        ServiceEntity service = new ServiceEntity();
+        service.setId(serviceId);
+
+
+        InviteEntity anInvite = createInvite();
+        anInvite.setType(InviteType.SERVICE);
+        when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
+        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
+        when(mockRoleDao.findByRoleName(roleName)).thenReturn(Optional.of(new RoleEntity()));
+
+        Invite invite = inviteCompleter.complete(anInvite.getCode()).get();
+
+        verify(mockServiceDao).persist(expectedService.capture());
+        verify(mockUserDao).persist(expectedInvitedUser.capture());
+        verify(mockInviteDao).persist(expectedInvite.capture());
+
+        assertThat(invite.isDisabled(), is(true));
+        assertThat(invite.getLinks().size(), is(1));
+        assertThat(invite.getLinks().get(0).getRel().toString(), is("user"));
+        assertThat(invite.getLinks().get(0).getHref(), matchesPattern("^" + baseUrl +  "/v1/api/users/[0-9a-z]{32}$"));
+    }
+
+    @Test
+    public void shouldCreateOnlyUser_whenPassedValidUserInviteCode() {
+        ServiceEntity service = new ServiceEntity();
+        service.setId(serviceId);
+
+        InviteEntity anInvite = createInvite();
+        anInvite.setType(InviteType.USER);
+
+        when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
+        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
+        when(mockRoleDao.findByRoleName(roleName)).thenReturn(Optional.of(new RoleEntity()));
+
+        Invite invite = inviteCompleter.complete(anInvite.getCode()).get();
+
+        verifyNoMoreInteractions(mockServiceDao);
+        verify(mockUserDao).persist(expectedInvitedUser.capture());
+        verify(mockInviteDao).persist(expectedInvite.capture());
+
+        assertThat(invite.isDisabled(), is(true));
+        assertThat(invite.getLinks().size(), is(1));
+        assertThat(invite.getLinks().get(0).getRel().toString(), is("user"));
+        assertThat(invite.getLinks().get(0).getHref(), matchesPattern("^" + baseUrl +  "/v1/api/users/[0-9a-z]{32}$"));
+
+    }
+
+    @Test(expected= WebApplicationException.class)
+    public void shouldThrowEmailExistsException_whenPassedInviteCodeWithExistingUserEmail() {
+        ServiceEntity service = new ServiceEntity();
+        service.setId(serviceId);
+
+        InviteEntity anInvite = createInvite();
+        anInvite.setType(InviteType.USER);
+
+        when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(UserEntity.from(aUser("bob@example.com"))));
+        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
+        when(mockRoleDao.findByRoleName(roleName)).thenReturn(Optional.of(new RoleEntity()));
+
+        inviteCompleter.complete(anInvite.getCode());
+    }
+
+    @Test(expected= WebApplicationException.class)
+    public void shouldThrowEmailExistsException_whenPassedInviteCodeWhichIsDisabled() {
+        ServiceEntity service = new ServiceEntity();
+        service.setId(serviceId);
+
+        InviteEntity anInvite = createInvite();
+        anInvite.setType(InviteType.USER);
+        anInvite.setDisabled(true);
+
+        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
+
+        inviteCompleter.complete(anInvite.getCode());
+    }
+
+    @Test(expected= WebApplicationException.class)
+    public void shouldThrowEmailExistsException_whenPassedInviteCodeWhichIsExpired() {
+        ServiceEntity service = new ServiceEntity();
+        service.setId(serviceId);
+
+        InviteEntity anInvite = createInvite();
+        anInvite.setType(InviteType.USER);
+        anInvite.setExpiryDate(ZonedDateTime.now().minusDays(1));
+
+        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
+
+        inviteCompleter.complete(anInvite.getCode());
+    }
+
+    private InviteEntity createInvite() {
+
+        ServiceEntity service = new ServiceEntity();
+        service.setId(serviceId);
+
+        UserEntity senderUser = new UserEntity();
+        senderUser.setExternalId(senderExternalId);
+        senderUser.setEmail(senderEmail);
+        RoleEntity role = new RoleEntity(role(ADMIN.getId(), "admin", "Admin Role"));
+        senderUser.setServiceRole(new ServiceRoleEntity(service, role));
+
+        InviteEntity anInvite = anInvite(email, inviteCode, otpKey, senderUser, service, role);
+
+
+        return anInvite;
+    }
+
+    private InviteEntity anInvite(String email, String code, String otpKey, UserEntity userEntity, ServiceEntity serviceEntity, RoleEntity roleEntity) {
+        return new InviteEntity(email, code, otpKey, userEntity, serviceEntity, roleEntity);
+    }
+
+    private User aUser(String email) {
+        Service service = Service.from(serviceId, serviceExternalId, Service.DEFAULT_NAME_VALUE);
+        return User.from(randomInt(), randomUuid(), "a-username", "random-password", email, asList("1"), asList(service), "784rh", "8948924",
+                asList(ServiceRole.from(service, role(ADMIN.getId(), "Admin", "Administrator"))));
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
@@ -252,6 +252,34 @@ public class DatabaseTestHelper {
         return this;
     }
 
+    public DatabaseTestHelper addServiceInvite(int id, int senderId, int roleId,
+                                        String email, String code, String otpKey,
+                                        ZonedDateTime date, ZonedDateTime expiryDate,
+                                        String telephoneNumber, String password,
+                                        Boolean disabled,
+                                        Integer loginCounter) {
+        jdbi.withHandle(handle ->
+                handle
+                        .createStatement("INSERT INTO invites(id, sender_id, role_id, email, code, otp_key, date, expiry_date, telephone_number, password, disabled, login_counter, type) " +
+                                "VALUES (:id, :senderId, :roleId, :email, :code, :otpKey, :date, :expiryDate, :telephoneNumber, :password, :disabled, :loginCounter, :type)")
+                        .bind("id", id)
+                        .bind("senderId", senderId)
+                        .bind("roleId", roleId)
+                        .bind("email", email)
+                        .bind("code", code)
+                        .bind("otpKey", otpKey)
+                        .bind("telephoneNumber", telephoneNumber)
+                        .bind("password", password)
+                        .bind("date", from(date.toInstant()))
+                        .bind("expiryDate", from(expiryDate.toInstant()))
+                        .bind("disabled", disabled)
+                        .bind("loginCounter", loginCounter)
+                        .bind("type", "service")
+                        .execute()
+        );
+        return this;
+    }
+
     public List<Map<String, Object>> findInviteByCode(String code) {
         return jdbi.withHandle(h ->
                 h.createQuery("SELECT id, sender_id, service_id, role_id, email, code, otp_key, date, telephone_number, disabled, login_counter FROM invites " +


### PR DESCRIPTION
In order to cleanly use invites to create entities (Users, Services),
it makes sense to have an action on the Invite resource that triggers the
transformation of the Invite into the required resources.

This commit adds an endpoint of form `/v1/api/invites/{inviteCode}/complete`

which finds the specified invite, and creates user and service (if needed) based on
data in the invite. It then disables the invite.