### PR TITLE
PP-2382 fix otp resend causing password reset to blank

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
@@ -160,7 +160,7 @@ public class InviteResource {
         return inviteValidator.validateResendOtpRequest(payload)
                 .map(errors -> Response.status(BAD_REQUEST).entity(errors).build())
                 .orElseGet(() -> {
-                    inviteService.generateOtp(InviteOtpRequest.from(payload));
+                    inviteService.reGenerateOtp(InviteOtpRequest.from(payload));
                     return Response.status(OK).build();
                 });
     }


### PR DESCRIPTION
 This was caused by reusing the same logic between generateOtp when a new user signs up (where password is mandatory) by resend otp step(in self provisioning a service and new user creation).
 As we have refactored out the generate Otp to new resource `v1/api/invites/{code}/otp/generate` this resource is only used by resend attempts. So no need of password setting in with either cases.

 It probably better to remove this method (InviteService.reGenerateOtp()) altogether and use a an approach similar to UserOtpDispatcher.java to avoid confusion.