### PR TITLE
PP-2959 Explicit docker pull postgres image for testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
         <eclipselink.version>2.6.4</eclipselink.version>
         <guice.version>4.1.0</guice.version>
         <jersey2.version>2.25.1</jersey2.version>
+        <docker-client.version>8.9.2</docker-client.version>
     </properties>
     <repositories>
         <repository>
@@ -207,7 +208,7 @@
         <dependency>
             <groupId>com.spotify</groupId>
             <artifactId>docker-client</artifactId>
-            <version>8.1.1</version>
+            <version>${docker-client.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/uk/gov/pay/adminusers/infra/PostgresContainer.java
+++ b/src/test/java/uk/gov/pay/adminusers/infra/PostgresContainer.java
@@ -28,18 +28,19 @@ public class PostgresContainer {
     private String host;
     private volatile boolean stopped = false;
 
+    private static final String GOVUK_POSTGRES_IMAGE = "govukpay/postgres:9.4.4";
     private static final String DB_PASSWORD = "mysecretpassword";
     private static final String DB_USERNAME = "postgres";
     private static final int DB_TIMEOUT_SEC = 15;
-    private static final String GOVUK_POSTGRES_IMAGE = "govukpay/postgres:9.4.4";
     private static final String INTERNAL_PORT = "5432";
 
-    public PostgresContainer(DockerClient docker, String host) throws InterruptedException, IOException, ClassNotFoundException, DockerException {
+    public  PostgresContainer(DockerClient docker, String host) throws InterruptedException, IOException, ClassNotFoundException, DockerException {
         Class.forName("org.postgresql.Driver");
 
         this.docker = docker;
         this.host = host;
 
+        failsafeDockerPull(docker, GOVUK_POSTGRES_IMAGE);
         docker.listImages(DockerClient.ListImagesParam.create("name", GOVUK_POSTGRES_IMAGE));
 
         final HostConfig hostConfig = HostConfig.builder().logConfig(LogConfig.create("json-file")).publishAllPorts(true).build();
@@ -65,6 +66,14 @@ public class PostgresContainer {
 
     public String getConnectionUrl() {
         return "jdbc:postgresql://" + host + ":" + port + "/";
+    }
+
+    private void failsafeDockerPull(DockerClient docker, String image) {
+        try {
+            docker.pull(image);
+        } catch (Exception e) {
+            logger.error("Docker image " + image + " could not be pulled from DockerHub", e);
+        }
     }
 
     private static int hostPortNumber(ContainerInfo containerInfo) {

--- a/src/test/java/uk/gov/pay/adminusers/infra/PostgresDockerRule.java
+++ b/src/test/java/uk/gov/pay/adminusers/infra/PostgresDockerRule.java
@@ -17,11 +17,10 @@ import static org.junit.Assert.assertNotNull;
 
 public class PostgresDockerRule implements TestRule {
 
-    private static String host;
-    private static PostgresContainer container;
-
     private static final String DOCKER_HOST = "DOCKER_HOST";
     private static final String DOCKER_CERT_PATH = "DOCKER_CERT_PATH";
+    private static String host;
+    private static PostgresContainer container;
 
     static {
         try {
@@ -29,7 +28,7 @@ public class PostgresDockerRule implements TestRule {
                     orElseThrow(() -> new RuntimeException(DOCKER_HOST + " environment variable not set. It has to be set to the docker daemon location."));
             URI dockerHostURI = new URI(dockerHost);
             boolean isDockerDaemonLocal = "unix".equals(dockerHostURI.getScheme());
-            if(!isDockerDaemonLocal) {
+            if (!isDockerDaemonLocal) {
                 assertNotNull(DOCKER_CERT_PATH + " environment variable not set.", System.getenv(DOCKER_CERT_PATH));
             }
             host = isDockerDaemonLocal ? "localhost" : dockerHostURI.getHost();


### PR DESCRIPTION
## WHAT

- Current integration tests are using a non ideal manually built Postgres image for testing. Even less ideal is pulling the image locally when it does not exist (example as in new machines, docker images clean up, changed a reference to a new image)

- Pull explicitly the docker image before running the tests

- Upgrade docker-client (test scope) version from 8.1.1 -> 8.9.2