### PR TITLE
bau: Use doms chamber

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,13 @@
 FROM govukpay/openjdk:8-jre-alpine
 
-ARG CHAMBER_URL=https://github.com/segmentio/chamber/releases/download/v1.9.0/chamber-v1.9.0-linux-amd64
 
 RUN apk update
 RUN apk upgrade
 
 RUN apk add --no-cache bash
 
-ADD chamber.sha256sum /tmp/chamber.sha256sum
 RUN apk add --no-cache openssl && \
     mkdir -p bin && \
-    wget -qO bin/chamber $CHAMBER_URL && \
-    sha256sum -c /tmp/chamber.sha256sum && \
-    rm /tmp/chamber.sha256sum && \
-    chmod 755 bin/chamber && \
     apk del --purge openssl
 
 ENV PORT 8080
@@ -24,6 +18,8 @@ EXPOSE 8081
 
 WORKDIR /app
 
+
+ADD chamber--linux-amd64 /app/
 ADD target/*.yaml /app/
 ADD target/pay-*-allinone.jar /app/
 ADD docker-startup.sh /app/docker-startup.sh

--- a/chamber.sha256sum
+++ b/chamber.sha256sum
@@ -1,1 +1,0 @@
-88290cff6960fce9a2f30a7447d8c2a7dfa6e3d1d7a0446de75cb475505ef537  bin/chamber

--- a/run-with-chamber.sh
+++ b/run-with-chamber.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-AWS_REGION="${ECS_AWS_REGION}" chamber exec "${ECS_SERVICE}" -- ./docker-startup.sh
+AWS_REGION="${ECS_AWS_REGION}" ./chamber--linux-amd64 exec "${ECS_SERVICE}" -- ./docker-startup.sh


### PR DESCRIPTION
As a stop gap we need to use dominic's version of chamber as this can take the
cert path as an environment variable.

So I've just taken the chamber from selfservice and have switched to using it.