### PR TITLE
pp-3096: fix chamber startup startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,6 @@ WORKDIR /app
 ADD target/*.yaml /app/
 ADD target/pay-*-allinone.jar /app/
 ADD docker-startup.sh /app/docker-startup.sh
+ADD run-with-chamber.sh /app/run-with-chamber.sh
 
 CMD bash ./docker-startup.sh

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -3,9 +3,4 @@
 java -jar *-allinone.jar waitOnDependencies *.yaml && \
 java -jar *-allinone.jar migrateToInitialDbState *.yaml && \
 java -jar *-allinone.jar db migrate *.yaml && \
-
-if [ -n "$CHAMBER" ]; then
-  AWS_REGION=${ECS_AWS_REGION} chamber exec ${ECS_SERVICE} -- java $JAVA_OPTS -jar *-allinone.jar server *.yaml
-else
-  java $JAVA_OPTS -jar *-allinone.jar server *.yaml
-fi
+java $JAVA_OPTS -jar *-allinone.jar server *.yaml

--- a/run-with-chamber.sh
+++ b/run-with-chamber.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+AWS_REGION="${ECS_AWS_REGION}" chamber exec "${ECS_SERVICE}" -- ./docker-startup.sh


### PR DESCRIPTION
I broke this yesterday, this fixes the broken change and adds a new
script which just calls the regular script but with chamber.

We override the entrypoint in the ECS task definition to call the regular startup script with chamber.

solo @tlwr