### PR TITLE
PP-3265 Jenkins jobs converted to use selenium style smoke tests for all

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,36 @@ pipeline {
         branch 'master'
       }
       steps {
-        deployEcs("adminusers", "test", null, true, true)
+        deployEcs("adminusers", "test", null, false, false)
+      }
+    }
+    stage('Smoke Tests') {
+      when {
+        branch 'master'
+      }
+      steps {
+        runProductsSmokeTest()
+      }
+    }
+    stage('Complete') {
+      failFast true
+      parallel {
+        stage('Tag Build') {
+          when {
+            branch 'master'
+          }
+          steps {
+            tagDeployment("adminusers")
+          }
+        }
+        stage('Trigger Deploy Notification') {
+          when {
+            branch 'master'
+          }
+          steps {
+            triggerGraphiteDeployEvent("adminusers")
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
microservices

Use new separate split out jobs for deployment, smoke tests, tagging and
deployment event notification
Updated deployEcs arguments not to run tests and tag

solo @belindac