### PR TITLE
PP-3096: Add chamber to docker startup script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,20 @@
 FROM govukpay/openjdk:8-jre-alpine
 
+ARG CHAMBER_URL=https://github.com/segmentio/chamber/releases/download/v1.9.0/chamber-v1.9.0-linux-amd64
+
 RUN apk update
 RUN apk upgrade
 
-RUN apk add bash
+RUN apk add --no-cache bash
+
+ADD chamber.sha256sum /tmp/chamber.sha256sum
+RUN apk add --no-cache openssl && \
+    mkdir -p bin && \
+    wget -qO bin/chamber $CHAMBER_URL && \
+    sha256sum -c /tmp/chamber.sha256sum && \
+    rm /tmp/chamber.sha256sum && \
+    chmod 755 bin/chamber && \
+    apk del --purge openssl
 
 ENV PORT 8080
 ENV ADMIN_PORT 8081

--- a/chamber.sha256sum
+++ b/chamber.sha256sum
@@ -1,0 +1,1 @@
+88290cff6960fce9a2f30a7447d8c2a7dfa6e3d1d7a0446de75cb475505ef537  bin/chamber

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -3,4 +3,9 @@
 java -jar *-allinone.jar waitOnDependencies *.yaml && \
 java -jar *-allinone.jar migrateToInitialDbState *.yaml && \
 java -jar *-allinone.jar db migrate *.yaml && \
-java $JAVA_OPTS -jar *-allinone.jar server *.yaml
+
+if [ -n "$CHAMBER" ]; then
+  AWS_REGION=${ECS_AWS_REGION} chamber exec ${ECS_SERVICE} -- java $JAVA_OPTS -jar *-allinone.jar server *.yaml
+else
+  java $JAVA_OPTS -jar *-allinone.jar server *.yaml
+fi


### PR DESCRIPTION
To get this to run in ECS we require the docker container to be able to
start up the app with chamber to get the variables from the environment.

This commit adds a new codepath to run the app with chamber if the
`CHAMBER` env var is set, and it adds a chamber binary (copied from
pay-selfservice).

solo @tlwr