### PR TITLE
BAU Remove ECS deployment during refactor

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,8 +51,7 @@ pipeline {
         branch 'master'
       }
       steps {
-        deploy("adminusers", "test", null, true, false)
-        deployEcs("adminusers", "test", null, true, true)
+        deploy("adminusers", "test", null, true, true)
       }
     }
   }


### PR DESCRIPTION
Environment and ECS is being totally refactored, removing the ECS
deployment step temporarily until ECS is ready.

Reinstate tests to run after non ecs deployment.

with @tlwr