### PR TITLE
PP-1611 add service to user

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The GOV.UK Pay Admin Users Module in Java (Dropwizard)
 | [```/v1/api/users/{externalId}```](/docs/api_specification.md#get-v1apiusersexternalid)              | GET    |  Gets a user with the associated external id            |
 | [```/v1/api/users/{externalId}```](/docs/api_specification.md#patch-v1apiusersexternalid)              | PATCH    |  amend a specific user attribute            |
 | [```/v1/api/users/{externalId}/services/{serviceId}```](/docs/api_specification.md#put-v1apiusersexternalidservicesserviceid)  | PUT    |  update user's role for a service            |
+| [```/v1/api/users/{externalId}/services```](/docs/api_specification.md#post-v1apiusersexternalidservicesserviceid)  | POST    |  assign a new service along with role to a user        |
 | [```/v1/api/users/authenticate```](/docs/api_specification.md#post-v1apiusersauthenticate)              | POST    |  Authenticate a given username/password            |
 | [```/v1/api/forgotten-passwords```](/docs/api_specification.md#post-v1apiforgottenpasswords)              | POST    |  Create a new forgotten password request            |
 | [```/v1/api/forgotten-passwords/{code}```](/docs/api_specification.md#get-v1apiforgottenpasswordscode)              | GET    |  GETs a forgotten password record by code            |

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -394,6 +394,92 @@ Content-Type: application/json
 
 -----------------------------------------------------------------------------------------------------------
 
+## POST /v1/api/users/{externalId}/services
+
+This endpoint assigns a new service role to a user.
+
+### Request example
+
+```
+POST /v1/api/users/7d19aff33f8948deb97ed16b2912dcd3/services
+Content-Type: application/json
+{
+    "service_external_id": "ahq8745yq387"
+    "role_name": "view-and-refund"
+}
+```
+
+### Response example
+
+```
+200 OK
+Content-Type: application/json
+{
+    "external_id": "7d19aff33f8948deb97ed16b2912dcd3",
+    "username": "abcd1234",
+    "email": "email@email.com",
+    "gateway_account_ids": ["1"],
+    "telephone_number": "49875792",
+    "otp_key": "43c3c4t",
+    "sessionVersion": 2,
+    "service_role":[{
+        service:{external_id: "ahq8745yq387",name:"service-name"},
+        role:{
+            name:"view-and-refund", 
+            permissions:[{name:"perm-1", description:"perm-description"}]
+        }  
+    }],
+    "_links": [{
+        "href": "http://adminusers.service/v1/api/users/7d19aff33f8948deb97ed16b2912dcd3",
+        "rel" : "self",
+        "method" : "GET"
+    }]
+    
+}
+```
+
+if user not found:
+```
+404 Not found
+```
+
+if service id not found:
+```
+400 Bad request
+Content-Type: application/json
+{
+  "errors": "Service ahq8745yq387 provided does not exist"
+}
+```
+
+
+if provided role name not valid:
+```
+400 Bad request
+Content-Type: application/json
+{
+  "errors": "role [xyz] not recognised"
+}
+```
+
+if provided the user already has access to the given service
+```
+409 Conflict
+Content-Type: application/json
+{
+  "errors": "Cannot assign service role. user [7d19aff33f8948deb97ed16b2912dcd3] already got access to service [ahq8745yq387]."
+}
+```
+
+#### Request field description
+
+| Field                    | required | Description                                                | Supported Values     |
+| ------------------------ |:--------:| ---------------------------------------------------------- |----------------------|
+| `service_external_id`    |   X      | the external id of an existing service                     |                      |
+| `role_name`              |   X      | the name of an existing valid role                         | e.g. admin           |
+
+-----------------------------------------------------------------------------------------------------------
+
 ## POST /v1/api/services
 
 This endpoint creates a new service. And assigns to gateway account ids (Optional)

--- a/src/main/java/uk/gov/pay/adminusers/model/User.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/User.java
@@ -16,6 +16,7 @@ import static java.util.Collections.emptyList;
 public class User {
 
     public static final String FIELD_USERNAME = "username";
+    public static final String FIELD_SERVICE_EXTERNAL_ID = "service_external_id";
     public static final String FIELD_PASSWORD = "password";
     public static final String FIELD_EMAIL = "email";
     public static final String FIELD_GATEWAY_ACCOUNT_IDS = "gateway_account_ids";

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
@@ -226,7 +226,7 @@ public class InviteEntity extends AbstractEntity {
         userEntity.setLoginCounter(0);
         userEntity.setDisabled(Boolean.FALSE);
         userEntity.setSessionVersion(0);
-        userEntity.setServiceRole(new ServiceRoleEntity(service, role));
+        userEntity.addServiceRole(new ServiceRoleEntity(service, role));
         ZonedDateTime now = ZonedDateTime.now(ZoneId.of("UTC"));
         userEntity.setCreatedAt(now);
         userEntity.setUpdatedAt(now);

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
@@ -234,10 +234,9 @@ public class UserEntity extends AbstractEntity {
         return user;
     }
 
-    public void setServiceRole(ServiceRoleEntity service) {
-        this.servicesRoles.clear();
-        service.setUser(this);
-        this.servicesRoles.add(service);
+    public void addServiceRole(ServiceRoleEntity serviceRole) {
+        serviceRole.setUser(this);
+        this.servicesRoles.add(serviceRole);
     }
 
     @Deprecated // Use external Id version
@@ -258,5 +257,9 @@ public class UserEntity extends AbstractEntity {
 
     public void remove(ServiceRoleEntity serviceRole) {
         servicesRoles.remove(serviceRole);
+    }
+
+    public List<ServiceRoleEntity> getServicesRoles() {
+        return servicesRoles;
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/resources/UserRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/UserRequestValidator.java
@@ -59,6 +59,11 @@ public class UserRequestValidator {
         return missingMandatoryFields.map(Errors::from);
     }
 
+    public Optional<Errors> validateAssignServiceRequest(JsonNode payload) {
+        Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExists(payload, FIELD_SERVICE_EXTERNAL_ID,FIELD_ROLE_NAME);
+        return missingMandatoryFields.map(Errors::from);
+    }
+
     public Optional<Errors> validatePatchRequest(JsonNode payload) {
         Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExists(payload, "op", "path", "value");
         if (missingMandatoryFields.isPresent()) {

--- a/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
@@ -162,6 +162,24 @@ public class UserResource {
                 });
     }
 
+    @POST
+    @Path(USER_SERVICES_RESOURCE)
+    @Produces(APPLICATION_JSON)
+    @Consumes(APPLICATION_JSON)
+    public Response createServiceRole(@PathParam("externalId") String userExternalId, JsonNode payload) {
+        logger.info("Assign service role to a user {} request", userExternalId);
+        return validator.validateAssignServiceRequest(payload)
+                .map(errors -> Response.status(BAD_REQUEST).entity(errors).build())
+                .orElseGet(() -> {
+                    String serviceExternalId = payload.get(User.FIELD_SERVICE_EXTERNAL_ID).asText();
+                    String roleName = payload.get(User.FIELD_ROLE_NAME).asText();
+                    return userServicesFactory.serviceRoleCreator().doCreate(userExternalId, serviceExternalId, roleName)
+                            .map(user -> Response.status(OK).entity(user).build())
+                            .orElseGet(() -> Response.status(NOT_FOUND).build());
+                });
+
+    }
+
     private Response handleCreateUserException(String userName, Exception e) {
         if (e.getMessage().contains(CONSTRAINT_VIOLATION_MESSAGE)) {
             throw conflictingUsername(userName);

--- a/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
@@ -39,12 +39,17 @@ public class AdminUsersExceptions {
         return buildWebApplicationException(error, CONFLICT.getStatusCode());
     }
 
+    public static WebApplicationException conflictingServiceRoleForUser(String userExternalId, String serviceExternalId) {
+        String error = format("Cannot assign service role. user [%s] already got access to service [%s].", userExternalId, serviceExternalId);
+        return buildWebApplicationException(error, CONFLICT.getStatusCode());
+    }
+
     public static WebApplicationException conflictingServiceForUser(String userExternalId, String serviceExternalId) {
         String error = format("user [%s] does not belong to service [%s]", userExternalId, serviceExternalId);
         return buildWebApplicationException(error, CONFLICT.getStatusCode());
     }
 
-    public static WebApplicationException notFoundServiceError(String serviceId) {
+    public static WebApplicationException serviceDoesNotExistError(String serviceId) {
         String error = format("Service %s provided does not exist", serviceId);
         return buildWebApplicationException(error, BAD_REQUEST.getStatusCode());
     }

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceRoleCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceRoleCreator.java
@@ -1,0 +1,61 @@
+package uk.gov.pay.adminusers.service;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+import uk.gov.pay.adminusers.model.User;
+import uk.gov.pay.adminusers.persistence.dao.RoleDao;
+import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
+import uk.gov.pay.adminusers.persistence.dao.UserDao;
+import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
+import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
+import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
+import uk.gov.pay.adminusers.persistence.entity.UserEntity;
+
+import java.util.Optional;
+
+import static uk.gov.pay.adminusers.service.AdminUsersExceptions.*;
+
+public class ServiceRoleCreator {
+
+    private final UserDao userDao;
+    private final ServiceDao serviceDao;
+    private final RoleDao roleDao;
+    private final LinksBuilder linksBuilder;
+
+    @Inject
+    public ServiceRoleCreator(UserDao userDao, ServiceDao serviceDao, RoleDao roleDao, LinksBuilder linksBuilder) {
+        this.userDao = userDao;
+        this.serviceDao = serviceDao;
+        this.roleDao = roleDao;
+        this.linksBuilder = linksBuilder;
+    }
+
+    @Transactional
+    public Optional<User> doCreate(String userExternalId, String serviceExternalId, String roleName) {
+        Optional<UserEntity> userMaybe = userDao.findByExternalId(userExternalId);
+        if (!userMaybe.isPresent()) {
+            return Optional.empty();
+        }
+
+        Optional<ServiceEntity> serviceMaybe = serviceDao.findByExternalId(serviceExternalId);
+        if (!serviceMaybe.isPresent()) {
+            throw serviceDoesNotExistError(serviceExternalId);
+        }
+
+        Optional<RoleEntity> roleMaybe = roleDao.findByRoleName(roleName);
+        if (!roleMaybe.isPresent()) {
+            throw undefinedRoleException(roleName);
+        }
+
+        UserEntity userEntity = userMaybe.get();
+        userEntity.getServicesRole(serviceExternalId)
+                .ifPresent(serviceRoleEntity -> {
+                    throw conflictingServiceRoleForUser(userExternalId, serviceExternalId);
+                });
+
+        userEntity.addServiceRole(new ServiceRoleEntity(serviceMaybe.get(), roleMaybe.get()));
+        userDao.merge(userEntity);
+
+        return Optional.of(linksBuilder.decorate(userEntity.toUser()));
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceRoleUpdater.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceRoleUpdater.java
@@ -48,7 +48,7 @@ public class ServiceRoleUpdater {
         if (StringUtils.isNumeric(serviceId)) {
             serviceExternalId = serviceDao.findById(Integer.valueOf(serviceId))
                     .map(serviceEntity -> serviceEntity.getExternalId())
-                    .orElseThrow(() -> notFoundServiceError(serviceId));
+                    .orElseThrow(() -> serviceDoesNotExistError(serviceId));
         }
 
         Optional<UserEntity> userMaybe = userDao.findByExternalId(userExternalId);
@@ -76,7 +76,7 @@ public class ServiceRoleUpdater {
             }
         }
         serviceRoleEntity.setRole(roleEntity);
-        userEntity.setServiceRole(serviceRoleEntity);
+        userEntity.addServiceRole(serviceRoleEntity);
         userDao.persist(userEntity);
         return Optional.of(linksBuilder.decorate(userEntity.toUser()));
     }

--- a/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
@@ -28,7 +28,8 @@ import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 import static uk.gov.pay.adminusers.model.PatchRequest.PATH_DISABLED;
 import static uk.gov.pay.adminusers.model.PatchRequest.PATH_SESSION_VERSION;
-import static uk.gov.pay.adminusers.service.AdminUsersExceptions.*;
+import static uk.gov.pay.adminusers.service.AdminUsersExceptions.conflictingServiceGatewayAccountsForUser;
+import static uk.gov.pay.adminusers.service.AdminUsersExceptions.undefinedRoleException;
 
 public class UserServices {
 
@@ -260,17 +261,17 @@ public class UserServices {
                     return new ServiceRoleEntity(service, role);
                 });
         serviceRole.setUser(user);
-        user.setServiceRole(serviceRole);
+        user.addServiceRole(serviceRole);
     }
 
     private void addServiceRoleToUser(UserEntity user, RoleEntity role, String serviceId) {
         ServiceRoleEntity serviceRole = serviceDao.findById(Integer.parseInt(serviceId))
                 .map(serviceEntity -> new ServiceRoleEntity(serviceEntity, role))
                 .orElseGet(() -> {
-                    throw AdminUsersExceptions.notFoundServiceError(serviceId);
+                    throw AdminUsersExceptions.serviceDoesNotExistError(serviceId);
                 });
         serviceRole.setUser(user);
-        user.setServiceRole(serviceRole);
+        user.addServiceRole(serviceRole);
     }
 
     private Optional<ServiceEntity> getServiceAssignedTo(List<String> gatewayAccountIds) {

--- a/src/main/java/uk/gov/pay/adminusers/service/UserServicesFactory.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserServicesFactory.java
@@ -10,4 +10,5 @@ public interface UserServicesFactory {
 
     ServiceRoleUpdater serviceRoleUpdater();
 
+    ServiceRoleCreator serviceRoleCreator();
 }

--- a/src/test/java/uk/gov/pay/adminusers/model/UserEntityTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/UserEntityTest.java
@@ -52,7 +52,7 @@ public class UserEntityTest {
         RoleEntity roleEntity = new RoleEntity(role);
         ServiceRoleEntity serviceRole = new ServiceRoleEntity(service, roleEntity);
 
-        userEntity.setServiceRole(serviceRole);
+        userEntity.addServiceRole(serviceRole);
 
         assertThat(userEntity.getRoles().size(), is(1));
         assertThat(userEntity.getRoles().get(0).getId(), is(1));

--- a/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
@@ -16,6 +16,7 @@ public class IntegrationTest {
     static final String USER_RESOURCE_URL = "/v1/api/users/%s";
     static final String USERS_AUTHENTICATE_URL = "/v1/api/users/authenticate";
     static final String USER_2FA_URL = "/v1/api/users/%s/second-factor";
+    static final String USER_SERVICES_RESOURCE = USER_RESOURCE_URL + "/services";
     static final String USER_SERVICE_RESOURCE = USER_RESOURCE_URL + "/services/%s";
 
     static final String INVITES_RESOURCE_URL = "/v1/api/invites";

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserRequestValidatorTest.java
@@ -179,6 +179,25 @@ public class UserRequestValidatorTest {
     }
 
     @Test
+    public void shouldSuccess_whenAddingServiceRole() throws Exception {
+        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("service_external_id", "blah-blah", "role_name", "blah"));
+        Optional<Errors> optionalErrors = validator.validateAssignServiceRequest(payload);
+
+        assertFalse(optionalErrors.isPresent());
+    }
+
+    @Test
+    public void shouldError_whenAddingServiceRole_ifRequiredParamMissing() throws Exception {
+        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("service_external_id", "blah-blah"));
+        Optional<Errors> optionalErrors = validator.validateAssignServiceRequest(payload);
+
+        Errors errors = optionalErrors.get();
+        assertThat(errors.getErrors().size(), is(1));
+        assertThat(errors.getErrors(), hasItems(
+                "Field [role_name] is required"));
+    }
+
+    @Test
     public void shouldError_ifNumericFieldsAreNotNumeric() throws Exception {
         String invalidPayload = "{" +
                 "\"username\": \"a-username\"," +

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateServiceRoleTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateServiceRoleTest.java
@@ -1,0 +1,82 @@
+package uk.gov.pay.adminusers.resources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import uk.gov.pay.adminusers.model.Role;
+import uk.gov.pay.adminusers.model.Service;
+import uk.gov.pay.adminusers.model.User;
+
+import static com.jayway.restassured.http.ContentType.JSON;
+import static java.lang.String.format;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.adminusers.fixtures.RoleDbFixture.roleDbFixture;
+import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
+import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
+
+public class UserResourceCreateServiceRoleTest extends IntegrationTest {
+
+    @Test
+    public void shouldSuccess_whenAddServiceRoleForUser() throws Exception {
+        Role role = roleDbFixture(databaseHelper).insertAdmin();
+        Service service = serviceDbFixture(databaseHelper).insertService();
+        User user = userDbFixture(databaseHelper).insertUser();
+
+        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("service_external_id", service.getExternalId(), "role_name", role.getName()));
+
+        givenSetup()
+                .when()
+                .contentType(JSON)
+                .body(payload)
+                .post(format(USER_SERVICES_RESOURCE, user.getExternalId()))
+                .then()
+                .statusCode(200)
+                .body("username", is(user.getUsername()))
+                .body("service_roles", hasSize(1))
+                .body("service_roles[0].role.name", is(role.getName()))
+                .body("service_roles[0].service.external_id", is(service.getExternalId()));
+    }
+
+    @Test
+    public void shouldError_whenAddServiceRoleForUser_ifMandatoryParamsMissing() throws Exception {
+        Role role = roleDbFixture(databaseHelper).insertAdmin();
+        serviceDbFixture(databaseHelper).insertService();
+        User user = userDbFixture(databaseHelper).insertUser();
+
+        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("role_name", role.getName()));
+
+        givenSetup()
+                .when()
+                .contentType(JSON)
+                .body(payload)
+                .post(format(USER_SERVICES_RESOURCE, user.getExternalId()))
+                .then()
+                .statusCode(400)
+                .body("errors", Matchers.hasSize(1))
+                .body("errors[0]", is(format("Field [service_external_id] is required")));
+    }
+
+    @Test
+    public void shouldError_whenAddServiceRoleForUser_ifUserAlreadyHasService() throws Exception {
+        Role role = roleDbFixture(databaseHelper).insertAdmin();
+        String roleName = "view-and-refund";
+        roleDbFixture(databaseHelper).withName(roleName).insertAdmin();
+        Service service = serviceDbFixture(databaseHelper).insertService();
+        User user = userDbFixture(databaseHelper).withServiceRole(service.getId(), role.getId()).insertUser();
+
+        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("service_external_id", service.getExternalId(), "role_name", roleName));
+
+        givenSetup()
+                .when()
+                .contentType(JSON)
+                .body(payload)
+                .post(format(USER_SERVICES_RESOURCE, user.getExternalId()))
+                .then()
+                .statusCode(409)
+                .body("errors", Matchers.hasSize(1))
+                .body("errors[0]", is(format("Cannot assign service role. user [%s] already got access to service [%s].", user.getExternalId(), service.getExternalId())));
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/service/InviteServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/InviteServiceTest.java
@@ -107,7 +107,7 @@ public class InviteServiceTest {
         senderUser.setExternalId(senderExternalId);
         senderUser.setEmail(senderEmail);
         RoleEntity role = new RoleEntity(role(ADMIN.getId(), "admin", "Admin Role"));
-        senderUser.setServiceRole(new ServiceRoleEntity(service, role));
+        senderUser.addServiceRole(new ServiceRoleEntity(service, role));
         when(mockUserDao.findByExternalId(senderExternalId)).thenReturn(Optional.of(senderUser));
 
         InviteEntity anInvite = anInvite(email, inviteCode, otpKey, senderUser, service, role);

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceRoleCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceRoleCreatorTest.java
@@ -1,0 +1,134 @@
+package uk.gov.pay.adminusers.service;
+
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.pay.adminusers.model.Role;
+import uk.gov.pay.adminusers.model.Service;
+import uk.gov.pay.adminusers.model.User;
+import uk.gov.pay.adminusers.persistence.dao.RoleDao;
+import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
+import uk.gov.pay.adminusers.persistence.dao.UserDao;
+import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
+import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
+import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
+import uk.gov.pay.adminusers.persistence.entity.UserEntity;
+
+import javax.ws.rs.WebApplicationException;
+import java.util.Optional;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ServiceRoleCreatorTest {
+    @Mock
+    private UserDao userDao;
+    @Mock
+    private RoleDao roleDao;
+    @Mock
+    private ServiceDao serviceDao;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private ServiceRoleCreator serviceRoleCreator;
+
+    private static final String EXISTING_USER_EXTERNAL_ID = "7d19aff33f8948deb97ed16b2912dcd3";
+    private static final String EXISTING_SERVICE_EXTERNAL_ID = "8374rgw88934r98c9io";
+    private static final String EXISTING_ROLE_NAME = "admin";
+
+    @Before
+    public void before() throws Exception {
+        serviceRoleCreator = new ServiceRoleCreator(userDao, serviceDao, roleDao, new LinksBuilder("http://localhost"));
+    }
+
+    @Test
+    public void shouldSuccess_whenAssignANewServiceRole() throws Exception {
+        when(userDao.findByExternalId(EXISTING_USER_EXTERNAL_ID)).thenReturn(Optional.of(UserEntity.from(aUser(EXISTING_USER_EXTERNAL_ID))));
+        when(serviceDao.findByExternalId(EXISTING_SERVICE_EXTERNAL_ID)).thenReturn(Optional.of(ServiceEntity.from(aService(EXISTING_SERVICE_EXTERNAL_ID))));
+        when(roleDao.findByRoleName(EXISTING_ROLE_NAME)).thenReturn(Optional.of(new RoleEntity(aRole(1,EXISTING_ROLE_NAME))));
+
+        Optional<User> userOptional = serviceRoleCreator.doCreate(EXISTING_USER_EXTERNAL_ID, EXISTING_SERVICE_EXTERNAL_ID, EXISTING_ROLE_NAME);
+
+        assertTrue(userOptional.isPresent());
+
+        User user = userOptional.get();
+        assertThat(user.getServiceRoles().size(),is(1));
+        assertThat(user.getServiceRoles().get(0).getRole().getName(),is(EXISTING_ROLE_NAME));
+        assertThat(user.getServiceRoles().get(0).getService().getExternalId(),is(EXISTING_SERVICE_EXTERNAL_ID));
+    }
+
+    @Test
+    public void shouldReturnEmpty_whenAssignANewServiceRole_ifUserNotFound() throws Exception {
+        when(userDao.findByExternalId(EXISTING_USER_EXTERNAL_ID)).thenReturn(Optional.empty());
+
+        Optional<User> userOptional = serviceRoleCreator.doCreate(EXISTING_USER_EXTERNAL_ID, EXISTING_SERVICE_EXTERNAL_ID, EXISTING_ROLE_NAME);
+
+        assertFalse(userOptional.isPresent());
+    }
+
+    @Test
+    public void shouldError400_whenAssignANewServiceRole_ifServiceNotFound() throws Exception {
+        when(userDao.findByExternalId(EXISTING_USER_EXTERNAL_ID)).thenReturn(Optional.of(UserEntity.from(aUser(EXISTING_USER_EXTERNAL_ID))));
+        when(serviceDao.findByExternalId(EXISTING_SERVICE_EXTERNAL_ID)).thenReturn(Optional.empty());
+
+        thrown.expect(WebApplicationException.class);
+        thrown.expectMessage("HTTP 400 Bad Request");
+        serviceRoleCreator.doCreate(EXISTING_USER_EXTERNAL_ID, EXISTING_SERVICE_EXTERNAL_ID, EXISTING_ROLE_NAME);
+
+    }
+
+    @Test
+    public void shouldError400_whenAssignANewServiceRole_ifRoleNotFound() throws Exception {
+        ServiceEntity serviceEntity = ServiceEntity.from(aService(EXISTING_SERVICE_EXTERNAL_ID));
+        UserEntity userEntity = UserEntity.from(aUser(EXISTING_USER_EXTERNAL_ID));
+        RoleEntity roleEntity = new RoleEntity(aRole(1, EXISTING_ROLE_NAME));
+
+        userEntity.addServiceRole(new ServiceRoleEntity(serviceEntity,roleEntity));
+
+        when(serviceDao.findByExternalId(EXISTING_SERVICE_EXTERNAL_ID)).thenReturn(Optional.of(serviceEntity));
+        when(userDao.findByExternalId(EXISTING_USER_EXTERNAL_ID)).thenReturn(Optional.of(userEntity));
+        when(roleDao.findByRoleName(EXISTING_ROLE_NAME)).thenReturn(Optional.of(roleEntity));
+
+        thrown.expect(WebApplicationException.class);
+        thrown.expectMessage("HTTP 409 Conflict");
+        serviceRoleCreator.doCreate(EXISTING_USER_EXTERNAL_ID, EXISTING_SERVICE_EXTERNAL_ID, EXISTING_ROLE_NAME);
+
+    }
+
+    @Test
+    public void shouldError409_whenAssignANewServiceRole_ifRoleForServiceAlreadyExists() throws Exception {
+        when(userDao.findByExternalId(EXISTING_USER_EXTERNAL_ID)).thenReturn(Optional.of(UserEntity.from(aUser(EXISTING_USER_EXTERNAL_ID))));
+        when(serviceDao.findByExternalId(EXISTING_SERVICE_EXTERNAL_ID)).thenReturn(Optional.of(ServiceEntity.from(aService(EXISTING_SERVICE_EXTERNAL_ID))));
+        when(roleDao.findByRoleName(EXISTING_ROLE_NAME)).thenReturn(Optional.empty());
+
+        thrown.expect(WebApplicationException.class);
+        thrown.expectMessage("HTTP 400 Bad Request");
+        serviceRoleCreator.doCreate(EXISTING_USER_EXTERNAL_ID, EXISTING_SERVICE_EXTERNAL_ID, EXISTING_ROLE_NAME);
+
+    }
+
+    private Service aService(String serviceExternalId) {
+        return Service.from(randomInt(),serviceExternalId,"random-service");
+    }
+
+    private Role aRole(int roleId, String roleName) {
+        return Role.role(roleId, roleName, roleName + "-description");
+    }
+
+    private User aUser(String externalId) {
+        return User.from(randomInt(), externalId, "random-name", "random-password", "random@example.com", asList("1"), newArrayList(), "784rh", "8948924", newArrayList());
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceRoleUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceRoleUpdaterTest.java
@@ -93,7 +93,7 @@ public class ServiceRoleUpdaterTest {
         RoleEntity roleEntity = new RoleEntity(aRole(10, role)); //non admin
         ServiceEntity serviceEntity = new ServiceEntity(asList("1"));
         serviceEntity.setExternalId(serviceExternalId);
-        userEntity.setServiceRole(new ServiceRoleEntity(serviceEntity, roleEntity));
+        userEntity.addServiceRole(new ServiceRoleEntity(serviceEntity, roleEntity));
 
         when(userDao.findByExternalId(EXISTING_USER_EXTERNAL_ID)).thenReturn(Optional.of(userEntity));
         when(roleDao.findByRoleName(role)).thenReturn(Optional.of(roleEntity));
@@ -113,7 +113,7 @@ public class ServiceRoleUpdaterTest {
         RoleEntity roleEntity = new RoleEntity(aRole(10, role)); //non admin
         ServiceEntity serviceEntity = new ServiceEntity(asList("1"));
         serviceEntity.setExternalId(serviceExternalId);
-        userEntity.setServiceRole(new ServiceRoleEntity(serviceEntity, roleEntity));
+        userEntity.addServiceRole(new ServiceRoleEntity(serviceEntity, roleEntity));
 
         when(userDao.findByExternalId(EXISTING_USER_EXTERNAL_ID)).thenReturn(Optional.of(userEntity));
         when(roleDao.findByRoleName(role)).thenReturn(Optional.of(roleEntity));

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceUserRemoverTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceUserRemoverTest.java
@@ -163,7 +163,7 @@ public class ServiceUserRemoverTest {
         final UserEntity user = new UserEntity();
         user.setExternalId(externalId);
         user.setExternalId(random(10));
-        user.setServiceRole(serviceRole);
+        user.addServiceRole(serviceRole);
         return user;
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
@@ -171,7 +171,7 @@ public class UserInviteCreatorTest {
         senderUser.setExternalId(senderExternalId);
         senderUser.setEmail(senderEmail);
         RoleEntity role = new RoleEntity(role(ADMIN.getId(), "admin", "Admin Role"));
-        senderUser.setServiceRole(new ServiceRoleEntity(service, role));
+        senderUser.addServiceRole(new ServiceRoleEntity(service, role));
         when(mockUserDao.findByExternalId(senderExternalId)).thenReturn(Optional.of(senderUser));
 
         String inviteCode = "code";

--- a/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
@@ -594,7 +594,7 @@ public class UserServicesTest {
         role.setPermissions(asList(aPermission()));
 
         ServiceRoleEntity serviceRoleEntity = new ServiceRoleEntity(serviceEntity, new RoleEntity(role));
-        userEntity.setServiceRole(serviceRoleEntity);
+        userEntity.addServiceRole(serviceRoleEntity);
 
         return userEntity;
     }


### PR DESCRIPTION
Added a new resource that adds a new service role to a user. This is required in order to write a proper accept test for this story.

- It makes sure the same service is not added to the user twice.
- Also renamed the `notFoundService` exception as it was confusing (throwing 404).
    
with @maxcbc
