### PR TITLE
PP-2017 remove jstl dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,12 @@
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
             <version>3.3.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>jstl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>


### PR DESCRIPTION
Same as for connector:

This was pulled by a transitive dependency of liquibase, although they themselves doesn't need it