### PR TITLE
PP-3061 Sort Gateway Accounts with ad-hoc comparator

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/model/CreateUserRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/CreateUserRequest.java
@@ -54,7 +54,7 @@ public class CreateUserRequest {
                 gatewayAccountIds =
                         ImmutableList.copyOf(node.get(FIELD_GATEWAY_ACCOUNT_IDS).iterator())
                                 .stream().map(JsonNode::asText)
-                                .sorted(Comparators.usingNumericComparator())
+                                .sorted(Comparators.compareGatewayAccounts())
                                 .collect(Collectors.toList());
             }
             //Deprecated .. to remove when full y adopted to external Ids

--- a/src/main/java/uk/gov/pay/adminusers/model/CreateUserRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/CreateUserRequest.java
@@ -54,7 +54,7 @@ public class CreateUserRequest {
                 gatewayAccountIds =
                         ImmutableList.copyOf(node.get(FIELD_GATEWAY_ACCOUNT_IDS).iterator())
                                 .stream().map(JsonNode::asText)
-                                .sorted(Comparators.compareGatewayAccounts())
+                                .sorted(Comparators.numericallyThenLexicographically())
                                 .collect(Collectors.toList());
             }
             //Deprecated .. to remove when full y adopted to external Ids

--- a/src/main/java/uk/gov/pay/adminusers/utils/Comparators.java
+++ b/src/main/java/uk/gov/pay/adminusers/utils/Comparators.java
@@ -1,10 +1,26 @@
 package uk.gov.pay.adminusers.utils;
 
+import org.apache.commons.lang3.math.NumberUtils;
+
 import java.util.Comparator;
 
 public class Comparators {
 
     public static Comparator<String> usingNumericComparator() {
         return Comparator.comparingLong(Long::valueOf);
+    }
+
+    public static Comparator<String> compareGatewayAccounts() {
+        return (o1, o2) -> {
+            if (NumberUtils.isDigits(o1) && NumberUtils.isDigits(o2)){
+                return Comparators.usingNumericComparator().compare(o1, o2);
+            } else if (NumberUtils.isDigits(o1)) {
+                return -1;
+            } else if (NumberUtils.isDigits(o2)) {
+                return 1;
+            } else {
+                return o1.compareTo(o2);
+            }
+        };
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/utils/Comparators.java
+++ b/src/main/java/uk/gov/pay/adminusers/utils/Comparators.java
@@ -10,7 +10,7 @@ public class Comparators {
         return Comparator.comparingLong(Long::valueOf);
     }
 
-    public static Comparator<String> compareGatewayAccounts() {
+    public static Comparator<String> numericallyThenLexicographically() {
         return (o1, o2) -> {
             if (NumberUtils.isDigits(o1) && NumberUtils.isDigits(o2)){
                 return Comparators.usingNumericComparator().compare(o1, o2);

--- a/src/test/java/uk/gov/pay/adminusers/utils/ComparatorsTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/ComparatorsTest.java
@@ -1,0 +1,27 @@
+package uk.gov.pay.adminusers.utils;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ComparatorsTest {
+
+    @Test
+    public void shouldOrderNumericStringsInAscendingOrder() {
+        List<String> result = Stream.of("1", "6", "4", "10", "5").sorted(Comparators.usingNumericComparator()).collect(Collectors.toList());
+        assertThat(result, is(Arrays.asList("1","4","5","6","10")));
+    }
+
+    @Test
+    public void shouldOrderGatewayAccountsIdsNumericFirst() {
+        List<String> result = Stream.of("1aaa","1", "6", "cde", "4", "bbb23", "10", "5").sorted(Comparators.compareGatewayAccounts()).collect(Collectors.toList());
+        assertThat(result, is(Arrays.asList("1","4","5","6","10","1aaa","bbb23","cde")));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/adminusers/utils/ComparatorsTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/ComparatorsTest.java
@@ -9,18 +9,23 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static uk.gov.pay.adminusers.utils.Comparators.*;
 
 public class ComparatorsTest {
 
     @Test
     public void shouldOrderNumericStringsInAscendingOrder() {
-        List<String> result = Stream.of("1", "6", "4", "10", "5").sorted(Comparators.usingNumericComparator()).collect(Collectors.toList());
+        List<String> result = Stream.of("1", "6", "4", "10", "5")
+                .sorted(usingNumericComparator())
+                .collect(Collectors.toList());
         assertThat(result, is(Arrays.asList("1","4","5","6","10")));
     }
 
     @Test
-    public void shouldOrderGatewayAccountsIdsNumericFirst() {
-        List<String> result = Stream.of("1aaa","1", "6", "cde", "4", "bbb23", "10", "5").sorted(Comparators.compareGatewayAccounts()).collect(Collectors.toList());
+    public void shouldOrderGatewayAccountsIdsNumericallyThenLexicographically() {
+        List<String> result = Stream.of("1aaa","1", "6", "cde", "4", "bbb23", "10", "5")
+                .sorted(numericallyThenLexicographically())
+                .collect(Collectors.toList());
         assertThat(result, is(Arrays.asList("1","4","5","6","10","1aaa","bbb23","cde")));
     }
 


### PR DESCRIPTION
- We are introducing external account ids which are alphanumeric. In order to maintain backwards
  compatibility with numeric internal ids we can't use the Numeric Comparator any more.
- This PR introduces a new comparator that sorts the numeric account ids before the alphanumeric ids

 with @alexbishop1