### PR TITLE
PP-1615 Correct supportUrl

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -80,7 +80,7 @@ links:
   selfserviceInvitesUrl: ${SELFSERVICE_INVITES_URL:-https://selfservice.pymnt.localdomain/invites}
   selfserviceLoginUrl: ${SELFSERVICE_LOGIN_URL:-https://selfservice.pymnt.localdomain/login}
   selfserviceForgottenPasswordUrl: ${SELFSERVICE_FORGOTTEN_PASSWORD_URL:-https://selfservice.pymnt.localdomain/reset-password}
-  supportUrl: ${SUPPORT_URL:-https://frontend.pymnt.localdomain/support.html}
+  supportUrl: ${SUPPORT_URL:-https://frontend.pymnt.localdomain/contact/}
 
 baseUrl: ${BASE_URL:-http://localhost:8080}
 loginAttemptCap: ${LOGIN_ATTEMPT_CAP:-10}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -80,7 +80,7 @@ links:
   selfserviceInvitesUrl: ${SELFSERVICE_INVITES_URL:-https://selfservice.pymnt.localdomain/invites}
   selfserviceLoginUrl: ${SELFSERVICE_LOGIN_URL:-https://selfservice.pymnt.localdomain/login}
   selfserviceForgottenPasswordUrl: ${SELFSERVICE_FORGOTTEN_PASSWORD_URL:-https://selfservice.pymnt.localdomain/reset-password}
-  supportUrl: ${SUPPORT_URL:-https://frontend.pymnt.localdomain/support.html}
+  supportUrl: ${SUPPORT_URL:-https://frontend.pymnt.localdomain/contact/}
 
 baseUrl: ${BASE_URL:-http://localhost:8080}
 loginAttemptCap: ${LOGIN_ATTEMPT_CAP:-10}


### PR DESCRIPTION
## WHAT

In notify email templates currently https://www.payments.service.gov.uk/support.html is returning `404 - not found`. That is why https://www.payments.service.gov.uk/contact/ seems to be more appropriate.
