### PR TITLE
PP-3096: Refactor docker-startup WRT migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ WORKDIR /app
 ADD target/*.yaml /app/
 ADD target/pay-*-allinone.jar /app/
 ADD docker-startup.sh /app/docker-startup.sh
+ADD docker-startup-with-db-migration.sh /app/docker-startup-with-db-migration.sh
 ADD run-with-chamber.sh /app/run-with-chamber.sh
 
 CMD bash ./docker-startup.sh

--- a/docker-startup-with-db-migration.sh
+++ b/docker-startup-with-db-migration.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
 java -jar *-allinone.jar waitOnDependencies *.yaml && \
+java -jar *-allinone.jar migrateToInitialDbState *.yaml && \
+java -jar *-allinone.jar db migrate *.yaml && \
 java $JAVA_OPTS -jar *-allinone.jar server *.yaml


### PR DESCRIPTION
Like pay-connector there should be 2 docker startup scripts:
- docker-startup.sh
- docker-startup-with-db-migration.sh

This is so ECS will not run the migrations.