### PR TITLE
PP-2453 Made custom_branding to be a JSON object

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -698,8 +698,9 @@ Content-Type: application/json
 This endpoint modifies updatable attributes of a Service. Currently supports
  - Update the name of a service
  - Add new gateway account(s) to a service.
+ - Update/replace the custom branding of a service.
 
-### Request example
+### Request example (for updating name)
 
 ```
 PATCH /v1/api/services/7d19aff33f8948deb97ed16b2912dcd3
@@ -712,13 +713,43 @@ Content-Type: application/json
 
 ```
 
+### Request example (for assigning gateway accounts)
+
+```
+PATCH /v1/api/services/7d19aff33f8948deb97ed16b2912dcd3
+Content-Type: application/json
+{
+ "op": "add",
+ "path": "gateway_account_ids", 
+ "value": ["1", "123"] 
+}
+
+```
+
+### Request example (for updating custom branding)
+Any valid JSON is allowed for value (including empty `{}`)
+
+```
+PATCH /v1/api/services/7d19aff33f8948deb97ed16b2912dcd3
+Content-Type: application/json
+{
+ "op": "add",
+ "path": "gateway_account_ids", 
+ "value": {
+    "css_path" : "/some.url/css.css",
+    "image_path" : "/some.url/image.jpg",
+ } 
+}
+
+```
+
 #### Request body description
 
 | Field                    | required | Description                                                      | Supported Values     |
 | ------------------------ |:--------:| ---------------------------------------------------------------- |----------------------|
 | `op`                     |   X      | operation to perform on attribute                                | `replace`, `add`     |
 | `path`                   |   X      | attribute that is affecting                                      | `gateway_account_ids` , `name`, `custom_branding` |
-| `value`                  |   X         | value to be replaced                                          |                      |
+| `value`                  |   X      | value to be replaced                                             |                      |
 
 ### Response example
 

--- a/src/main/java/uk/gov/pay/adminusers/model/Service.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Service.java
@@ -90,7 +90,14 @@ public class Service {
         return customBranding;
     }
 
+    /**
+     * nullify if map is empty, so that it will be undefined in response
+     * @param customBranding
+     */
     public void setCustomBranding(Map<String, Object> customBranding) {
+        if (customBranding != null && customBranding.isEmpty()) {
+            customBranding = null;
+        }
         this.customBranding = customBranding;
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/model/Service.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Service.java
@@ -1,15 +1,18 @@
 package uk.gov.pay.adminusers.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class Service {
 
@@ -20,7 +23,7 @@ public class Service {
     private String name = DEFAULT_NAME_VALUE;
     private List<Link> links = new ArrayList<>();
     private List<String> gatewayAccountIds = new ArrayList<>();
-    private String customBranding;
+    private Map<String, Object> customBranding;
 
     public static Service from() {
         return from(DEFAULT_NAME_VALUE);
@@ -83,11 +86,11 @@ public class Service {
         this.gatewayAccountIds = gatewayAccountIds;
     }
 
-    public String getCustomBranding() {
+    public Map<String, Object> getCustomBranding() {
         return customBranding;
     }
 
-    public void setCustomBranding(String customBranding) {
+    public void setCustomBranding(Map<String, Object> customBranding) {
         this.customBranding = customBranding;
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/CustomBrandingConverter.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/CustomBrandingConverter.java
@@ -1,0 +1,42 @@
+package uk.gov.pay.adminusers.persistence.entity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.postgresql.util.PGobject;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Map;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+@Converter
+public class CustomBrandingConverter implements AttributeConverter<Map<String, Object>, PGobject> {
+    @Override
+    public PGobject convertToDatabaseColumn(Map<String, Object> customBranding) {
+        PGobject dbCustomBranding = new PGobject();
+        dbCustomBranding.setType("json");
+        try {
+            dbCustomBranding.setValue(new ObjectMapper().writeValueAsString(customBranding));
+        } catch (SQLException | JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        return dbCustomBranding;
+    }
+
+    @Override
+    public Map<String, Object> convertToEntityAttribute(PGobject dbCustomBranding) {
+        try {
+            if (dbCustomBranding != null && !isEmpty(dbCustomBranding.toString())) {
+                return new ObjectMapper().readValue(dbCustomBranding.toString(), new TypeReference<Map<String, Object>>() {});
+            } else {
+                return null;
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
@@ -99,9 +99,7 @@ public class ServiceEntity {
         service.setGatewayAccountIds(gatewayAccountIds.stream()
                 .map(idEntity -> idEntity.getGatewayAccountId())
                 .collect(Collectors.toList()));
-        if (this.customBranding != null) {
-            service.setCustomBranding(this.customBranding);
-        }
+        service.setCustomBranding(this.customBranding);
         return service;
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
@@ -6,6 +6,7 @@ import uk.gov.pay.adminusers.model.Service;
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
@@ -26,8 +27,9 @@ public class ServiceEntity {
     @Column(name = "name")
     private String name = Service.DEFAULT_NAME_VALUE;
 
-    @Column(name = "custom_branding")
-    private String customBranding;
+    @Column(name = "custom_branding", columnDefinition = "json")
+    @Convert(converter = CustomBrandingConverter.class)
+    private Map<String, Object> customBranding;
 
     @OneToMany(mappedBy = "service", targetEntity = GatewayAccountIdEntity.class, fetch = FetchType.EAGER, cascade = CascadeType.PERSIST)
     private List<GatewayAccountIdEntity> gatewayAccountIds = new ArrayList<>();
@@ -84,11 +86,11 @@ public class ServiceEntity {
         populateGatewayAccountIds(asList(gatewayAccountIds));
     }
 
-    public String getCustomBranding() {
+    public Map<String, Object> getCustomBranding() {
         return customBranding;
     }
 
-    public void setCustomBranding(String customBranding) {
+    public void setCustomBranding(Map<String, Object> customBranding) {
         this.customBranding = customBranding;
     }
 
@@ -97,7 +99,7 @@ public class ServiceEntity {
         service.setGatewayAccountIds(gatewayAccountIds.stream()
                 .map(idEntity -> idEntity.getGatewayAccountId())
                 .collect(Collectors.toList()));
-        if(this.customBranding!=null) {
+        if (this.customBranding != null) {
             service.setCustomBranding(this.customBranding);
         }
         return service;

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
@@ -83,10 +83,8 @@ public class ServiceRequestValidator {
     }
 
     private Optional<List<String>> checkIfNotEmptyAndJson(JsonNode payload) {
-        if (payload != null && payload.isTextual() && !isBlank(payload.asText())) {
-            if (!payload.isObject()) {
-                return Optional.of(Collections.singletonList(format("Value for path [%s] must be a JSON", FIELD_CUSTOM_BRANDING)));
-            }
+        if (payload == null || !payload.isObject()) {
+            return Optional.of(Collections.singletonList(format("Value for path [%s] must be a JSON", FIELD_CUSTOM_BRANDING)));
         }
         return Optional.empty();
     }

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
@@ -3,16 +3,11 @@ package uk.gov.pay.adminusers.resources;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.math.NumberUtils;
-import org.slf4j.Logger;
-import uk.gov.pay.adminusers.logger.PayLoggerFactory;
 import uk.gov.pay.adminusers.utils.Errors;
 import uk.gov.pay.adminusers.validations.RequestValidations;
 
 import javax.inject.Inject;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -22,8 +17,6 @@ import static uk.gov.pay.adminusers.model.ServiceUpdateRequest.*;
 
 
 public class ServiceRequestValidator {
-
-    private static final Logger LOGGER = PayLoggerFactory.getLogger(ServiceRequestValidator.class);
 
     public static final String FIELD_SERVICE_NAME = "name";
     public static final String FIELD_GATEWAY_ACCOUNT_IDS = "gateway_account_ids";
@@ -68,10 +61,13 @@ public class ServiceRequestValidator {
 
         String path = payload.get("path").asText();
         if (!FIELD_CUSTOM_BRANDING.equals(path)) {
-            errors = requestValidations.checkIfExists(payload,FIELD_VALUE);
-            if (errors.isPresent()) {
-                return Optional.of(Errors.from(errors.get()));
-            }
+            errors = requestValidations.checkIfExists(payload, FIELD_VALUE);
+        } else {
+            errors = checkIfNotEmptyAndJson(payload.get(FIELD_VALUE));
+        }
+
+        if (errors.isPresent()) {
+            return Optional.of(Errors.from(errors.get()));
         }
 
         if (!VALID_ATTRIBUTE_UPDATE_OPERATIONS.keySet().contains(path)) {
@@ -83,6 +79,15 @@ public class ServiceRequestValidator {
             return Optional.of(Errors.from(format("Operation [%s] is invalid for path [%s]", op, path)));
         }
 
+        return Optional.empty();
+    }
+
+    private Optional<List<String>> checkIfNotEmptyAndJson(JsonNode payload) {
+        if (payload != null && payload.isTextual() && !isBlank(payload.asText())) {
+            if (!payload.isObject()) {
+                return Optional.of(Collections.singletonList(format("Value for path [%s] must be a JSON", FIELD_CUSTOM_BRANDING)));
+            }
+        }
         return Optional.empty();
     }
 

--- a/src/main/resources/migrations/00029_drop_column_custom_branding.sql
+++ b/src/main/resources/migrations/00029_drop_column_custom_branding.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:drop_column_custom_branding
+ALTER TABLE services DROP COLUMN IF EXISTS custom_branding;

--- a/src/main/resources/migrations/00030_add_column_custom_branding_json.sql
+++ b/src/main/resources/migrations/00030_add_column_custom_branding_json.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_column_custom_branding
+ALTER TABLE services ADD COLUMN custom_branding json NULL;

--- a/src/test/java/uk/gov/pay/adminusers/model/ServiceUpdateRequestTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/ServiceUpdateRequestTest.java
@@ -1,0 +1,35 @@
+package uk.gov.pay.adminusers.model;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class ServiceUpdateRequestTest {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Before
+    public void before() throws Exception {
+        objectMapper.configure(JsonParser.Feature.AUTO_CLOSE_SOURCE, true);
+    }
+
+    @Test
+    public void shouldTransformToObjectCorrectly() throws Exception {
+        Map<String, Object> payload = ImmutableMap.of("path", "custom_branding", "op", "replace", "value", ImmutableMap.of("image_url", "image url", "css_url", "css url"));
+        String content = objectMapper.writeValueAsString(payload);
+        JsonNode jsonNode = objectMapper.readTree(content);
+        ServiceUpdateRequest request = ServiceUpdateRequest.from(jsonNode);
+
+        Map<String, Object> objectMap = request.valueAsObject();
+        assertThat(objectMap.get("image_url"), is("image url"));
+        assertThat(objectMap.get("css_url"), is("css url"));
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceRequestValidatorTest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
-import org.hamcrest.core.Is;
 import org.junit.Test;
 import uk.gov.pay.adminusers.utils.Errors;
 import uk.gov.pay.adminusers.validations.RequestValidations;
@@ -11,7 +10,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
@@ -112,7 +110,7 @@ public class ServiceRequestValidatorTest {
 
     @Test
     public void shouldSuccess_replacingCustomBranding() throws Exception {
-        ImmutableMap<String, String> payload = ImmutableMap.of("path", "custom_branding", "op", "replace", "value", "custom branding");
+        ImmutableMap<String, Object> payload = ImmutableMap.of("path", "custom_branding", "op", "replace", "value", ImmutableMap.of("image_url","image url", "css_url","css url"));
         Optional<Errors> errors = serviceRequestValidator.validateUpdateAttributeRequest(mapper.valueToTree(payload));
 
         assertThat(errors.isPresent(), is(false));
@@ -124,5 +122,16 @@ public class ServiceRequestValidatorTest {
         Optional<Errors> errors = serviceRequestValidator.validateUpdateAttributeRequest(mapper.valueToTree(payload));
 
         assertThat(errors.isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldError_replacingCustomBranding_ifValueIsNotJSON() throws Exception {
+        ImmutableMap<String, String> payload = ImmutableMap.of("path", "custom_branding", "op", "replace", "value", "&*£&^(P%£");
+        Optional<Errors> errors = serviceRequestValidator.validateUpdateAttributeRequest(mapper.valueToTree(payload));
+
+        assertThat(errors.isPresent(), is(true));
+        List<String> errorsList = errors.get().getErrors();
+        assertThat(errorsList.size(), is(1));
+        assertThat(errorsList, hasItem("Value for path [custom_branding] must be a JSON"));
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceRequestValidatorTest.java
@@ -117,11 +117,33 @@ public class ServiceRequestValidatorTest {
     }
 
     @Test
-    public void shouldSuccess_emptyCustomBranding() throws Exception {
-        ImmutableMap<String, String> payload = ImmutableMap.of("path", "custom_branding", "op", "replace", "value", "");
+    public void shouldSuccess_replacingCustomBranding_forEmptyObject() throws Exception {
+        ImmutableMap<String, Object> payload = ImmutableMap.of("path", "custom_branding", "op", "replace", "value", ImmutableMap.of());
         Optional<Errors> errors = serviceRequestValidator.validateUpdateAttributeRequest(mapper.valueToTree(payload));
 
         assertThat(errors.isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldError_ifCustomBrandingIsEmptyString() throws Exception {
+        ImmutableMap<String, String> payload = ImmutableMap.of("path", "custom_branding", "op", "replace", "value", "");
+        Optional<Errors> errors = serviceRequestValidator.validateUpdateAttributeRequest(mapper.valueToTree(payload));
+
+        assertThat(errors.isPresent(), is(true));
+        List<String> errorsList = errors.get().getErrors();
+        assertThat(errorsList.size(), is(1));
+        assertThat(errorsList, hasItem("Value for path [custom_branding] must be a JSON"));
+    }
+
+    @Test
+    public void shouldError_ifCustomBrandingIsNull() throws Exception {
+        ImmutableMap<String, String> payload = ImmutableMap.of("path", "custom_branding", "op", "replace");
+        Optional<Errors> errors = serviceRequestValidator.validateUpdateAttributeRequest(mapper.valueToTree(payload));
+
+        assertThat(errors.isPresent(), is(true));
+        List<String> errorsList = errors.get().getErrors();
+        assertThat(errorsList.size(), is(1));
+        assertThat(errorsList, hasItem("Value for path [custom_branding] must be a JSON"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateCustomBrandingTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateCustomBrandingTest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 
@@ -21,7 +22,7 @@ public class ServiceResourceUpdateCustomBrandingTest extends IntegrationTest {
         Service service = Service.from(randomInt(), serviceExternalId, "existing-name");
         databaseHelper.addService(service, randomInt().toString());
 
-        Map<String, String> payload = ImmutableMap.of("path", "custom_branding", "op", "replace", "value", "custom branding");
+        Map<String, Object> payload = ImmutableMap.of("path", "custom_branding", "op", "replace", "value", ImmutableMap.of("image_url","image url","css_url","css url"));
 
         givenSetup()
                 .when()
@@ -31,18 +32,19 @@ public class ServiceResourceUpdateCustomBrandingTest extends IntegrationTest {
                 .patch(format(SERVICE_RESOURCE, serviceExternalId))
                 .then()
                 .statusCode(200)
-                .body("custom_branding", is("custom branding"));
+                .body("custom_branding.image_url", is("image url"))
+                .body("custom_branding.css_url", is("css url"));
 
     }
 
     @Test
     public void shouldReplaceWithEmpty_whenUpdatingCustomBranding_withEmptyValue() throws Exception {
         String serviceExternalId = randomUuid();
+        Map<String, Object> payload = ImmutableMap.of("path", "custom_branding", "op", "replace", "value", "");
         Service service = Service.from(randomInt(), serviceExternalId, "existing-name");
-        service.setCustomBranding("custom branding");
+        service.setCustomBranding(payload);
         databaseHelper.addService(service, randomInt().toString());
 
-        Map<String, String> payload = ImmutableMap.of("path", "custom_branding", "op", "replace", "value", "");
 
         givenSetup()
                 .when()
@@ -52,14 +54,14 @@ public class ServiceResourceUpdateCustomBrandingTest extends IntegrationTest {
                 .patch(format(SERVICE_RESOURCE, serviceExternalId))
                 .then()
                 .statusCode(200)
-                .body("custom_branding", is(""));
+                .body("custom_branding", is(nullValue()));
 
     }
 
     @Test
     public void shouldReturn404_whenUpdatingServiceCustomisations_ifNotFound() throws Exception {
 
-        Map<String, String> payload = ImmutableMap.of("path", "custom_branding", "op", "replace", "value", "blah");
+        Map<String, Object> payload = ImmutableMap.of("path", "custom_branding", "op", "replace", "value", ImmutableMap.of("image_url","image url","css_url","css url"));
 
         givenSetup()
                 .when()


### PR DESCRIPTION
Updated Database column type to `json`. 
Added validation to verify if provided value is a JSON.

Currently validations do not restrict the structure of the JSON as long as its a Json, leaving it flexible for expansion later. The clients (technically) can store any JSON. Although, for now we will be implementing the `Frontend` only to store/retrieve `css_path` and `image_path`. 