### PR TITLE
PP-3061 Gateway account ids might be not numeric

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
@@ -69,13 +69,6 @@ public class InviteResource {
         return inviteServiceFactory.inviteCompleteRouter().routeComplete(inviteCode)
                 .map(inviteCompleterAndValidate -> {
                     InviteCompleter inviteCompleter = inviteCompleterAndValidate.getLeft();
-
-                    if (inviteCompleterAndValidate.getRight()) {
-                        Optional<Errors> errors = serviceRequestValidator.validateCreateRequest(payload);
-                        if (errors.isPresent()) {
-                            return Response.status(BAD_REQUEST).entity(errors).build();
-                        }
-                    }
                     return inviteCompleter.withData(inviteCompleteRequestFrom(payload)).complete(inviteCode)
                             .map(inviteCompleteResponse -> Response.status(OK).entity(inviteCompleteResponse).build())
                             .orElseGet(() -> Response.status(NOT_FOUND).build());

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
@@ -40,24 +40,6 @@ public class ServiceRequestValidator {
         this.requestValidations = requestValidations;
     }
 
-    public Optional<Errors> validateCreateRequest(JsonNode payload) {
-        if (payload == null || "{}".equals(payload.toString())) {
-            return Optional.empty();
-        }
-
-        if (!requestValidations.notExistOrEmptyArray().apply(payload.get(FIELD_GATEWAY_ACCOUNT_IDS))) {
-            if (nonNumericGatewayAccountIds(payload.get(FIELD_GATEWAY_ACCOUNT_IDS))) {
-                return Optional.of(Errors.from(format("Field [%s] must contain numeric values", FIELD_GATEWAY_ACCOUNT_IDS)));
-            }
-        }
-        return Optional.empty();
-    }
-
-    private boolean nonNumericGatewayAccountIds(JsonNode gatewayAccountNode) {
-        List<JsonNode> accountIds = Lists.newArrayList(gatewayAccountNode.elements());
-        return accountIds.stream().filter(idNode -> !NumberUtils.isDigits(idNode.asText())).count() > 0;
-    }
-
     public Optional<Errors> validateUpdateAttributeRequest(JsonNode payload) {
         Optional<List<String>> errors = requestValidations.checkIfExistsOrEmpty(payload, FIELD_OP, FIELD_PATH);
         if (errors.isPresent()) {

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
@@ -3,7 +3,6 @@ package uk.gov.pay.adminusers.resources;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.inject.Inject;
 import io.dropwizard.jersey.PATCH;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import uk.gov.pay.adminusers.exception.ServiceNotFoundException;
 import uk.gov.pay.adminusers.exception.ValidationException;
@@ -17,7 +16,16 @@ import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.service.LinksBuilder;
 import uk.gov.pay.adminusers.service.ServiceServicesFactory;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.Optional;
@@ -26,7 +34,12 @@ import java.util.stream.Collectors;
 import static com.google.common.collect.Lists.newArrayList;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status;
-import static javax.ws.rs.core.Response.Status.*;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.CONFLICT;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.NO_CONTENT;
+import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static uk.gov.pay.adminusers.resources.ServiceRequestValidator.FIELD_GATEWAY_ACCOUNT_IDS;
 import static uk.gov.pay.adminusers.resources.ServiceRequestValidator.FIELD_SERVICE_NAME;
@@ -87,15 +100,11 @@ public class ServiceResource {
     @Consumes(APPLICATION_JSON)
     public Response createService(JsonNode payload) {
         LOGGER.info("Create Service POST request - [ {} ]", payload);
-        return serviceRequestValidator.validateCreateRequest(payload)
-                .map(errors -> Response.status(BAD_REQUEST).entity(errors).build())
-                .orElseGet(() -> {
-                    Optional<String> serviceName = extractServiceName(payload);
-                    Optional<List<String>> gatewayAccountIds = extractGatewayAccountIds(payload);
+        Optional<String> serviceName = extractServiceName(payload);
+        Optional<List<String>> gatewayAccountIds = extractGatewayAccountIds(payload);
 
-                    Service service = serviceServicesFactory.serviceCreator().doCreate(serviceName, gatewayAccountIds);
-                    return Response.status(CREATED).entity(service).build();
-                });
+        Service service = serviceServicesFactory.serviceCreator().doCreate(serviceName, gatewayAccountIds);
+        return Response.status(CREATED).entity(service).build();
 
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceServiceCompleteTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceServiceCompleteTest.java
@@ -103,33 +103,6 @@ public class InviteResourceServiceCompleteTest extends IntegrationTest {
                 .body("service_roles[0].service.gateway_account_ids", hasItems(gatewayAccountId1, gatewayAccountId2));
     }
 
-
-    @Test
-    public void shouldReturn400w_WhenPassedAValidInviteCode_invalidPayload() throws Exception {
-        String email = format("%s@example.gov.uk", randomUuid());
-        String telephoneNumber = "088882345689";
-        String password = "valid_password";
-        String gatewayAccountId1 = "syfuer";
-        String gatewayAccountId2 = "uaigoiwblUERT";
-
-        ImmutableMap<String, List<String>> payload = ImmutableMap.of("gateway_account_ids", asList(gatewayAccountId1, gatewayAccountId2));
-
-        String inviteCode = inviteDbFixture(databaseHelper)
-                .withTelephoneNumber(telephoneNumber)
-                .withEmail(email)
-                .withPassword(password)
-                .insertServiceInvite();
-        givenSetup()
-                .when()
-                .body(mapper.writeValueAsString(payload))
-                .post(INVITES_RESOURCE_URL + "/" + inviteCode + "/complete")
-                .then()
-                .statusCode(BAD_REQUEST.getStatusCode())
-                .body("errors", hasSize(1))
-                .body("errors[0]", is("Field [gateway_account_ids] must contain numeric values"));
-
-    }
-
     @Test
     public void shouldReturn410_WhenSameInviteCodeCompletedTwice() {
         String email = format("%s@example.gov.uk", randomUuid());

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceRequestValidatorTest.java
@@ -23,44 +23,6 @@ public class ServiceRequestValidatorTest {
     private ObjectMapper mapper = new ObjectMapper();
     private ServiceRequestValidator serviceRequestValidator = new ServiceRequestValidator(new RequestValidations());
 
-    @Test
-    public void shouldSuccess_onEmptyJson() throws Exception {
-        Optional<Errors> errors = serviceRequestValidator.validateCreateRequest(mapper.readTree("{}"));
-        assertFalse(errors.isPresent());
-    }
-
-    @Test
-    public void shouldSuccess_onNullPayload() throws Exception {
-        Optional<Errors> errors = serviceRequestValidator.validateCreateRequest(null);
-        assertFalse(errors.isPresent());
-    }
-
-    @Test
-    public void shouldSuccess_ifNameIsEmpty() throws Exception {
-        ImmutableMap<String, String> payload = ImmutableMap.of("name", "");
-        Optional<Errors> errors = serviceRequestValidator.validateCreateRequest(mapper.valueToTree(payload));
-        assertFalse(errors.isPresent());
-    }
-
-    @Test
-    public void shouldSuccess_ifGatewayAccountIdsIsEmptyArray() throws Exception {
-        ImmutableMap<Object, Object> payload = ImmutableMap.builder()
-                .put("gateway_account_ids", new String[]{})
-                .build();
-
-        Optional<Errors> errors = serviceRequestValidator.validateCreateRequest(mapper.valueToTree(payload));
-        assertFalse(errors.isPresent());
-    }
-
-    @Test
-    public void shouldSuccess_forValidGatewayAccountIds() throws Exception {
-        ImmutableMap<Object, Object> payload = ImmutableMap.builder()
-                .put("gateway_account_ids", new String[]{"1", "2"})
-                .build();
-
-        Optional<Errors> errors = serviceRequestValidator.validateCreateRequest(mapper.valueToTree(payload));
-        assertFalse(errors.isPresent());
-    }
 
     @Test
     public void shouldSuccess_whenUpdate_whenAllFieldPresentAndValid() throws Exception {

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceCreateTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceCreateTest.java
@@ -36,7 +36,7 @@ public class ServiceResourceCreateTest extends IntegrationTest {
     public void shouldSuccess_whenCreateAServiceWithValidGatewayAccounts() throws Exception{
 
         ImmutableMap<Object, Object> payload = ImmutableMap.builder()
-                .put("gateway_account_ids", new String[]{"1", "2"})
+                .put("gateway_account_ids", new String[]{"thisisnotanumber", "2"})
                 .build();
 
         givenSetup()
@@ -49,27 +49,7 @@ public class ServiceResourceCreateTest extends IntegrationTest {
                 .body("name", is("System Generated"))
                 .body("external_id", notNullValue())
                 .body("gateway_account_ids", hasSize(2))
-                .body("gateway_account_ids", containsInAnyOrder("1","2"));
-
-    }
-
-    @Test
-    public void shouldError400_whenCreateAServiceWithInvalidGatewayAccounts() throws Exception{
-
-        ImmutableMap<Object, Object> payload = ImmutableMap.builder()
-                .put("name", "some service name")
-                .put("gateway_account_ids", new String[]{"blah", "blahblah"})
-                .build();
-
-        givenSetup()
-                .when()
-                .accept(JSON)
-                .body(mapper.writeValueAsString(payload))
-                .post("/v1/api/services")
-                .then()
-                .statusCode(400)
-                .body("errors", hasSize(1))
-                .body("errors", hasItems("Field [gateway_account_ids] must contain numeric values"));
+                .body("gateway_account_ids", containsInAnyOrder("thisisnotanumber","2"));
 
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceCreatorTest.java
@@ -63,15 +63,15 @@ public class ServiceCreatorTest {
     @Test
     public void shouldSuccess_whenProvidedOnlyWithUnassignedGatewayID() throws Exception {
 
-        Service service = serviceCreator.doCreate(Optional.empty(), Optional.of(asList("1", "2")));
+        Service service = serviceCreator.doCreate(Optional.empty(), Optional.of(asList("1siudha", "2")));
 
         verify(serviceDao, times(1)).persist(persistedServiceEntity.capture());
 
         assertThat(service.getName(), is("System Generated"));
         List<String> persistedGatewayIds = persistedServiceEntity.getValue().getGatewayAccountIds().stream().map(gai -> gai.getGatewayAccountId()).collect(toList());
         assertThat(persistedGatewayIds.size(),is(2));
-        assertThat(persistedGatewayIds,hasItems("1","2"));
-        assertThat(service.getGatewayAccountIds(), hasItems("1","2"));
+        assertThat(persistedGatewayIds,hasItems("1siudha","2"));
+        assertThat(service.getGatewayAccountIds(), hasItems("1siudha","2"));
     }
 
     @Test


### PR DESCRIPTION
 - `gatewayAccountIds` in a service can now be non-numeric, as we are migrating microservices to using external ids instead of internal ids.
 - There's no point in validating the create service request anymore, as the only cause for a `BAD REQUEST` was supplying non  numeric ids.