### PR TITLE
BAU: Use chamber in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ EXPOSE 8081
 WORKDIR /app
 
 
-ADD chamber--linux-amd64 /app/
 ADD target/*.yaml /app/
 ADD target/pay-*-allinone.jar /app/
 ADD docker-startup.sh /app/docker-startup.sh

--- a/run-with-chamber.sh
+++ b/run-with-chamber.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-AWS_REGION="${ECS_AWS_REGION}" ./chamber--linux-amd64 exec "${ECS_SERVICE}" -- ./docker-startup.sh
+AWS_REGION="${ECS_AWS_REGION}" chamber exec "${ECS_SERVICE}" -- ./docker-startup.sh


### PR DESCRIPTION
chamber is now in the base image for java and node

we don't vendor it anymore

and it is in /usr/bin so it is in the path

solo @tlwr