### PR TITLE
PP-2694 Add acas.org.uk to email whitelist 

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
@@ -35,8 +35,9 @@ public class EmailValidator {
                 "police\\.uk",
                 "scotent\\.co\\.uk",
                 "slc\\.co\\.uk",
-                "ucds\\.email"
-        ));
+                "ucds\\.email",
+                "acas\\.org\\.uk"
+                ));
     }
     private static final Pattern PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERN;
     static {

--- a/src/test/java/uk/gov/pay/adminusers/utils/email/EmailValidatorIsPublicSectorEmailTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/email/EmailValidatorIsPublicSectorEmailTest.java
@@ -77,6 +77,8 @@ public class EmailValidatorIsPublicSectorEmailTest {
                 {"valid@scotent.co.uk", true},
                 {"valid@slc.co.uk", true},
                 {"valid@ucds.email", true},
+                {"valid@acas.org.uk", true},
+
 
                 // all valid emails with subdomains
                 {"valid@subdomain.assembly.wales", true},


### PR DESCRIPTION
We currently hard code the list of whitelisted domains allowed for account set up. This commit adds acas.org.uk to allow selfservice account creation.

We should move this to DB and have an API to modify some day.
Today is not that day.