### PR TITLE
PP-1615 refactored otp generate resource to support service invites

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/model/InviteOtpRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/InviteOtpRequest.java
@@ -2,15 +2,21 @@ package uk.gov.pay.adminusers.model;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import static com.google.common.collect.Lists.newArrayList;
+
 public class InviteOtpRequest {
 
     public static final String FIELD_CODE = "code";
     public static final String FIELD_TELEPHONE_NUMBER = "telephone_number";
     public static final String FIELD_PASSWORD = "password";
 
-    private final String code;
-    private final String telephoneNumber;
-    private final String password;
+    @Deprecated //until selfservice adopts to use /v1/api/invites/{code}/otp/generate
+    private String code;
+    private String telephoneNumber;
+    private String password;
+
+    private InviteOtpRequest() {
+    }
 
     private InviteOtpRequest(String code, String telephoneNumber, String password) {
         this.code = code;
@@ -19,10 +25,16 @@ public class InviteOtpRequest {
     }
 
     public static InviteOtpRequest from(JsonNode jsonNode) {
-        String password = (jsonNode.get(FIELD_PASSWORD) != null) ? jsonNode.get(FIELD_PASSWORD).asText() : null;
-        return new InviteOtpRequest(jsonNode.get(FIELD_CODE).asText(), jsonNode.get(FIELD_TELEPHONE_NUMBER).asText(), password);
+        if(jsonNode == null || newArrayList(jsonNode.fieldNames()).isEmpty()) {
+            return new InviteOtpRequest();
+        } else {
+            String password = (jsonNode.get(FIELD_PASSWORD) != null) ? jsonNode.get(FIELD_PASSWORD).asText() : null;
+            String code = (jsonNode.get(FIELD_CODE) != null) ? jsonNode.get(FIELD_CODE).asText() : null;
+            return new InviteOtpRequest(code, jsonNode.get(FIELD_TELEPHONE_NUMBER).asText(), password);
+        }
     }
 
+    @Deprecated
     public String getCode() {
         return code;
     }

--- a/src/main/java/uk/gov/pay/adminusers/model/OtpGenerateRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/OtpGenerateRequest.java
@@ -1,0 +1,4 @@
+package uk.gov.pay.adminusers.model;
+
+public class OtpGenerateRequest {
+}

--- a/src/main/java/uk/gov/pay/adminusers/resources/InviteRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InviteRequestValidator.java
@@ -42,13 +42,17 @@ public class InviteRequestValidator {
     }
 
     public Optional<Errors> validateGenerateOtpRequest(JsonNode payload) {
-        Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExists(payload, FIELD_CODE, FIELD_TELEPHONE_NUMBER, FIELD_PASSWORD);
+        Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExists(payload, FIELD_TELEPHONE_NUMBER, FIELD_PASSWORD);
         if (missingMandatoryFields.isPresent()) {
             return Optional.of(Errors.from(missingMandatoryFields.get()));
         }
-        Optional<List<String>> invalidLength = requestValidations.checkMaxLength(payload, MAX_LENGTH_CODE, FIELD_CODE);
-        return invalidLength.map(Errors::from);
+        if (payload.get(FIELD_CODE) != null) {
+            Optional<List<String>> invalidLength = requestValidations.checkMaxLength(payload, MAX_LENGTH_CODE, FIELD_CODE);
+            return invalidLength.map(Errors::from);
+        }
+        return Optional.empty();
     }
+
 
     public Optional<Errors> validateResendOtpRequest(JsonNode payload) {
         Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExists(payload, FIELD_CODE, FIELD_TELEPHONE_NUMBER);
@@ -76,7 +80,7 @@ public class InviteRequestValidator {
 
 
         String email = payload.get(InviteServiceRequest.FIELD_EMAIL).asText();
-        if(!isValid(email)) {
+        if (!isValid(email)) {
             return Optional.of(Errors.from(format("Field [%s] must be a valid email address", InviteServiceRequest.FIELD_EMAIL)));
         } else if (!isPublicSectorEmail(email)) {
             throw AdminUsersExceptions.invalidPublicSectorEmail(email);

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteOtpDispatcher.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteOtpDispatcher.java
@@ -1,0 +1,17 @@
+package uk.gov.pay.adminusers.service;
+
+import uk.gov.pay.adminusers.model.InviteOtpRequest;
+
+public abstract class InviteOtpDispatcher {
+
+    static final String SIX_DIGITS_WITH_LEADING_ZEROS = "%06d";
+
+    InviteOtpRequest inviteOtpRequest = null;
+
+    public abstract boolean dispatchOtp(String inviteCode);
+
+    public InviteOtpDispatcher withData(InviteOtpRequest data){
+        this.inviteOtpRequest = data;
+        return this;
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteRouter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteRouter.java
@@ -4,8 +4,10 @@ import com.google.inject.Inject;
 import org.apache.commons.lang3.tuple.Pair;
 import uk.gov.pay.adminusers.model.InviteType;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
+import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
 
 import java.util.Optional;
+import java.util.function.Function;
 
 public class InviteRouter {
 
@@ -18,13 +20,27 @@ public class InviteRouter {
         this.inviteDao = inviteDao;
     }
 
-    public Optional<Pair<InviteCompleter, Boolean>> route(String inviteCode) {
-        return inviteDao.findByCode(inviteCode)
-                .map(inviteEntity -> {
+    public Optional<Pair<InviteCompleter, Boolean>> routeComplete(String inviteCode) {
+        return routeIfExist(inviteCode,
+                inviteEntity -> {
                     boolean isServiceType = InviteType.SERVICE.getType().equals(inviteEntity.getType());
                     InviteCompleter inviteCompleter = isServiceType ? inviteServiceFactory.completeServiceInvite() : inviteServiceFactory.completeUserInvite();
                     return Optional.of(Pair.of(inviteCompleter, isServiceType));
-                })
-                .orElseGet(() -> Optional.empty());
+                });
+    }
+
+    public Optional<Pair<InviteOtpDispatcher, Boolean>> routeOtpDispatch(String inviteCode) {
+        return routeIfExist(inviteCode,
+                inviteEntity -> {
+                    boolean isUserType = InviteType.USER.getType().equals(inviteEntity.getType());
+                    InviteOtpDispatcher inviteOtpDispatcher = isUserType ? inviteServiceFactory.dispatchUserOtp() : inviteServiceFactory.dispatchServiceOtp();
+                    return Optional.of(Pair.of(inviteOtpDispatcher, isUserType));
+                });
+
+    }
+
+    private <T> Optional<Pair<T, Boolean>> routeIfExist(String inviteCode, Function<InviteEntity, Optional<Pair<T, Boolean>>> routeFunction) {
+        return inviteDao.findByCode(inviteCode).map(routeFunction)
+                .orElseGet(Optional::empty);
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteServiceFactory.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteServiceFactory.java
@@ -9,9 +9,15 @@ public interface InviteServiceFactory {
 
     InviteFinder inviteFinder();
 
-    InviteRouter inviteRouter();
+    InviteRouter inviteCompleteRouter();
 
     ServiceInviteCompleter completeServiceInvite();
 
     UserInviteCompleter completeUserInvite();
+
+    InviteRouter inviteOtpRouter();
+
+    ServiceOtpDispatcher dispatchServiceOtp();
+
+    UserOtpDispatcher dispatchUserOtp();
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcher.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcher.java
@@ -1,0 +1,47 @@
+package uk.gov.pay.adminusers.service;
+
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import uk.gov.pay.adminusers.logger.PayLoggerFactory;
+import uk.gov.pay.adminusers.persistence.dao.InviteDao;
+
+import java.util.Locale;
+
+import static java.lang.String.format;
+
+public class ServiceOtpDispatcher extends InviteOtpDispatcher {
+
+    private static final Logger LOGGER = PayLoggerFactory.getLogger(ServiceOtpDispatcher.class);
+    private final InviteDao inviteDao;
+    private final SecondFactorAuthenticator secondFactorAuthenticator;
+    private final NotificationService notificationService;
+
+    @Inject
+    public ServiceOtpDispatcher(InviteDao inviteDao, SecondFactorAuthenticator secondFactorAuthenticator, NotificationService notificationService) {
+        this.inviteDao = inviteDao;
+        this.secondFactorAuthenticator = secondFactorAuthenticator;
+        this.notificationService = notificationService;
+    }
+
+    //This doesn't really need to be transactional. as it read-only from database
+    @Override
+    public boolean dispatchOtp(String inviteCode) {
+        return inviteDao.findByCode(inviteCode)
+                .map(inviteEntity -> {
+                    int newPassCode = secondFactorAuthenticator.newPassCode(inviteEntity.getOtpKey());
+                    String passcode = format(Locale.ENGLISH, SIX_DIGITS_WITH_LEADING_ZEROS, newPassCode);
+                    notificationService.sendSecondFactorPasscodeSms(inviteEntity.getTelephoneNumber(), passcode)
+                            .thenAcceptAsync(notificationId -> LOGGER.info("sent 2FA token successfully for invite code [{}], notification id [{}]",
+                                    inviteEntity.getCode(), notificationId))
+                            .exceptionally(exception -> {
+                                LOGGER.error(format("error sending 2FA token for invite code [%s]", inviteEntity.getCode()), exception);
+                                return null;
+                            });
+                    LOGGER.info("New 2FA token generated for invite code [{}]", inviteEntity.getCode());
+                    return true;
+                }).orElseGet(() -> {
+                    LOGGER.error("Unable to locate invite after validating and reaching to the service otp dispatcher. invite code [{}]", inviteCode);
+                    return false;
+                });
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/service/UserOtpDispatcher.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserOtpDispatcher.java
@@ -1,0 +1,53 @@
+package uk.gov.pay.adminusers.service;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+import org.slf4j.Logger;
+import uk.gov.pay.adminusers.logger.PayLoggerFactory;
+import uk.gov.pay.adminusers.persistence.dao.InviteDao;
+
+import java.util.Locale;
+
+import static java.lang.String.format;
+
+public class UserOtpDispatcher extends InviteOtpDispatcher {
+
+    private static final Logger LOGGER = PayLoggerFactory.getLogger(ServiceOtpDispatcher.class);
+    private final InviteDao inviteDao;
+    private final SecondFactorAuthenticator secondFactorAuthenticator;
+    private final PasswordHasher passwordHasher;
+    private final NotificationService notificationService;
+
+    @Inject
+    public UserOtpDispatcher(InviteDao inviteDao, SecondFactorAuthenticator secondFactorAuthenticator, PasswordHasher passwordHasher, NotificationService notificationService) {
+        this.inviteDao = inviteDao;
+        this.secondFactorAuthenticator = secondFactorAuthenticator;
+        this.passwordHasher = passwordHasher;
+        this.notificationService = notificationService;
+    }
+
+    @Transactional
+    @Override
+    public boolean dispatchOtp(String inviteCode) {
+        return inviteDao.findByCode(inviteCode)
+                .map(inviteEntity -> {
+                    inviteEntity.setTelephoneNumber(inviteOtpRequest.getTelephoneNumber());
+                    inviteEntity.setPassword(passwordHasher.hash(inviteOtpRequest.getPassword()));
+                    inviteDao.merge(inviteEntity);
+                    int newPassCode = secondFactorAuthenticator.newPassCode(inviteEntity.getOtpKey());
+                    String passcode = format(Locale.ENGLISH, SIX_DIGITS_WITH_LEADING_ZEROS, newPassCode);
+                    notificationService.sendSecondFactorPasscodeSms(inviteOtpRequest.getTelephoneNumber(), passcode)
+                            .thenAcceptAsync(notificationId -> LOGGER.info("sent 2FA token successfully for invite code [{}], notification id [{}]",
+                                    inviteCode, notificationId))
+                            .exceptionally(exception -> {
+                                LOGGER.error(format("error sending 2FA token for invite code [%s]", inviteCode), exception);
+                                return null;
+                            });
+                    LOGGER.info("New 2FA token generated for invite code [{}]", inviteCode);
+                    return true;
+                }).orElseGet(() -> {
+                    LOGGER.info("New 2FA token generated for invite code [{}]", inviteCode);
+                    return false;
+                });
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
@@ -21,6 +21,7 @@ public class IntegrationTest {
 
     static final String INVITES_RESOURCE_URL = "/v1/api/invites";
     static final String INVITES_GENERATE_OTP_RESOURCE_URL = "/v1/api/invites/otp/generate";
+    static final String INVITES_GENERATE_OTP_RESOURCE_V2_URL = "/v1/api/invites/%s/otp/generate";
     static final String INVITES_RESEND_OTP_RESOURCE_URL = "/v1/api/invites/otp/resend";
     static final String INVITES_VALIDATE_OTP_RESOURCE_URL = "/v1/api/invites/otp/validate";
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGenerateOtpTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGenerateOtpTest.java
@@ -1,0 +1,97 @@
+package uk.gov.pay.adminusers.resources;
+
+import com.google.common.collect.ImmutableMap;
+import com.jayway.restassured.http.ContentType;
+import org.junit.Test;
+import uk.gov.pay.adminusers.fixtures.InviteDbFixture;
+
+import static java.lang.String.format;
+import static javax.ws.rs.core.Response.Status.*;
+import static org.apache.commons.lang3.RandomStringUtils.random;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.newId;
+
+public class InviteResourceGenerateOtpTest extends IntegrationTest {
+
+    private String code;
+
+    private static final String OTP_KEY = newId();
+    private static final String EMAIL = "invited-" + random(5) + "@example.com";
+    private static final String TELEPHONE_NUMBER = "+447999999999";
+    private static final String PASSWORD = "a-secure-password";
+
+
+    @Test
+    public void generateOtp_shouldSucceed_forUserInvite_evenWhenTokenIsExpired_sinceItShouldBeValidatedOnGetInvite() throws Exception {
+        givenAnExistingUserInvite();
+        ImmutableMap<Object, Object> invitationRequest = ImmutableMap.builder()
+                .put("telephone_number", TELEPHONE_NUMBER)
+                .put("password", PASSWORD)
+                .build();
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(invitationRequest))
+                .contentType(ContentType.JSON)
+                .post(format(INVITES_GENERATE_OTP_RESOURCE_V2_URL, code))
+                .then()
+                .statusCode(OK.getStatusCode());
+    }
+
+    @Test
+    public void generateOtp_should_FailforUserInvite_whenInviteDoesNotExist() throws Exception {
+        ImmutableMap<Object, Object> invitationRequest = ImmutableMap.builder()
+                .put("telephone_number", TELEPHONE_NUMBER)
+                .put("password", PASSWORD)
+                .build();
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(invitationRequest))
+                .contentType(ContentType.JSON)
+                .post(format(INVITES_GENERATE_OTP_RESOURCE_V2_URL, "not-existing-code"))
+                .then()
+                .statusCode(NOT_FOUND.getStatusCode());
+    }
+
+    @Test
+    public void generateOtp_shouldFail_forUserInvite_whenAllMandatoryFieldsAreMissing() throws Exception {
+        givenAnExistingUserInvite();
+        ImmutableMap<Object, Object> invitationRequest = ImmutableMap.builder()
+                .build();
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(invitationRequest))
+                .contentType(ContentType.JSON)
+                .post(format(INVITES_GENERATE_OTP_RESOURCE_V2_URL, code))
+                .then()
+                .statusCode(BAD_REQUEST.getStatusCode());
+    }
+
+
+    @Test
+    public void generateOtp_shouldSucceed_forServiceInvite_evenWhenTokenIsExpired_sinceItShouldBeValidatedOnGetInvite() throws Exception {
+        givenAnExistingServiceInvite();
+        givenSetup()
+                .when()
+                .contentType(ContentType.JSON)
+                .post(format(INVITES_GENERATE_OTP_RESOURCE_V2_URL, code))
+                .then()
+                .statusCode(OK.getStatusCode());
+    }
+
+    private void givenAnExistingUserInvite() {
+        code = InviteDbFixture.inviteDbFixture(databaseHelper)
+                .withEmail(EMAIL)
+                .withOtpKey(OTP_KEY)
+                .expired()
+                .insertInvite();
+    }
+
+    private void givenAnExistingServiceInvite() {
+        code = InviteDbFixture.inviteDbFixture(databaseHelper)
+                .withEmail(EMAIL)
+                .withOtpKey(OTP_KEY)
+                .insertServiceInvite();
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpTest.java
@@ -40,6 +40,7 @@ public class InviteResourceOtpTest extends IntegrationTest {
                 .insertInvite();
     }
 
+    //TODO Deprecated, leaving for backward compatibility
     @Test
     public void generateOtp_shouldSucceed_evenWhenTokenIsExpired_sinceItShouldBeValidatedOnGetInvite() throws Exception {
 
@@ -58,6 +59,7 @@ public class InviteResourceOtpTest extends IntegrationTest {
                 .statusCode(OK.getStatusCode());
     }
 
+    //TODO Deprecated, leaving for backward compatibility
     @Test
     public void generateOtp_shouldFail_whenInviteDoesNotExist() throws Exception {
 
@@ -76,6 +78,7 @@ public class InviteResourceOtpTest extends IntegrationTest {
                 .statusCode(NOT_FOUND.getStatusCode());
     }
 
+    //TODO Deprecated, leaving for backward compatibility
     @Test
     public void generateOtp_shouldFail_whenAllMandatoryFieldsAreMissing() throws Exception {
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteUserRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteUserRequestValidatorTest.java
@@ -113,9 +113,8 @@ public class InviteUserRequestValidatorTest {
         assertTrue(optionalErrors.isPresent());
         Errors errors = optionalErrors.get();
 
-        assertThat(errors.getErrors().size(), is(3));
+        assertThat(errors.getErrors().size(), is(2));
         assertThat(errors.getErrors(), hasItems(
-                "Field [code] is required",
                 "Field [telephone_number] is required",
                 "Field [password] is required"));
     }
@@ -124,7 +123,6 @@ public class InviteUserRequestValidatorTest {
     public void validateGenerateOtpRequest_shouldError_ifCodeFieldIsMissing() throws Exception {
 
         String invalidPayload = "{" +
-                "\"telephone_number\": \"a-telephone_number\"," +
                 "\"password\": \"a-password\"" +
                 "}";
         JsonNode jsonNode = objectMapper.readTree(invalidPayload);
@@ -136,7 +134,7 @@ public class InviteUserRequestValidatorTest {
 
         assertThat(errors.getErrors().size(), is(1));
         assertThat(errors.getErrors(), hasItems(
-                "Field [code] is required"));
+                "Field [telephone_number] is required"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/service/InviteRouterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/InviteRouterTest.java
@@ -1,0 +1,99 @@
+package uk.gov.pay.adminusers.service;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.pay.adminusers.model.InviteType;
+import uk.gov.pay.adminusers.persistence.dao.InviteDao;
+import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
+
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.adminusers.model.InviteType.SERVICE;
+import static uk.gov.pay.adminusers.model.InviteType.USER;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InviteRouterTest {
+
+    @Mock
+    InviteDao inviteDao;
+
+    @Mock
+    InviteServiceFactory inviteServiceFactory;
+
+    InviteRouter inviteRouter;
+
+    @Before
+    public void before() throws Exception {
+        inviteRouter = new InviteRouter(inviteServiceFactory, inviteDao);
+    }
+
+    @Test
+    public void shouldResolve_serviceInviteCompleter_withValidation() throws Exception {
+        String inviteCode = "a-code";
+        InviteEntity inviteEntity = anInvite(inviteCode, SERVICE);
+        when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
+        when(inviteServiceFactory.completeServiceInvite()).thenReturn(new ServiceInviteCompleter(null, null, null, null));
+        Optional<Pair<InviteCompleter, Boolean>> result = inviteRouter.routeComplete(inviteCode);
+
+        assertThat(result.isPresent(), is(true));
+        assertThat(result.get().getLeft(), is(instanceOf(ServiceInviteCompleter.class)));
+        assertThat(result.get().getRight(), is(true));
+    }
+
+    @Test
+    public void shouldResolve_userInviteCompleter_withoutValidation() throws Exception {
+        String inviteCode = "a-code";
+        InviteEntity inviteEntity = anInvite(inviteCode, USER);
+        when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
+        when(inviteServiceFactory.completeUserInvite()).thenReturn(new UserInviteCompleter(null, null));
+        Optional<Pair<InviteCompleter, Boolean>> result = inviteRouter.routeComplete(inviteCode);
+
+        assertThat(result.isPresent(), is(true));
+        assertThat(result.get().getLeft(), is(instanceOf(UserInviteCompleter.class)));
+        assertThat(result.get().getRight(), is(false));
+    }
+
+    @Test
+    public void shouldResolve_userInviteDispatcher_withValidation() throws Exception {
+        String inviteCode = "a-code";
+        InviteEntity inviteEntity = anInvite(inviteCode, USER);
+        when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
+        when(inviteServiceFactory.dispatchUserOtp()).thenReturn(new UserOtpDispatcher(null, null, null, null));
+        Optional<Pair<InviteOtpDispatcher, Boolean>> result = inviteRouter.routeOtpDispatch(inviteCode);
+
+        assertThat(result.isPresent(), is(true));
+        assertThat(result.get().getLeft(), is(instanceOf(UserOtpDispatcher.class)));
+        assertThat(result.get().getRight(), is(true));
+    }
+
+    @Test
+    public void shouldResolve_serviceInviteDispatcher_withoutValidation() throws Exception {
+        String inviteCode = "a-code";
+        InviteEntity inviteEntity = anInvite(inviteCode, SERVICE);
+        when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
+        when(inviteServiceFactory.dispatchServiceOtp()).thenReturn(new ServiceOtpDispatcher(null, null, null));
+        Optional<Pair<InviteOtpDispatcher, Boolean>> result = inviteRouter.routeOtpDispatch(inviteCode);
+
+        assertThat(result.isPresent(), is(true));
+        assertThat(result.get().getLeft(), is(instanceOf(ServiceOtpDispatcher.class)));
+        assertThat(result.get().getRight(), is(false));
+    }
+
+    private InviteEntity anInvite(String code, InviteType inviteType) {
+        InviteEntity inviteEntity = new InviteEntity();
+        inviteEntity.setCode(code);
+        inviteEntity.setEmail("example@example.com");
+        inviteEntity.setTelephoneNumber("2746234782");
+        inviteEntity.setOtpKey("u73t2b7");
+        inviteEntity.setType(inviteType);
+        return inviteEntity;
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcherTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcherTest.java
@@ -1,0 +1,65 @@
+package uk.gov.pay.adminusers.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.pay.adminusers.model.InviteType;
+import uk.gov.pay.adminusers.persistence.dao.InviteDao;
+import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ServiceOtpDispatcherTest {
+
+    @Mock
+    InviteDao inviteDao;
+    @Mock
+    SecondFactorAuthenticator secondFactorAuthenticator;
+    @Mock
+    NotificationService notificationService;
+
+    InviteOtpDispatcher serviceOtpDispatcher;
+
+    @Before
+    public void before() throws Exception {
+        serviceOtpDispatcher = new ServiceOtpDispatcher(inviteDao, secondFactorAuthenticator, notificationService);
+    }
+
+    @Test
+    public void shouldSuccess_whenDispatchServiceOtp_ifInviteEntityExist() throws Exception {
+        String inviteCode = "valid-invite-code";
+        String telephone = "78562835762";
+        InviteEntity inviteEntity = new InviteEntity();
+        inviteEntity.setCode(inviteCode);
+        inviteEntity.setType(InviteType.SERVICE);
+        inviteEntity.setOtpKey("otp-key");
+        inviteEntity.setTelephoneNumber(telephone);
+
+
+        when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
+        when(secondFactorAuthenticator.newPassCode("otp-key")).thenReturn(123456);
+        when(notificationService.sendSecondFactorPasscodeSms(telephone,"123456")).thenReturn(CompletableFuture.completedFuture("success code from notify"));
+        boolean dispatched = serviceOtpDispatcher.dispatchOtp(inviteCode);
+
+        assertThat(dispatched,is(true));
+    }
+
+    @Test
+    public void shouldFail_whenDispatchServiceOtp_ifInviteEntityNotFound() throws Exception {
+
+        String inviteCode = "non-existent-code";
+        when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.empty());
+
+        boolean dispatched = serviceOtpDispatcher.dispatchOtp(inviteCode);
+
+        assertThat(dispatched,is(false));
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/service/UserOtpDispatcherTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserOtpDispatcherTest.java
@@ -1,0 +1,77 @@
+package uk.gov.pay.adminusers.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.pay.adminusers.model.InviteOtpRequest;
+import uk.gov.pay.adminusers.model.InviteType;
+import uk.gov.pay.adminusers.persistence.dao.InviteDao;
+import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UserOtpDispatcherTest {
+
+    @Mock
+    InviteDao inviteDao;
+    @Mock
+    SecondFactorAuthenticator secondFactorAuthenticator;
+    @Mock
+    NotificationService notificationService;
+
+    ArgumentCaptor<InviteEntity> expectedInvite = ArgumentCaptor.forClass(InviteEntity.class);
+
+    InviteOtpDispatcher userOtpDispatcher;
+
+    @Before
+    public void before() throws Exception {
+        userOtpDispatcher = new UserOtpDispatcher(inviteDao, secondFactorAuthenticator, new PasswordHasher(), notificationService);
+    }
+
+    @Test
+    public void shouldSuccess_whenDispatchUserOtp_ifInviteEntityExist() throws Exception {
+        String inviteCode = "valid-invite-code";
+        String telephone = "78562835762";
+        InviteEntity inviteEntity = new InviteEntity();
+        inviteEntity.setCode(inviteCode);
+        inviteEntity.setType(InviteType.USER);
+        inviteEntity.setOtpKey("otp-key");
+
+        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("telephone_number", telephone, "password", "random"));
+        userOtpDispatcher = userOtpDispatcher.withData(InviteOtpRequest.from(payload));
+
+        when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
+        when(secondFactorAuthenticator.newPassCode("otp-key")).thenReturn(123456);
+        when(notificationService.sendSecondFactorPasscodeSms(telephone, "123456")).thenReturn(CompletableFuture.completedFuture("success code from notify"));
+        boolean dispatched = userOtpDispatcher.dispatchOtp(inviteCode);
+
+        verify(inviteDao).merge(expectedInvite.capture());
+        assertThat(dispatched, is(true));
+        assertThat(expectedInvite.getValue().getTelephoneNumber(),is(telephone));
+        assertThat(expectedInvite.getValue().getPassword(),is(notNullValue()));
+    }
+
+    @Test
+    public void shouldFail_whenDispatchServiceOtp_ifInviteEntityNotFound() throws Exception {
+        String inviteCode = "non-existent-code";
+        when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.empty());
+
+        boolean dispatched = userOtpDispatcher.dispatchOtp(inviteCode);
+
+        assertThat(dispatched,is(false));
+    }
+}


### PR DESCRIPTION
This now generates + dispatches otp for both USER and SERVICE invites.
Using the same routing approach similar to `complete` resource
Leaving the old `generateOtp` resource for backward compatibility