### PR TITLE
PP-3129 Adapt adminusers' log formats to match the other microservices

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/logger/RequestIdLoggingHandler.java
+++ b/src/main/java/uk/gov/pay/adminusers/logger/RequestIdLoggingHandler.java
@@ -23,7 +23,7 @@ class RequestIdLoggingHandler implements InvocationHandler {
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
         if (args[0] != null && (args[0] instanceof String)) {
-            args[0] = format("[%s] - %s", currentRequestId(), args[0]);
+            args[0] = format("[requestID=%s] - %s", currentRequestId(), args[0]);
         }
         return method.invoke(target, args);
     }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -13,7 +13,7 @@ logging:
         threshold: ALL
         timeZone: UTC
         target: stdout
-        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
+        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] [%-5level] [%logger{15}] %msg %n"
 
 database:
   driverClass: org.postgresql.Driver

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -13,7 +13,7 @@ logging:
         threshold: ALL
         timeZone: UTC
         target: stdout
-        logFormat: "[%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
+        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] [%-5level] [%logger{15}] - %msg %n"
 
 database:
   driverClass: org.postgresql.Driver


### PR DESCRIPTION
- Adminusers is using a different pattern (a request Id logging filter, instead of
  specifying the log format in `config.yaml`, so the format in that file is slightly different
- Removed colors