### PR TITLE
PP-2575 Added get multiple users endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The GOV.UK Pay Admin Users Module in Java (Dropwizard)
 | ----------------------------- | ----------------- | ---------------------------------- |
 | [```/v1/api/users```](/docs/api_specification.md#post-v1apiusers)              | POST    |  Creates a new user            |
 | [```/v1/api/users/{externalId}```](/docs/api_specification.md#get-v1apiusersexternalid)              | GET    |  Gets a user with the associated external id            |
+| [```/v1/api/users/?ids={externalId1},{externalId2}...```](/docs/api_specification.md#get-v1apiusersids)              | GET    |  Gets users with the associated external ids            |
 | [```/v1/api/users/{externalId}```](/docs/api_specification.md#patch-v1apiusersexternalid)              | PATCH    |  amend a specific user attribute            |
 | [```/v1/api/users/{externalId}/services/{serviceId}```](/docs/api_specification.md#put-v1apiusersexternalidservicesserviceid)  | PUT    |  update user's role for a service            |
 | [```/v1/api/users/{externalId}/services```](/docs/api_specification.md#post-v1apiusersexternalidservicesserviceid)  | POST    |  assign a new service along with role to a user        |

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -121,6 +121,76 @@ Content-Type: application/json
 
 -----------------------------------------------------------------------------------------------------------
 
+## GET /v1/api/users/?ids=`{externalId1}`,`{externalId2}`...
+
+This endpoint finds and return users with the given external ids.
+
+### Request example
+
+```
+GET /v1/api/users?=ids=7d19aff33f8948deb97ed16b2912dcd3,4e89tlf59f9148deb79ed61b9212bhj7
+```
+
+### Response example
+
+```
+200 OK
+Content-Type: application/json
+[
+{
+    "external_id": "7d19aff33f8948deb97ed16b2912dcd3",
+    "username": "abcd1234",
+    "email": "email@email.com",
+    "gateway_account_ids": ["1"],
+    "telephone_number": "49875792",
+    "otp_key": "43c3c4t",
+    "role": {"admin","Administrator"},
+    "sessionVersion": 0,
+    "permissions":["perm-1","perm-2","perm-3"], 
+    "_links": [{
+        "href": "http://adminusers.service/v1/api/users/7d19aff33f8948deb97ed16b2912dcd3",
+        "rel" : "self",
+        "method" : "GET"
+    }]
+    
+},
+{
+    "external_id": "4e89tlf59f9148deb79ed61b9212bhj7",
+    "username": "efgh5678",
+    "email": "emai2l@email.com",
+    "gateway_account_ids": ["1"],
+    "telephone_number": "49875793",
+    "otp_key": "21d7g4t",
+    "role": {"admin","Administrator"},
+    "sessionVersion": 0,
+    "permissions":["perm-1","perm-2","perm-3"], 
+    "_links": [{
+        "href": "http://adminusers.service/v1/api/users/4e89tlf59f9148deb79ed61b9212bhj7",
+        "rel" : "self",
+        "method" : "GET"
+    }]
+    
+}
+]
+```
+
+#### Response field description
+
+| Field                    | always present | Description                                   |
+| ------------------------ |:--------------:| --------------------------------------------- |
+| `[i].external_id`     | X              | External id for this user       |
+| `[i].username`     | X              | Username for this user       |
+| `[i].gateway_account_ids`     | X              | The account Ids created by the connector       |
+| `[i].email`                   | X              | email address     |
+| `[i].telephone_number`            | X              | user's mobile/phone number |
+| `[i].otp_key`           | X              | top key for this user      |
+| `[i].role`           | X              | Role assigned to this user      |
+| `[i].permissions`                  | X              | names of all the permissions granted by this role.     |
+| `[i]._links`                  | X              | Self link for this user.     |
+
+-----------------------------------------------------------------------------------------------------------
+
+
 ## PATCH /v1/api/users/`{externalId}`
 
 This endpoint amends a specific attribute in user resource.

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -13,7 +13,7 @@ Content-Type: application/json
 
 {
     "username": "abcd1234",
-    "email": "email@email.com",
+    "email": "email@example.com",
     "gateway_account_ids": ["1"],
     "telephone_number": "49875792",
     "otp_key": "43c3c4t",
@@ -40,7 +40,7 @@ Content-Type: application/json
 {
     "external_id": "7d19aff33f8948deb97ed16b2912dcd3",
     "username": "abcd1234",
-    "email": "email@email.com",
+    "email": "email@example.com",
     "gateway_account_ids": ["1"],
     "telephone_number": "49875792",
     "otp_key": "43c3c4t",
@@ -89,9 +89,9 @@ Content-Type: application/json
 {
     "external_id": "7d19aff33f8948deb97ed16b2912dcd3",
     "username": "abcd1234",
-    "email": "email@email.com",
+    "email": "email@example.com",
     "gateway_account_ids": ["1"],
-    "telephone_number": "49875792",
+    "telephone_number": "447700900000",
     "otp_key": "43c3c4t",
     "role": {"admin","Administrator"},
     "sessionVersion": 0,
@@ -125,6 +125,10 @@ Content-Type: application/json
 
 This endpoint finds and return users with the given external ids.
 
+### Notes
+
+Will return `404` if any of the provided external ids do not match a user.
+
 ### Request example
 
 ```
@@ -140,9 +144,9 @@ Content-Type: application/json
 {
     "external_id": "7d19aff33f8948deb97ed16b2912dcd3",
     "username": "abcd1234",
-    "email": "email@email.com",
+    "email": "email@example.com",
     "gateway_account_ids": ["1"],
-    "telephone_number": "49875792",
+    "telephone_number": "447700900000",
     "otp_key": "43c3c4t",
     "role": {"admin","Administrator"},
     "sessionVersion": 0,
@@ -157,9 +161,9 @@ Content-Type: application/json
 {
     "external_id": "4e89tlf59f9148deb79ed61b9212bhj7",
     "username": "efgh5678",
-    "email": "emai2l@email.com",
+    "email": "email2@example.com",
     "gateway_account_ids": ["1"],
-    "telephone_number": "49875793",
+    "telephone_number": "447700900001",
     "otp_key": "21d7g4t",
     "role": {"admin","Administrator"},
     "sessionVersion": 0,
@@ -215,9 +219,9 @@ Content-Type: application/json
 {
     "external_id": "7d19aff33f8948deb97ed16b2912dcd3",
     "username": "abcd1234",
-    "email": "email@email.com",
+    "email": "email@example.com",
     "gateway_account_ids": ["1"],
-    "telephone_number": "49875792",
+    "telephone_number": "447700900000",
     "otp_key": "43c3c4t",
     "sessionVersion": 2,
     "role": {"admin","Administrator"},
@@ -275,9 +279,9 @@ Content-Type: application/json
 {
     "external_id": "7d19aff33f8948deb97ed16b2912dcd3",
     "username": "abcd1234",
-    "email": "email@email.com",
+    "email": "email@example.com",
     "gateway_account_ids": ["1"],
-    "telephone_number": "49875792",
+    "telephone_number": "447700900000",
     "otp_key": "43c3c4t",
     "role": {"admin","Administrator"},
     "permissions":["perm-1","perm-2","perm-3"], 
@@ -409,9 +413,9 @@ Content-Type: application/json
 {
     "external_id": "7d19aff33f8948deb97ed16b2912dcd3",
     "username": "abcd1234",
-    "email": "email@email.com",
+    "email": "email@example.com",
     "gateway_account_ids": ["1"],
-    "telephone_number": "49875792",
+    "telephone_number": "447700900000",
     "otp_key": "43c3c4t",
     "sessionVersion": 2,
     "role": {"view-and-refund","View and Refund"},
@@ -487,9 +491,9 @@ Content-Type: application/json
 {
     "external_id": "7d19aff33f8948deb97ed16b2912dcd3",
     "username": "abcd1234",
-    "email": "email@email.com",
+    "email": "email@example.com",
     "gateway_account_ids": ["1"],
-    "telephone_number": "49875792",
+    "telephone_number": "447700900000",
     "otp_key": "43c3c4t",
     "sessionVersion": 2,
     "service_role":[{

--- a/src/main/java/uk/gov/pay/adminusers/persistence/dao/UserDao.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/dao/UserDao.java
@@ -29,6 +29,17 @@ public class UserDao extends JpaDao<UserEntity> {
                 .getResultList().stream().findFirst();
     }
 
+    public List<UserEntity> findByExternalIds(List<String> externalIds) {
+        String query = "SELECT u FROM UserEntity u WHERE LOWER(u.externalId) in :externalIds";
+
+        externalIds = externalIds.stream().map(String::toLowerCase).collect(Collectors.toList());
+
+        return entityManager.get()
+                .createQuery(query, UserEntity.class)
+                .setParameter("externalIds", externalIds)
+                .getResultList();
+    }
+
     public Optional<UserEntity> findByUsername(String username) {
         String query = "SELECT u FROM UserEntity u " +
                 "WHERE LOWER(u.username) = LOWER(:username)";

--- a/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
@@ -15,9 +15,11 @@ import uk.gov.pay.adminusers.service.UserServicesFactory;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.*;
@@ -77,6 +79,26 @@ public class UserResource {
         return userServices.findUserByExternalId(externalId)
                 .map(user -> Response.status(OK).type(APPLICATION_JSON).entity(user).build())
                 .orElseGet(() -> Response.status(NOT_FOUND).build());
+    }
+
+    @Path(USERS_RESOURCE)
+    @GET
+    @Produces(APPLICATION_JSON)
+    @Consumes(APPLICATION_JSON)
+    public Response getUsers(@QueryParam("ids") String externalIds) {
+        logger.info("Users GET request - [ {} ]", externalIds);
+        List<String> externalIdsList = Arrays
+                .stream(externalIds.split(","))
+                .map(String::trim)
+                .collect(Collectors.toList());
+
+        List<User> users = userServices.findUsersByExternalIds(externalIdsList);
+
+        if (users.size() == externalIdsList.size()) {
+            return Response.status(OK).type(APPLICATION_JSON).entity(users).build();
+        } else {
+            return Response.status(NOT_FOUND).build();
+        }
     }
 
     @Path(USERS_RESOURCE)

--- a/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
@@ -41,6 +42,7 @@ public class UserResource {
     private static final String SECOND_FACTOR_AUTHENTICATE_RESOURCE = SECOND_FACTOR_RESOURCE + "/authenticate";
     private static final String USER_SERVICES_RESOURCE = USER_RESOURCE + "/services";
     private static final String USER_SERVICE_RESOURCE = USER_SERVICES_RESOURCE + "/{serviceExternalId}";
+    private static final Splitter COMMA_SEPARATOR = Splitter.on(',').trimResults();
 
     public static final String CONSTRAINT_VIOLATION_MESSAGE = "ERROR: duplicate key value violates unique constraint";
 
@@ -87,10 +89,7 @@ public class UserResource {
     @Consumes(APPLICATION_JSON)
     public Response getUsers(@QueryParam("ids") String externalIds) {
         logger.info("Users GET request - [ {} ]", externalIds);
-        List<String> externalIdsList = Arrays
-                .stream(externalIds.split(","))
-                .map(String::trim)
-                .collect(Collectors.toList());
+        List<String> externalIdsList = COMMA_SEPARATOR.splitToList(externalIds);
 
         List<User> users = userServices.findUsersByExternalIds(externalIdsList);
 

--- a/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
@@ -14,7 +14,10 @@ import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.Integer.parseInt;
@@ -98,9 +101,20 @@ public class UserServices {
     public Optional<User> findUserByExternalId(String externalId) {
         Optional<UserEntity> userEntityOptional = userDao.findByExternalId(externalId);
         return userEntityOptional
-                .map(userEntity -> Optional.of(
-                        linksBuilder.decorate(userEntity.toUser())))
+                .map(userEntity -> Optional.of(linksBuilder.decorate(userEntity.toUser())))
                 .orElse(Optional.empty());
+    }
+
+    /**
+     *
+     * @param externalIds
+     * @return A {@link List} of {@link User} or an empty {@link List} otherwise
+     */
+    public List<User> findUsersByExternalIds(List<String> externalIds) {
+        return userDao.findByExternalIds(externalIds)
+                .stream()
+                .map(userEntity -> linksBuilder.decorate(userEntity.toUser()))
+                .collect(Collectors.toList());
     }
 
     /**

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoTest.java
@@ -13,6 +13,7 @@ import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -129,6 +130,54 @@ public class UserDaoTest extends DaoTestBase {
         assertThat(foundUser.getRoles().size(), is(1));
         assertThat(foundUser.toUser().getServiceRoles().size(), is(2));
         assertThat(foundUser.getRoles().get(0).getId(), is(role.getId()));
+    }
+
+    @Test
+    public void shouldFindUsersBy_ExternalIds() throws Exception {
+        Role role = roleDbFixture(databaseHelper).insertRole();
+        int serviceId1 = serviceDbFixture(databaseHelper)
+                .insertService().getId();
+        int serviceId2 = serviceDbFixture(databaseHelper)
+                .insertService().getId();
+        User user1 = userDbFixture(databaseHelper)
+                .withServiceRole(serviceId1, role.getId())
+                .withServiceRole(serviceId2, role.getId())
+                .insertUser();
+        User user2 = userDbFixture(databaseHelper)
+                .withServiceRole(serviceId1, role.getId())
+                .withServiceRole(serviceId2, role.getId())
+                .insertUser();
+
+        List<String> externalIds = Arrays.asList(user1.getExternalId(), user2.getExternalId());
+
+        List<UserEntity> userEntities = userDao.findByExternalIds(externalIds);
+        assertTrue(userEntities.size() == 2);
+
+        UserEntity foundUser1 = userEntities.get(0);
+        assertThat(foundUser1.getExternalId(), is(user1.getExternalId()));
+        assertThat(foundUser1.getUsername(), is(user1.getUsername()));
+        assertThat(foundUser1.getEmail(), is(user1.getUsername() + "@example.com"));
+        assertThat(foundUser1.getOtpKey(), is(user1.getOtpKey()));
+        assertThat(foundUser1.getTelephoneNumber(), is("374628482"));
+        assertThat(foundUser1.isDisabled(), is(false));
+        assertThat(foundUser1.getLoginCounter(), is(0));
+        assertThat(foundUser1.getSessionVersion(), is(0));
+        assertThat(foundUser1.getRoles().size(), is(1));
+        assertThat(foundUser1.toUser().getServiceRoles().size(), is(2));
+        assertThat(foundUser1.getRoles().get(0).getId(), is(role.getId()));
+
+        UserEntity foundUser2 = userEntities.get(1);
+        assertThat(foundUser2.getExternalId(), is(user2.getExternalId()));
+        assertThat(foundUser2.getUsername(), is(user2.getUsername()));
+        assertThat(foundUser2.getEmail(), is(user2.getUsername() + "@example.com"));
+        assertThat(foundUser2.getOtpKey(), is(user2.getOtpKey()));
+        assertThat(foundUser2.getTelephoneNumber(), is("374628482"));
+        assertThat(foundUser2.isDisabled(), is(false));
+        assertThat(foundUser2.getLoginCounter(), is(0));
+        assertThat(foundUser2.getSessionVersion(), is(0));
+        assertThat(foundUser2.getRoles().size(), is(1));
+        assertThat(foundUser2.toUser().getServiceRoles().size(), is(2));
+        assertThat(foundUser2.getRoles().get(0).getId(), is(role.getId()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoTest.java
@@ -147,6 +147,11 @@ public class UserDaoTest extends DaoTestBase {
                 .withServiceRole(serviceId1, role.getId())
                 .withServiceRole(serviceId2, role.getId())
                 .insertUser();
+        // Add third user to prove we're not just returning all users
+        userDbFixture(databaseHelper)
+                .withServiceRole(serviceId1, role.getId())
+                .withServiceRole(serviceId2, role.getId())
+                .insertUser();
 
         List<String> externalIds = Arrays.asList(user1.getExternalId(), user2.getExternalId());
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateTest.java
@@ -24,7 +24,7 @@ import static uk.gov.pay.adminusers.fixtures.RoleDbFixture.roleDbFixture;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
 
-public class UserResourceCreateAndGetTest extends IntegrationTest {
+public class UserResourceCreateTest extends IntegrationTest {
 
     @Test
     public void shouldCreateAUser_Successfully() throws Exception {
@@ -130,41 +130,7 @@ public class UserResourceCreateAndGetTest extends IntegrationTest {
         assertThat(servicesAssociatedToUser.size(), is(1));
     }
 
-    @Test
-    public void shouldReturnUser_whenGetUserWithExternalId() throws Exception {
-        String gatewayAccount1 = valueOf(nextInt());
-        String gatewayAccount2 = valueOf(nextInt());
-        Service service = serviceDbFixture(databaseHelper).withGatewayAccountIds(gatewayAccount1, gatewayAccount2).insertService();
-        String serviceExternalId = service.getExternalId();
-        Role role = roleDbFixture(databaseHelper).insertRole();
-        User user = userDbFixture(databaseHelper).withServiceRole(service.getId(), role.getId()).insertUser();
 
-        givenSetup()
-                .when()
-                .contentType(JSON)
-                .accept(JSON)
-                .get(format(USER_RESOURCE_URL, user.getExternalId()))
-                .then()
-                .statusCode(200)
-                .body("external_id", is(user.getExternalId()))
-                .body("username", is(user.getUsername()))
-                .body("password", nullValue())
-                .body("email", is(user.getEmail()))
-                .body("service_roles", hasSize(1))
-                .body("service_roles[0].service.external_id", is(serviceExternalId))
-                .body("service_roles[0].service.name", is(service.getName()))
-                .body("telephone_number", is(user.getTelephoneNumber()))
-                .body("otp_key", is(user.getOtpKey()))
-                .body("login_counter", is(0))
-                .body("disabled", is(false))
-                .body("service_roles[0].role.name", is(role.getName()))
-                .body("service_roles[0].role.description", is(role.getDescription()))
-                .body("service_roles[0].role.permissions", hasSize(role.getPermissions().size()))
-                .body("_links", hasSize(1))
-                .body("_links[0].href", is("http://localhost:8080/v1/api/users/" + user.getExternalId()))
-                .body("_links[0].method", is("GET"))
-                .body("_links[0].rel", is("self"));
-    }
 
 
     @Test
@@ -237,25 +203,5 @@ public class UserResourceCreateAndGetTest extends IntegrationTest {
                 .body("errors[0]", is(format("username [%s] already exists", username)));
     }
 
-
-    @Test
-    public void shouldReturn404_whenGetUser_withNonExistentUsername() throws Exception {
-        givenSetup()
-                .when()
-                .accept(JSON)
-                .get(format(USER_RESOURCE_URL, "non-existent-user"))
-                .then()
-                .statusCode(404);
-    }
-
-    @Test
-    public void shouldReturn404_whenGetUser_withInvalidMaxLengthUsername() throws Exception {
-        givenSetup()
-                .when()
-                .accept(JSON)
-                .get(format(USER_RESOURCE_URL, RandomStringUtils.randomAlphanumeric(256)))
-                .then()
-                .statusCode(404);
-    }
 }
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceGetMultipleTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceGetMultipleTest.java
@@ -1,0 +1,141 @@
+package uk.gov.pay.adminusers.resources;
+
+import org.junit.Test;
+import uk.gov.pay.adminusers.model.Role;
+import uk.gov.pay.adminusers.model.Service;
+import uk.gov.pay.adminusers.model.User;
+
+import static com.jayway.restassured.http.ContentType.JSON;
+import static java.lang.String.valueOf;
+import static org.apache.commons.lang3.RandomUtils.nextInt;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.adminusers.fixtures.RoleDbFixture.roleDbFixture;
+import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
+import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
+import static uk.gov.pay.adminusers.resources.UserResource.USERS_RESOURCE;
+
+public class UserResourceGetMultipleTest extends IntegrationTest {
+
+    @Test
+    public void shouldReturnMultipleUsers_whenGetUsersWithMultipleIds() throws Exception {
+        String gatewayAccount1 = valueOf(nextInt());
+        String gatewayAccount2 = valueOf(nextInt());
+        Service service = serviceDbFixture(databaseHelper).withGatewayAccountIds(gatewayAccount1, gatewayAccount2).insertService();
+        String serviceExternalId = service.getExternalId();
+        Role role = roleDbFixture(databaseHelper).insertRole();
+        User user1 = userDbFixture(databaseHelper).withServiceRole(service.getId(), role.getId()).insertUser();
+        User user2 = userDbFixture(databaseHelper).withServiceRole(service.getId(), role.getId()).insertUser();
+
+        givenSetup()
+                .when()
+                .contentType(JSON)
+                .accept(JSON)
+                .get(USERS_RESOURCE +"?ids=" + user1.getExternalId() + "," + user2.getExternalId())
+                .then()
+                .statusCode(200)
+                .body("[0].external_id", is(user1.getExternalId()))
+                .body("[0].username", is(user1.getUsername()))
+                .body("[0].password", nullValue())
+                .body("[0].email", is(user1.getEmail()))
+                .body("[0].service_roles", hasSize(1))
+                .body("[0].service_roles[0].service.external_id", is(serviceExternalId))
+                .body("[0].service_roles[0].service.name", is(service.getName()))
+                .body("[0].telephone_number", is(user1.getTelephoneNumber()))
+                .body("[0].otp_key", is(user1.getOtpKey()))
+                .body("[0].login_counter", is(0))
+                .body("[0].disabled", is(false))
+                .body("[0].service_roles[0].role.name", is(role.getName()))
+                .body("[0].service_roles[0].role.description", is(role.getDescription()))
+                .body("[0].service_roles[0].role.permissions", hasSize(role.getPermissions().size()))
+                .body("[0]._links", hasSize(1))
+                .body("[0]._links[0].href", is("http://localhost:8080/v1/api/users/" + user1.getExternalId()))
+                .body("[0]._links[0].method", is("GET"))
+                .body("[0]._links[0].rel", is("self"))
+                .body("[1].external_id", is(user2.getExternalId()))
+                .body("[1].username", is(user2.getUsername()))
+                .body("[1].password", nullValue())
+                .body("[1].email", is(user2.getEmail()))
+                .body("[1].service_roles", hasSize(1))
+                .body("[1].service_roles[0].service.external_id", is(serviceExternalId))
+                .body("[1].service_roles[0].service.name", is(service.getName()))
+                .body("[1].telephone_number", is(user2.getTelephoneNumber()))
+                .body("[1].otp_key", is(user2.getOtpKey()))
+                .body("[1].login_counter", is(0))
+                .body("[1].disabled", is(false))
+                .body("[1].service_roles[0].role.name", is(role.getName()))
+                .body("[1].service_roles[0].role.description", is(role.getDescription()))
+                .body("[1].service_roles[0].role.permissions", hasSize(role.getPermissions().size()))
+                .body("[1]._links", hasSize(1))
+                .body("[1]._links[0].href", is("http://localhost:8080/v1/api/users/" + user2.getExternalId()))
+                .body("[1]._links[0].method", is("GET"))
+                .body("[1]._links[0].rel", is("self"))
+                .body("size()", is(2));
+    }
+
+    @Test
+    public void shouldReturnSingleUser_whenGetUsersWithSingleId() throws Exception {
+        String gatewayAccount1 = valueOf(nextInt());
+        String gatewayAccount2 = valueOf(nextInt());
+        Service service = serviceDbFixture(databaseHelper).withGatewayAccountIds(gatewayAccount1, gatewayAccount2).insertService();
+        String serviceExternalId = service.getExternalId();
+        Role role = roleDbFixture(databaseHelper).insertRole();
+        User user = userDbFixture(databaseHelper).withServiceRole(service.getId(), role.getId()).insertUser();
+
+        givenSetup()
+                .when()
+                .contentType(JSON)
+                .accept(JSON)
+                .get(USERS_RESOURCE +"?ids=" + user.getExternalId())
+                .then()
+                .statusCode(200)
+                .body("[0].external_id", is(user.getExternalId()))
+                .body("[0].username", is(user.getUsername()))
+                .body("[0].password", nullValue())
+                .body("[0].email", is(user.getEmail()))
+                .body("[0].service_roles", hasSize(1))
+                .body("[0].service_roles[0].service.external_id", is(serviceExternalId))
+                .body("[0].service_roles[0].service.name", is(service.getName()))
+                .body("[0].telephone_number", is(user.getTelephoneNumber()))
+                .body("[0].otp_key", is(user.getOtpKey()))
+                .body("[0].login_counter", is(0))
+                .body("[0].disabled", is(false))
+                .body("[0].service_roles[0].role.name", is(role.getName()))
+                .body("[0].service_roles[0].role.description", is(role.getDescription()))
+                .body("[0].service_roles[0].role.permissions", hasSize(role.getPermissions().size()))
+                .body("[0]._links", hasSize(1))
+                .body("[0]._links[0].href", is("http://localhost:8080/v1/api/users/" + user.getExternalId()))
+                .body("[0]._links[0].method", is("GET"))
+                .body("[0]._links[0].rel", is("self"))
+                .body("size()", is(1));
+    }
+
+    @Test
+    public void shouldReturn404_whenGetUsers_withNonExistentExternalIds() throws Exception {
+        givenSetup()
+                .when()
+                .accept(JSON)
+                .get(USERS_RESOURCE +"?ids=NON-EXISTENT-USER,ANOTHER_NON_EXISTENT_USER")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void shouldReturn404_whenGetUsers_whereSomeNonExistentExternalIds() throws Exception {
+        String gatewayAccount1 = valueOf(nextInt());
+        String gatewayAccount2 = valueOf(nextInt());
+        Service service = serviceDbFixture(databaseHelper).withGatewayAccountIds(gatewayAccount1, gatewayAccount2).insertService();
+        Role role = roleDbFixture(databaseHelper).insertRole();
+        User existingUser = userDbFixture(databaseHelper).withServiceRole(service.getId(), role.getId()).insertUser();
+
+        givenSetup()
+                .when()
+                .contentType(JSON)
+                .accept(JSON)
+                .get(USERS_RESOURCE +"?ids=" + existingUser.getExternalId() + ",NON-EXISTENT-USER")
+                .then()
+                .statusCode(404);
+    }
+}
+

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceGetTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceGetTest.java
@@ -1,0 +1,82 @@
+package uk.gov.pay.adminusers.resources;
+
+import com.google.common.collect.ImmutableMap;
+import com.jayway.restassured.response.ValidatableResponse;
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Test;
+import uk.gov.pay.adminusers.model.Role;
+import uk.gov.pay.adminusers.model.Service;
+import uk.gov.pay.adminusers.model.User;
+
+import static com.jayway.restassured.http.ContentType.JSON;
+import static java.lang.String.format;
+import static java.lang.String.valueOf;
+import static org.apache.commons.lang3.RandomUtils.nextInt;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.adminusers.fixtures.RoleDbFixture.roleDbFixture;
+import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
+import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
+
+public class UserResourceGetTest extends IntegrationTest {
+
+
+
+    @Test
+    public void shouldReturnUser_whenGetUserWithExternalId() throws Exception {
+        String gatewayAccount1 = valueOf(nextInt());
+        String gatewayAccount2 = valueOf(nextInt());
+        Service service = serviceDbFixture(databaseHelper).withGatewayAccountIds(gatewayAccount1, gatewayAccount2).insertService();
+        String serviceExternalId = service.getExternalId();
+        Role role = roleDbFixture(databaseHelper).insertRole();
+        User user = userDbFixture(databaseHelper).withServiceRole(service.getId(), role.getId()).insertUser();
+
+        givenSetup()
+                .when()
+                .contentType(JSON)
+                .accept(JSON)
+                .get(format(USER_RESOURCE_URL, user.getExternalId()))
+                .then()
+                .statusCode(200)
+                .body("external_id", is(user.getExternalId()))
+                .body("username", is(user.getUsername()))
+                .body("password", nullValue())
+                .body("email", is(user.getEmail()))
+                .body("service_roles", hasSize(1))
+                .body("service_roles[0].service.external_id", is(serviceExternalId))
+                .body("service_roles[0].service.name", is(service.getName()))
+                .body("telephone_number", is(user.getTelephoneNumber()))
+                .body("otp_key", is(user.getOtpKey()))
+                .body("login_counter", is(0))
+                .body("disabled", is(false))
+                .body("service_roles[0].role.name", is(role.getName()))
+                .body("service_roles[0].role.description", is(role.getDescription()))
+                .body("service_roles[0].role.permissions", hasSize(role.getPermissions().size()))
+                .body("_links", hasSize(1))
+                .body("_links[0].href", is("http://localhost:8080/v1/api/users/" + user.getExternalId()))
+                .body("_links[0].method", is("GET"))
+                .body("_links[0].rel", is("self"));
+    }
+
+
+    @Test
+    public void shouldReturn404_whenGetUser_withNonExistentExternalId() throws Exception {
+        givenSetup()
+                .when()
+                .accept(JSON)
+                .get(format(USER_RESOURCE_URL, "non-existent-user"))
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void shouldReturn404_whenGetUser_withInvalidMaxLengthExternalId() throws Exception {
+        givenSetup()
+                .when()
+                .accept(JSON)
+                .get(format(USER_RESOURCE_URL, RandomStringUtils.randomAlphanumeric(256)))
+                .then()
+                .statusCode(404);
+    }
+}
+

--- a/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
@@ -18,6 +18,8 @@ import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -55,6 +57,8 @@ public class UserServicesTest {
 
     private static final String USER_EXTERNAL_ID = "7d19aff33f8948deb97ed16b2912dcd3";
     private static final String USER_USERNAME = "random-name";
+    private static final String ANOTHER_USER_EXTERNAL_ID = "7d19aff33f8948deb97ed16b2912dcd4";
+    private static final String ANOTHER_USER_USERNAME = "another-random-name";
 
     @Before
     public void before() throws Exception {
@@ -76,6 +80,25 @@ public class UserServicesTest {
         assertTrue(userOptional.isPresent());
 
         assertThat(userOptional.get().getExternalId(), is(USER_EXTERNAL_ID));
+    }
+
+    @Test
+    public void shouldFindAUsersByExternalIds() throws Exception {
+        User user1 = aUser();
+        User user2 = anotherUser();
+
+        UserEntity userEntity1 = aUserEntityWithTrimmings(user1);
+        UserEntity userEntity2 = aUserEntityWithTrimmings(user2);
+
+        List<String> userExternalIds = Arrays.asList(user1.getExternalId(), user2.getExternalId());
+        List<UserEntity> userEntities = Arrays.asList(userEntity1, userEntity2);
+        when(userDao.findByExternalIds(userExternalIds)).thenReturn(userEntities);
+
+        List<User> users = userServices.findUsersByExternalIds(userExternalIds);
+        assertTrue(users.size() == 2);
+
+        assertThat(users.get(0).getExternalId(), is(user1.getExternalId()));
+        assertThat(users.get(1).getExternalId(), is(user2.getExternalId()));
     }
 
     @Test
@@ -430,6 +453,9 @@ public class UserServicesTest {
 
     private User aUser() {
         return User.from(randomInt(), USER_EXTERNAL_ID, USER_USERNAME, "random-password", "email@example.com", asList("1"), newArrayList(), "784rh", "8948924", newArrayList(), null);
+    }
+    private User anotherUser() {
+        return User.from(randomInt(), ANOTHER_USER_EXTERNAL_ID, ANOTHER_USER_USERNAME, "random-password", "email@example.com", asList("1"), newArrayList(), "784rh", "8948924", newArrayList(), null);
     }
 
     private Role aRole() {

--- a/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
@@ -90,11 +90,9 @@ public class UserServicesTest {
         UserEntity userEntity1 = aUserEntityWithTrimmings(user1);
         UserEntity userEntity2 = aUserEntityWithTrimmings(user2);
 
-        List<String> userExternalIds = Arrays.asList(user1.getExternalId(), user2.getExternalId());
-        List<UserEntity> userEntities = Arrays.asList(userEntity1, userEntity2);
-        when(userDao.findByExternalIds(userExternalIds)).thenReturn(userEntities);
+        when(userDao.findByExternalIds(Arrays.asList(user1.getExternalId(), user2.getExternalId()))).thenReturn(Arrays.asList(userEntity1, userEntity2));
 
-        List<User> users = userServices.findUsersByExternalIds(userExternalIds);
+        List<User> users = userServices.findUsersByExternalIds(Arrays.asList(user1.getExternalId(), user2.getExternalId()));
         assertTrue(users.size() == 2);
 
         assertThat(users.get(0).getExternalId(), is(user1.getExternalId()));


### PR DESCRIPTION
## What
- added `/v1/api/users/?ids={externalId1},{externalId2}...`
- Also split out `create` and `get` user resource tests

## Why
This enables us to do mass look ups on users when we get a group of user externalIds. i.e. in a list of transaction events