### PR TITLE
PP-1876 invite existing user (already exists)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The GOV.UK Pay Admin Users Module in Java (Dropwizard)
 | [```/v1/api/invites/service```](/docs/api_specification.md#post-v1apiinvitesservice)               | POST   |  Creates a invitation for a new service     |
 | [```/v1/api/invites/user```](/docs/api_specification.md#post-v1apiinvitesuser)               | POST   |  Creates a user invitation     |
 | [```/v1/api/service/{externalId}```](/docs/api_specification.md#patch-v1apiservicesserviceexternalid)               | PATCH   |  Updates the value of a service attribute     |
+| [```/v1/api/invites/{code}/complete```](/docs/api_specification.md#post-v1apiinvitescodecomplete)               | POST   |  Completes an invitation by creating user/service     |
 
 
 -----------------------------------------------------------------------------------------------------------

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -674,3 +674,60 @@ Content-Type: application/json
     
 }
 ```
+-----------------------------------------------------------------------------------------------------------
+
+## POST /v1/api/invites/{code}/complete
+
+This endpoint completes the invite by creating user/service and invalidating itself.
+1. In the case of a `user` invite, this resource will assign the new service to the existing user and disables the invite
+2. In the case of a `service` invite, this resource will create a new service, assign gateway account ids (if provided) and also creates a new user and assign to the service 
+
+The response contains the user and the service id's affected as part of the invite completion in addition to the invite
+
+### Request example
+
+```
+POST /v1/api/invites/wewe87325875c6/complete
+```
+
+Optional body (only in the case of invite type `service`)
+```
+Content-Type: application/json
+{
+"gateway_account_ids": ["1","78"]
+}
+
+```
+
+#### Optional Request body description
+
+| Field                    | required | Description                                                      | Supported Values     |
+| ------------------------ |:--------:| ---------------------------------------------------------------- |----------------------|
+| `gateway_account_ids`    |   X      | gateway accounts that needs to be associated for the new service | |
+
+
+### Response example
+
+```
+200 OK
+Content-Type: application/json
+{  
+   invite: { "type":"user",
+             "email":"example@example.gov.uk",
+             "disabled":false,
+             "attempt_counter":0,
+             "_links":[  
+              {  
+                 "rel":"invite",
+                 "method":"GET",
+                 "href":"https://selfservice.pymnt.localdomain/invites/04f431f18c3243f5bb29d10c01659e9c"
+              },
+              {  
+                 "rel":"self",
+                 "method":"GET",
+                 "href":"http://localhost:8080/v1/api/invites/04f431f18c3243f5bb29d10c01659e9c"
+              }]
+            },
+   service_external_id: "89wi6il2364328",
+   user_external_id: "287cg75v3737"          
+```

--- a/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
@@ -34,6 +34,11 @@ public class AdminUsersExceptions {
         return buildWebApplicationException(error, CONFLICT.getStatusCode());
     }
 
+    public static WebApplicationException userAlreadyInService(String userExternalId, String serviceExternalId) {
+        String error = format("user [%s] already in service [%s]", userExternalId, serviceExternalId);
+        return buildWebApplicationException(error, PRECONDITION_FAILED.getStatusCode());
+    }
+
     public static WebApplicationException conflictingServiceGatewayAccountsForUser() {
         String error = format("List of gateway accounts not matching one of the existing services");
         return buildWebApplicationException(error, CONFLICT.getStatusCode());

--- a/src/main/java/uk/gov/pay/adminusers/service/UserInviteCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserInviteCreator.java
@@ -54,6 +54,12 @@ public class UserInviteCreator {
         }
 
         Optional<UserEntity> existingUser = userDao.findByEmail(inviteUserRequest.getEmail());
+        existingUser.ifPresent(userEntity -> {
+            if (userEntity.getServicesRole(inviteUserRequest.getServiceExternalId()).isPresent()) {
+                throw userAlreadyInService(userEntity.getExternalId(), inviteUserRequest.getServiceExternalId());
+            }
+        });
+
         List<InviteEntity> existingInvites = inviteDao.findByEmail(inviteUserRequest.getEmail());
         List<InviteEntity> validInvitesToTheSameService = existingInvites.stream()
                 .filter(inviteEntity -> !inviteEntity.isDisabled() && !inviteEntity.isExpired())

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/InviteDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/InviteDbFixture.java
@@ -9,6 +9,7 @@ import static java.time.temporal.ChronoUnit.DAYS;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.apache.commons.lang3.RandomUtils.nextInt;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 
 public class InviteDbFixture {
@@ -24,6 +25,7 @@ public class InviteDbFixture {
     private Boolean disabled = Boolean.FALSE;
     private Integer loginCounter = 0;
     private String externalServiceId = randomUuid();
+    private Integer serviceId = randomInt();
 
     private InviteDbFixture(DatabaseTestHelper databaseTestHelper) {
         this.databaseTestHelper = databaseTestHelper;
@@ -34,7 +36,7 @@ public class InviteDbFixture {
     }
 
     public String insertInvite() {
-        int serviceId = ServiceDbFixture.serviceDbFixture(databaseTestHelper).withExternalId(externalServiceId).insertService().getId();
+        ServiceDbFixture.serviceDbFixture(databaseTestHelper).withId(serviceId).withExternalId(externalServiceId).insertService().getId();
         int roleId = RoleDbFixture.roleDbFixture(databaseTestHelper).insertRole().getId();
         int invitingUserId = UserDbFixture.userDbFixture(databaseTestHelper).insertUser().getId();
         databaseTestHelper.addInvite(
@@ -93,6 +95,11 @@ public class InviteDbFixture {
 
     public InviteDbFixture withServiceExternalId(String serviceExternalId) {
         this.externalServiceId = serviceExternalId;
+        return this;
+    }
+
+    public InviteDbFixture withServiceId(Integer serviceId) {
+        this.serviceId = serviceId;
         return this;
     }
 }


### PR DESCRIPTION
Handling the corner case in case of the inviting user is already a member of the service. 

Using HTTP 412 (pre-condition failed) error code, just because we need a separate error code, as we have exhausted all other sensible http codes already in this resource.

Also updated the Readme for `complete` resource.