### PR TITLE
PP-2575 Retrieve user profiles from backend

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/model/GetUserProfilesRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/GetUserProfilesRequest.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.adminusers.model;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class GetUserProfilesRequest {
+
+    public static final String FIELD_EXTERNAL_IDS = "external_ids";
+
+    private List<String> externalIds = newArrayList();
+
+    public GetUserProfilesRequest() {
+    }
+
+    public GetUserProfilesRequest(List<String> externalIds) {
+        this.externalIds = externalIds;
+    }
+
+    public List<String> getExternalIds() {
+        return externalIds;
+    }
+
+    public void setExternalIds(List<String> externalIds) {
+        this.externalIds = externalIds;
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/model/UserEmail.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/UserEmail.java
@@ -1,0 +1,46 @@
+package uk.gov.pay.adminusers.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class UserEmail {
+
+
+    public static final String FIELD_EXTERNAL_ID = "external_id";
+    public static final String FIELD_EMAIL = "email";
+
+    private String externalId;
+    private String email;
+
+
+    public UserEmail(@JsonProperty("external_id") String externalId, @JsonProperty("email")  String email) {
+        this.externalId = externalId;
+        this.email = email;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    @Override
+    public String toString() {
+        return "UserEmail{" +
+                "externalId='" + externalId + '\'' +
+                ", email='" + email + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/persistence/dao/UserDao.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/dao/UserDao.java
@@ -2,6 +2,7 @@ package uk.gov.pay.adminusers.persistence.dao;
 
 import com.google.inject.Provider;
 import com.google.inject.persist.Transactional;
+import uk.gov.pay.adminusers.model.UserEmail;
 import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 
@@ -61,4 +62,16 @@ public class UserDao extends JpaDao<UserEntity> {
                 .map(ServiceRoleEntity::getUser)
                 .collect(Collectors.toList());
     }
+
+    public List<UserEmail> findByExternalIds(List<String> externalIds) {
+
+        String queryStr = "SELECT NEW uk.gov.pay.adminusers.model.UserEmail(u.externalId, u.email) FROM UserEntity u "+
+                           "WHERE LOWER(u.externalId) in :externalIds";
+
+        return entityManager.get()
+                .createQuery(queryStr, UserEmail.class)
+                .setParameter("externalIds", externalIds.stream().map(String::toLowerCase).collect(Collectors.toList()))
+                .getResultList();
+    }
+
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
@@ -9,11 +9,13 @@ import uk.gov.pay.adminusers.logger.PayLoggerFactory;
 import uk.gov.pay.adminusers.model.PatchRequest;
 import uk.gov.pay.adminusers.model.SecondFactorToken;
 import uk.gov.pay.adminusers.model.User;
+import uk.gov.pay.adminusers.model.UserEmail;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static java.lang.Boolean.parseBoolean;
@@ -101,6 +103,23 @@ public class UserServices {
                 .map(userEntity -> Optional.of(
                         linksBuilder.decorate(userEntity.toUser())))
                 .orElse(Optional.empty());
+    }
+
+    /**
+     * finds users by externalIds
+     *
+     * @param externalIds
+     * @return {@link User} as an {@link Optional} if found. Otherwise Optional.empty() will be returned.
+     */
+
+    /**
+     * finds users by externalIds
+     *
+     * @param externalIds
+     * @return List of matching userProfiles. Otherwise empty list is returned.
+     */
+    public List<UserEmail> findUserByExternalIds(List<String> externalIds) {
+        return userDao.findByExternalIds(externalIds);
     }
 
     /**

--- a/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
@@ -13,6 +13,7 @@ import static com.jayway.restassured.http.ContentType.JSON;
 public class IntegrationTest {
 
     static final String USERS_RESOURCE_URL = "/v1/api/users";
+    static final String USER_EMAILS_RESOURCE_URL = USERS_RESOURCE_URL+"/emails";
     static final String FIND_RESOURCE_URL = "/v1/api/users/find";
     static final String USER_RESOURCE_URL = "/v1/api/users/%s";
     static final String USERS_AUTHENTICATE_URL = "/v1/api/users/authenticate";


### PR DESCRIPTION
What
====
This exposes a new API call for retrieving a subset of User details (as UserProfile) for any given list of external user IDs.
An example is if a client calls the API with 4 different and existing user external IDs, it responds with the 4 user profiles for the iDs