### PR TITLE
PP-1615 remove deprecated otp generate endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ The GOV.UK Pay Admin Users Module in Java (Dropwizard)
 | [```/v1/api/invites/user```](/docs/api_specification.md#post-v1apiinvitesuser)               | POST   |  Creates a user invitation     |
 | [```/v1/api/service/{externalId}```](/docs/api_specification.md#patch-v1apiservicesserviceexternalid)               | PATCH   |  Updates the value of a service attribute     |
 | [```/v1/api/invites/{code}/complete```](/docs/api_specification.md#post-v1apiinvitescodecomplete)               | POST   |  Completes an invitation by creating user/service     |
-
-
+| [```/v1/api/invites/{code}/otp/generate```](/docs/api_specification.md#post-v1apiinvitescodeotpgenerate)               | POST   |  Generates and sends otp verification code to the phone number registered in the invite     |
+****
 -----------------------------------------------------------------------------------------------------------
 
 ## Licence

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -674,6 +674,7 @@ Content-Type: application/json
     
 }
 ```
+
 -----------------------------------------------------------------------------------------------------------
 
 ## POST /v1/api/invites/{code}/complete
@@ -730,4 +731,50 @@ Content-Type: application/json
             },
    service_external_id: "89wi6il2364328",
    user_external_id: "287cg75v3737"          
+```
+
+-----------------------------------------------------------------------------------------------------------
+
+## POST /v1/api/invites/`{code}`/otp/generate
+
+This endpoint generates and sends otp verification code to the phone number registered in the invite.
+
+### `user` invite
+
+#### Request example (`user` invite)
+
+```
+POST /v1/api/invites/265f39f63d8347f3bc5bf2d401b5e3ec/otp/generate
+Content-Type: application/json
+{
+ "telephone_number": "07451234567",
+ "password": "a-password"
+}
+```
+
+#### Request body description (`user` invite)
+
+| Field                    | required | Description                                                      | Supported Values     |
+| ------------------------ |:--------:| ---------------------------------------------------------------- |----------------------|
+| `telephone_number`       |   X      | the phone number of the user                                     | |
+| `password`               |   X      | password for the new user                                        | |
+
+#### Response example (`user` invite)
+
+```
+200 OK
+```
+
+### `service` invite
+
+#### Request example (`service` invite)
+
+```
+POST /v1/api/invites/265f39f63d8347f3bc5bf2d401b5e3ec/otp/generate
+```
+
+#### Response example (`service` invite)
+
+```
+200 OK
 ```

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -71,7 +71,7 @@ Content-Type: application/json
 
 -----------------------------------------------------------------------------------------------------------
 
-## GET /v1/api/users/{externalId}
+## GET /v1/api/users/`{externalId}`
 
 This endpoint finds and return a user with the given external id.
 
@@ -121,7 +121,7 @@ Content-Type: application/json
 
 -----------------------------------------------------------------------------------------------------------
 
-## PATCH /v1/api/users/{externalId}
+## PATCH /v1/api/users/`{externalId}`
 
 This endpoint amends a specific attribute in user resource.
 
@@ -282,7 +282,7 @@ Content-Type: application/json
 
 -----------------------------------------------------------------------------------------------------------
 
-## GET /v1/api/forgotten-passwords/{code}
+## GET /v1/api/forgotten-passwords/`{code}`
 
 Verify that the code is valid
 
@@ -317,7 +317,7 @@ Content-Type: application/json
 
 -----------------------------------------------------------------------------------------------------------
 
-## PUT /v1/api/users/{externalId}/services/{serviceId}
+## PUT /v1/api/users/`{externalId}`/services/`{serviceId}`
 
 This endpoint updates a service role of a perticular user.
 
@@ -394,7 +394,7 @@ Content-Type: application/json
 
 -----------------------------------------------------------------------------------------------------------
 
-## POST /v1/api/users/{externalId}/services
+## POST /v1/api/users/`{externalId}`/services
 
 This endpoint assigns a new service role to a user.
 
@@ -630,7 +630,7 @@ Content-Type: application/json
 
 -----------------------------------------------------------------------------------------------------------
 
-## PATCH /v1/api/services/{serviceExternalId}
+## PATCH /v1/api/services/`{serviceExternalId}`
 
 This endpoint modifies updatable attributes of a Service. Currently supports
  - Update the name of a service
@@ -677,7 +677,7 @@ Content-Type: application/json
 
 -----------------------------------------------------------------------------------------------------------
 
-## POST /v1/api/invites/{code}/complete
+## POST /v1/api/invites/`{code}`/complete
 
 This endpoint completes the invite by creating user/service and invalidating itself.
 1. In the case of a `user` invite, this resource will assign the new service to the existing user and disables the invite

--- a/src/main/java/uk/gov/pay/adminusers/model/InviteOtpRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/InviteOtpRequest.java
@@ -10,7 +10,7 @@ public class InviteOtpRequest {
     public static final String FIELD_TELEPHONE_NUMBER = "telephone_number";
     public static final String FIELD_PASSWORD = "password";
 
-    @Deprecated //until selfservice adopts to use /v1/api/invites/{code}/otp/generate
+    @Deprecated //until "/otp/resend" is refactored into "{code}/otp/resend"
     private String code;
     private String telephoneNumber;
     private String password;

--- a/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
@@ -149,23 +149,6 @@ public class InviteResource {
                 );
     }
 
-    @Deprecated // use
-    @POST
-    @Path("/otp/generate")
-    @Consumes(APPLICATION_JSON)
-    @Produces(APPLICATION_JSON)
-    public Response generateOtp(JsonNode payload) {
-
-        LOGGER.info("Invite POST request for generating otp");
-
-        return inviteValidator.validateGenerateOtpRequest(payload)
-                .map(errors -> Response.status(BAD_REQUEST).entity(errors).build())
-                .orElseGet(() -> {
-                    inviteService.generateOtp(InviteOtpRequest.from(payload));
-                    return Response.status(OK).build();
-                });
-    }
-
     @POST
     @Path("/otp/resend")
     @Consumes(APPLICATION_JSON)

--- a/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
@@ -20,8 +20,7 @@ public class IntegrationTest {
     static final String USER_SERVICE_RESOURCE = USER_RESOURCE_URL + "/services/%s";
 
     static final String INVITES_RESOURCE_URL = "/v1/api/invites";
-    static final String INVITES_GENERATE_OTP_RESOURCE_URL = "/v1/api/invites/otp/generate";
-    static final String INVITES_GENERATE_OTP_RESOURCE_V2_URL = "/v1/api/invites/%s/otp/generate";
+    static final String INVITES_GENERATE_OTP_RESOURCE_URL = "/v1/api/invites/%s/otp/generate";
     static final String INVITES_RESEND_OTP_RESOURCE_URL = "/v1/api/invites/otp/resend";
     static final String INVITES_VALIDATE_OTP_RESOURCE_URL = "/v1/api/invites/otp/validate";
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGenerateOtpTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGenerateOtpTest.java
@@ -32,7 +32,7 @@ public class InviteResourceGenerateOtpTest extends IntegrationTest {
                 .when()
                 .body(mapper.writeValueAsString(invitationRequest))
                 .contentType(ContentType.JSON)
-                .post(format(INVITES_GENERATE_OTP_RESOURCE_V2_URL, code))
+                .post(format(INVITES_GENERATE_OTP_RESOURCE_URL, code))
                 .then()
                 .statusCode(OK.getStatusCode());
     }
@@ -48,7 +48,7 @@ public class InviteResourceGenerateOtpTest extends IntegrationTest {
                 .when()
                 .body(mapper.writeValueAsString(invitationRequest))
                 .contentType(ContentType.JSON)
-                .post(format(INVITES_GENERATE_OTP_RESOURCE_V2_URL, "not-existing-code"))
+                .post(format(INVITES_GENERATE_OTP_RESOURCE_URL, "not-existing-code"))
                 .then()
                 .statusCode(NOT_FOUND.getStatusCode());
     }
@@ -63,7 +63,7 @@ public class InviteResourceGenerateOtpTest extends IntegrationTest {
                 .when()
                 .body(mapper.writeValueAsString(invitationRequest))
                 .contentType(ContentType.JSON)
-                .post(format(INVITES_GENERATE_OTP_RESOURCE_V2_URL, code))
+                .post(format(INVITES_GENERATE_OTP_RESOURCE_URL, code))
                 .then()
                 .statusCode(BAD_REQUEST.getStatusCode());
     }
@@ -75,7 +75,7 @@ public class InviteResourceGenerateOtpTest extends IntegrationTest {
         givenSetup()
                 .when()
                 .contentType(ContentType.JSON)
-                .post(format(INVITES_GENERATE_OTP_RESOURCE_V2_URL, code))
+                .post(format(INVITES_GENERATE_OTP_RESOURCE_URL, code))
                 .then()
                 .statusCode(OK.getStatusCode());
     }

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpTest.java
@@ -40,60 +40,6 @@ public class InviteResourceOtpTest extends IntegrationTest {
                 .insertInvite();
     }
 
-    //TODO Deprecated, leaving for backward compatibility
-    @Test
-    public void generateOtp_shouldSucceed_evenWhenTokenIsExpired_sinceItShouldBeValidatedOnGetInvite() throws Exception {
-
-        ImmutableMap<Object, Object> invitationRequest = ImmutableMap.builder()
-                .put("code", code)
-                .put("telephone_number", TELEPHONE_NUMBER)
-                .put("password", PASSWORD)
-                .build();
-
-        givenSetup()
-                .when()
-                .body(mapper.writeValueAsString(invitationRequest))
-                .contentType(ContentType.JSON)
-                .post(INVITES_GENERATE_OTP_RESOURCE_URL)
-                .then()
-                .statusCode(OK.getStatusCode());
-    }
-
-    //TODO Deprecated, leaving for backward compatibility
-    @Test
-    public void generateOtp_shouldFail_whenInviteDoesNotExist() throws Exception {
-
-        ImmutableMap<Object, Object> invitationRequest = ImmutableMap.builder()
-                .put("code", "not-existing-code")
-                .put("telephone_number", TELEPHONE_NUMBER)
-                .put("password", PASSWORD)
-                .build();
-
-        givenSetup()
-                .when()
-                .body(mapper.writeValueAsString(invitationRequest))
-                .contentType(ContentType.JSON)
-                .post(INVITES_GENERATE_OTP_RESOURCE_URL)
-                .then()
-                .statusCode(NOT_FOUND.getStatusCode());
-    }
-
-    //TODO Deprecated, leaving for backward compatibility
-    @Test
-    public void generateOtp_shouldFail_whenAllMandatoryFieldsAreMissing() throws Exception {
-
-        ImmutableMap<Object, Object> invitationRequest = ImmutableMap.builder()
-                .build();
-
-        givenSetup()
-                .when()
-                .body(mapper.writeValueAsString(invitationRequest))
-                .contentType(ContentType.JSON)
-                .post(INVITES_GENERATE_OTP_RESOURCE_URL)
-                .then()
-                .statusCode(BAD_REQUEST.getStatusCode());
-    }
-
     @Test
     public void validateOtp_shouldCreateUserWhenValidOtp() throws Exception {
 


### PR DESCRIPTION
# WHAT

- Removed deprecated `/v1/api/invites/otp/generate` endpoint. It is not used by selfservice anymore.
We use the new `/v1/api/invites/{code}/otp/generate` instead.
- Added documentation