### PR TITLE
PP-3332 Upgrade Dropwizard to 1.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
     <artifactId>pay-adminusers</artifactId>
 
     <properties>
-        <dropwizard.version>1.0.6</dropwizard.version>
+        <dropwizard.version>1.2.2</dropwizard.version>
         <hamcrest.version>1.3</hamcrest.version>
         <eclipselink.version>2.6.4</eclipselink.version>
         <guice.version>4.1.0</guice.version>
-        <jersey2.version>2.25.1</jersey2.version>
         <docker-client.version>8.9.2</docker-client.version>
+        <jackson.version>2.9.4</jackson.version>
     </properties>
     <repositories>
         <repository>
@@ -78,18 +78,23 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.8.7</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.8.10</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>21.0</version>
+            <version>24.0-jre</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
@@ -143,16 +148,6 @@
             <version>4.5.3</version>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-common</artifactId>
-            <version>${jersey2.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-jaxb</artifactId>
-            <version>${jersey2.version}</version>
-        </dependency>
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.2.2</version>
@@ -180,6 +175,12 @@
             <artifactId>dropwizard-testing</artifactId>
             <version>${dropwizard.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>2.0.54-beta</version>
+                <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.jayway.restassured</groupId>


### PR DESCRIPTION
- upgrade Dropwizard to latest due to security vulnerability of current version
- pin jackson-version to 2.9.4 (deserialization vulnerability)
- remove jersey2 dependencies
- temporary use of mockito 2.0.54-beta (upgrade to latest requires code changes)
- upgrade guava to latest