### PR TITLE
PP-3551 Unique constraint users username key failure fix

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -607,7 +607,7 @@ This endpoint creates an invitation to allow self provisioning new service with 
 POST /v1/api/invites/service
 Content-Type: application/json
 {
-"telephone_number":"088882345689",
+"telephone_number":"07700900000",
 "email": "example@example.gov.uk",
 "password" : "plain-txt-passsword"
 }
@@ -630,7 +630,7 @@ Content-Type: application/json
 {  
    "type":"service",
    "email":"example@example.gov.uk",
-   "telephone_number":"088882345689",
+   "telephone_number":"07700900000",
    "disabled":false,
    "attempt_counter":0,
    "_links":[  

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/InviteDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/InviteDbFixture.java
@@ -38,7 +38,14 @@ public class InviteDbFixture {
     public String insertInvite() {
         ServiceDbFixture.serviceDbFixture(databaseTestHelper).withId(serviceId).withExternalId(externalServiceId).insertService().getId();
         int roleId = RoleDbFixture.roleDbFixture(databaseTestHelper).insertRole().getId();
-        int invitingUserId = UserDbFixture.userDbFixture(databaseTestHelper).insertUser().getId();
+        String userUsername = randomUuid();
+        String userEmail = userUsername + "@example.com";
+        int invitingUserId =
+                UserDbFixture.userDbFixture(databaseTestHelper)
+                        .withUsername(userUsername)
+                        .withEmail(userEmail)
+                        .insertUser()
+                        .getId();
         databaseTestHelper.addInvite(
                 nextInt(), invitingUserId, serviceId, roleId,
                 email, code, otpKey, date, expiryDate, telephoneNumber, password,
@@ -49,9 +56,16 @@ public class InviteDbFixture {
 
     public String insertServiceInvite() {
         int roleId = RoleDbFixture.roleDbFixture(databaseTestHelper).insertRole().getId();
-        int userId = UserDbFixture.userDbFixture(databaseTestHelper).insertUser().getId();
+        String userUsername = randomUuid();
+        String userEmail = userUsername + "@example.com";
+        int invitingUserId =
+                UserDbFixture.userDbFixture(databaseTestHelper)
+                        .withUsername(userUsername)
+                        .withEmail(userEmail)
+                        .insertUser()
+                        .getId();
         databaseTestHelper.addServiceInvite(
-                nextInt(), userId, roleId,
+                nextInt(), invitingUserId, roleId,
                 email, code, otpKey, date, expiryDate, telephoneNumber, password,
                 disabled, loginCounter
         );

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
@@ -20,7 +20,7 @@ public class UserDbFixture {
     private final DatabaseTestHelper databaseTestHelper;
     private List<Pair<Service, Role>> serviceRolePairs = newArrayList();
     private String externalId = randomUuid();
-    private String username = RandomStringUtils.randomAlphabetic(10);
+    private String username = randomUuid();
     private String otpKey = RandomStringUtils.randomAlphabetic(10);
     private String password = "password-" + username;
     private String email = username + "@example.com";

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
@@ -24,7 +24,7 @@ public class UserDbFixture {
     private String otpKey = RandomStringUtils.randomAlphabetic(10);
     private String password = "password-" + username;
     private String email = username + "@example.com";
-    private String telephoneNumber = "374628482";
+    private String telephoneNumber = "07700900000";
     private String features = "FEATURE_1, FEATURE_2";
     private List<String> gatewayAccountIds = newArrayList();
 

--- a/src/test/java/uk/gov/pay/adminusers/pact/UsersApiTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/pact/UsersApiTest.java
@@ -26,10 +26,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.commons.lang3.RandomStringUtils.randomNumeric;
 import static org.apache.commons.lang3.RandomUtils.nextInt;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.RoleDbFixture.roleDbFixture;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 
@@ -61,7 +61,7 @@ public class UsersApiTest {
     public void aUserExistsWithAForgottenPasswordRequest() throws Exception {
         String code = "avalidforgottenpasswordtoken";
         String userExternalId = RandomIdGenerator.randomUuid();
-        createUserWithinAService(userExternalId, randomAlphabetic(20), "password");
+        createUserWithinAService(userExternalId, RandomIdGenerator.randomUuid(), "password");
         List<Map<String, Object>> userByExternalId = dbHelper.findUserByExternalId(userExternalId);
         dbHelper.add(ForgottenPassword.forgottenPassword(code, userExternalId), (Integer) userByExternalId.get(0).get("id"));
     }
@@ -91,8 +91,12 @@ public class UsersApiTest {
         Service service = ServiceDbFixture.serviceDbFixture(dbHelper).withExternalId(existingServiceExternalId).insertService();
         Role role = RoleDbFixture.roleDbFixture(dbHelper).insertAdmin();
 
-        UserDbFixture.userDbFixture(dbHelper).withExternalId(existingUserExternalId).withServiceRole(service, role.getId()).insertUser();
-        UserDbFixture.userDbFixture(dbHelper).withExternalId(existingUserRemoverExternalId).withServiceRole(service, role.getId()).insertUser();
+        String username1 = randomUuid();
+        String email1 = username1 + "@example.com";
+        UserDbFixture.userDbFixture(dbHelper).withExternalId(existingUserExternalId).withServiceRole(service, role.getId()).withUsername(username1).withEmail(email1).insertUser();
+        String username2 = randomUuid();
+        String email2 = username2 + "@example.com";
+        UserDbFixture.userDbFixture(dbHelper).withExternalId(existingUserRemoverExternalId).withServiceRole(service, role.getId()).withUsername(username2).withEmail(email2).insertUser();
     }
 
     @State("a user exists but not the remover before a delete operation")
@@ -104,7 +108,9 @@ public class UsersApiTest {
         Service service = ServiceDbFixture.serviceDbFixture(dbHelper).withExternalId(existingServiceExternalId).insertService();
         Role role = RoleDbFixture.roleDbFixture(dbHelper).insertAdmin();
 
-        UserDbFixture.userDbFixture(dbHelper).withExternalId(existingUserExternalId).withServiceRole(service, role.getId()).insertUser();
+        String username = randomUuid();
+        String email = username + "@example.com";
+        UserDbFixture.userDbFixture(dbHelper).withExternalId(existingUserExternalId).withServiceRole(service, role.getId()).withUsername(username).withEmail(email).insertUser();
     }
 
     private static void createUserWithinAService(String externalId, String username, String password) throws Exception {
@@ -127,7 +133,7 @@ public class UsersApiTest {
     })
     public void noSetUp() {
     }
-    
+
     private static void createUserWithinAService(String externalId, String username, int serviceId, String password) throws Exception {
         String gatewayAccount1 = randomNumeric(5);
         String gatewayAccount2 = randomNumeric(5);

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/ForgottenPasswordDaoTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/ForgottenPasswordDaoTest.java
@@ -41,7 +41,9 @@ public class ForgottenPasswordDaoTest extends DaoTestBase {
     @Test
     public void shouldPersistAForgottenPasswordEntity() throws Exception {
         String forgottenPasswordCode = random(10);
-        User user = userDbFixture(databaseHelper).insertUser();
+        String username = randomUuid();
+        String email = username + "@example.com";
+        User user = userDbFixture(databaseHelper).withUsername(username).withEmail(email).insertUser();
         String userExternalId = user.getExternalId();
         UserEntity userEntity = userDao.findByExternalId(userExternalId).get();
 
@@ -64,7 +66,9 @@ public class ForgottenPasswordDaoTest extends DaoTestBase {
     @Test
     public void shouldFindForgottenPasswordByCode_ifNotExpired() throws Exception {
         String forgottenPasswordCode = random(10);
-        User user = userDbFixture(databaseHelper).insertUser();
+        String username = randomUuid();
+        String email = username + "@example.com";
+        User user = userDbFixture(databaseHelper).withUsername(username).withEmail(email).insertUser();
         String userExternalId = user.getExternalId();
         UserEntity userEntity = userDao.findByExternalId(userExternalId).get();
 
@@ -84,7 +88,9 @@ public class ForgottenPasswordDaoTest extends DaoTestBase {
     @Test
     public void shouldNotFindForgottenPasswordByCode_ifExpired() throws Exception {
         String forgottenPasswordCode = randomUuid();
-        User user = userDbFixture(databaseHelper).insertUser();
+        String username = randomUuid();
+        String email = username + "@example.com";
+        User user = userDbFixture(databaseHelper).withUsername(username).withEmail(email).insertUser();
         String userExternalId = user.getExternalId();
         UserEntity userEntity = userDao.findByExternalId(userExternalId).get();
 
@@ -100,7 +106,9 @@ public class ForgottenPasswordDaoTest extends DaoTestBase {
     @Test
     public void shouldRemoveForgottenPasswordEntity() {
         String forgottenPasswordCode = randomUuid();
-        User user = userDbFixture(databaseHelper).insertUser();
+        String username = randomUuid();
+        String email = username + "@example.com";
+        User user = userDbFixture(databaseHelper).withUsername(username).withEmail(email).insertUser();
         String userExternalId = user.getExternalId();
         UserEntity userEntity = userDao.findByExternalId(userExternalId).get();
 

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/InviteDaoTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/InviteDaoTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.InviteDbFixture.inviteDbFixture;
 import static uk.gov.pay.adminusers.fixtures.RoleDbFixture.roleDbFixture;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
@@ -44,17 +45,18 @@ public class InviteDaoTest extends DaoTestBase {
 
         Role role = roleDbFixture(databaseHelper).insertRole();
         int serviceId = serviceDbFixture(databaseHelper).insertService().getId();
-        User sender = userDbFixture(databaseHelper).insertUser();
+        String username = randomUuid();
+        String email = username + "@example.com";
+        User sender = userDbFixture(databaseHelper).withUsername(username).withEmail(email).insertUser();
 
         RoleEntity roleEntity = roleDao.findByRoleName(role.getName()).get();
         ServiceEntity serviceEntity = serviceDao.findById(serviceId).get();
         UserEntity userSenderEntity = userDao.findById(sender.getId()).get();
 
-        String email = "USER@example.com";
         String code = randomAlphanumeric(10);
         String otpKey = randomAlphanumeric(10);
 
-        InviteEntity invite = new InviteEntity(email, code, otpKey, roleEntity);
+        InviteEntity invite = new InviteEntity("USER@example.com", code, otpKey, roleEntity);
         invite.setService(serviceEntity);
         invite.setSender(userSenderEntity);
 

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoTest.java
@@ -7,7 +7,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.postgresql.util.PGobject;
 import uk.gov.pay.adminusers.fixtures.UserDbFixture;
-import uk.gov.pay.adminusers.model.*;
+import uk.gov.pay.adminusers.model.MerchantDetails;
+import uk.gov.pay.adminusers.model.Permission;
+import uk.gov.pay.adminusers.model.Role;
+import uk.gov.pay.adminusers.model.Service;
+import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.persistence.entity.CustomBrandingConverter;
 import uk.gov.pay.adminusers.persistence.entity.MerchantDetailsEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
@@ -178,7 +182,7 @@ public class ServiceDaoTest extends DaoTestBase {
 
         Long count = serviceDao.countOfUsersWithRoleForService(serviceExternalId, roleId);
 
-        assertThat(count, is(3l));
+        assertThat(count, is(3L));
     }
 
     private void setupUsersForServiceAndRole(String externalId, int roleId, int noOfUsers) {
@@ -195,7 +199,9 @@ public class ServiceDaoTest extends DaoTestBase {
         databaseHelper.addService(service1, gatewayAccountId1);
 
         range(0, noOfUsers - 1).forEach(i -> {
-            UserDbFixture.userDbFixture(databaseHelper).withServiceRole(service1, roleId).insertUser();
+            String username = randomUuid();
+            String email = username + "@example.com";
+            UserDbFixture.userDbFixture(databaseHelper).withServiceRole(service1, roleId).withUsername(username).withEmail(email).insertUser();
         });
 
         //unmatching service
@@ -206,7 +212,9 @@ public class ServiceDaoTest extends DaoTestBase {
         databaseHelper.addService(service2, gatewayAccountId2);
 
         //same user 2 diff services - should count only once
-        User user3 = UserDbFixture.userDbFixture(databaseHelper).withServiceRole(service1, roleId).insertUser();
+        String username3 = randomUuid();
+        String email3 = username3 + "@example.com";
+        User user3 = UserDbFixture.userDbFixture(databaseHelper).withServiceRole(service1, roleId).withUsername(username3).withEmail(email3).insertUser();
         databaseHelper.addUserServiceRole(user3.getId(), serviceId2, role.getId());
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceRoleDaoTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceRoleDaoTest.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 
 public class ServiceRoleDaoTest extends DaoTestBase {
 
@@ -30,7 +31,14 @@ public class ServiceRoleDaoTest extends DaoTestBase {
 
         Service service = ServiceDbFixture.serviceDbFixture(databaseHelper).insertService();
         int roleId = RoleDbFixture.roleDbFixture(databaseHelper).insertRole().getId();
-        User user = UserDbFixture.userDbFixture(databaseHelper).withServiceRole(service, roleId).insertUser();
+        String username = randomUuid();
+        String email = username + "@example.com";
+        User user =
+                UserDbFixture.userDbFixture(databaseHelper)
+                        .withServiceRole(service, roleId)
+                        .withUsername(username)
+                        .withEmail(email)
+                        .insertUser();
         UserServiceId userServiceId = new UserServiceId();
         userServiceId.setServiceId(user.getServices().get(0).getId());
         userServiceId.setUserId(user.getId());

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoTest.java
@@ -22,11 +22,15 @@ import static java.lang.String.valueOf;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.RandomUtils.nextInt;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertTrue;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.RoleDbFixture.roleDbFixture;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
@@ -106,12 +110,15 @@ public class UserDaoTest extends DaoTestBase {
                 .insertService().getId();
         int serviceId2 = serviceDbFixture(databaseHelper)
                 .insertService().getId();
+        String username = randomUuid();
+        String email = username + "@example.com";
         User user = userDbFixture(databaseHelper)
                 .withServiceRole(serviceId1, role.getId())
                 .withServiceRole(serviceId2, role.getId())
+                .withUsername(username)
+                .withEmail(email)
                 .insertUser();
 
-        String username = user.getUsername();
         String externalId = user.getExternalId();
         String otpKey = user.getOtpKey();
 
@@ -121,7 +128,7 @@ public class UserDaoTest extends DaoTestBase {
         UserEntity foundUser = userEntityMaybe.get();
         assertThat(foundUser.getExternalId(), is(externalId));
         assertThat(foundUser.getUsername(), is(username));
-        assertThat(foundUser.getEmail(), is(username + "@example.com"));
+        assertThat(foundUser.getEmail(), is(email));
         assertThat(foundUser.getOtpKey(), is(otpKey));
         assertThat(foundUser.getTelephoneNumber(), is("374628482"));
         assertThat(foundUser.isDisabled(), is(false));
@@ -139,18 +146,30 @@ public class UserDaoTest extends DaoTestBase {
                 .insertService().getId();
         int serviceId2 = serviceDbFixture(databaseHelper)
                 .insertService().getId();
+        String username1 = randomUuid();
+        String email1 = username1 + "@example.com";
         User user1 = userDbFixture(databaseHelper)
                 .withServiceRole(serviceId1, role.getId())
                 .withServiceRole(serviceId2, role.getId())
+                .withUsername(username1)
+                .withEmail(email1)
                 .insertUser();
+        String username2 = randomUuid();
+        String email2 = username2 + "@example.com";
         User user2 = userDbFixture(databaseHelper)
                 .withServiceRole(serviceId1, role.getId())
                 .withServiceRole(serviceId2, role.getId())
+                .withUsername(username2)
+                .withEmail(email2)
                 .insertUser();
         // Add third user to prove we're not just returning all users
+        String username3 = randomUuid();
+        String email3 = username3 + "@example.com";
         userDbFixture(databaseHelper)
                 .withServiceRole(serviceId1, role.getId())
                 .withServiceRole(serviceId2, role.getId())
+                .withUsername(username3)
+                .withEmail(email3)
                 .insertUser();
 
         List<String> externalIds = Arrays.asList(user1.getExternalId(), user2.getExternalId());
@@ -161,7 +180,7 @@ public class UserDaoTest extends DaoTestBase {
         UserEntity foundUser1 = userEntities.get(0);
         assertThat(foundUser1.getExternalId(), is(user1.getExternalId()));
         assertThat(foundUser1.getUsername(), is(user1.getUsername()));
-        assertThat(foundUser1.getEmail(), is(user1.getUsername() + "@example.com"));
+        assertThat(foundUser1.getEmail(), is(user1.getEmail()));
         assertThat(foundUser1.getOtpKey(), is(user1.getOtpKey()));
         assertThat(foundUser1.getTelephoneNumber(), is("374628482"));
         assertThat(foundUser1.isDisabled(), is(false));
@@ -174,7 +193,7 @@ public class UserDaoTest extends DaoTestBase {
         UserEntity foundUser2 = userEntities.get(1);
         assertThat(foundUser2.getExternalId(), is(user2.getExternalId()));
         assertThat(foundUser2.getUsername(), is(user2.getUsername()));
-        assertThat(foundUser2.getEmail(), is(user2.getUsername() + "@example.com"));
+        assertThat(foundUser2.getEmail(), is(user2.getEmail()));
         assertThat(foundUser2.getOtpKey(), is(user2.getOtpKey()));
         assertThat(foundUser2.getTelephoneNumber(), is("374628482"));
         assertThat(foundUser2.isDisabled(), is(false));
@@ -190,17 +209,18 @@ public class UserDaoTest extends DaoTestBase {
         Role role = roleDbFixture(databaseHelper).insertRole();
         int serviceId = serviceDbFixture(databaseHelper)
                 .insertService().getId();
+        String username = randomUuid();
+        String email = username + "@example.com";
         User user = userDbFixture(databaseHelper)
-                .withServiceRole(serviceId, role.getId()).insertUser();
+                .withServiceRole(serviceId, role.getId()).withUsername(username).withEmail(email).insertUser();
 
-        String username = user.getUsername();
         String otpKey = user.getOtpKey();
 
         Optional<UserEntity> userEntityMaybe = userDao.findByUsername(username.toUpperCase());
         assertTrue(userEntityMaybe.isPresent());
 
         UserEntity foundUser = userEntityMaybe.get();
-        assertThat(foundUser.getEmail(), is(username + "@example.com"));
+        assertThat(foundUser.getEmail(), is(email));
         assertThat(foundUser.getUsername(), is(username));
         assertThat(foundUser.getOtpKey(), is(otpKey));
         assertThat(foundUser.getTelephoneNumber(), is("374628482"));
@@ -215,12 +235,12 @@ public class UserDaoTest extends DaoTestBase {
     public void shouldFindUser_ByEmail_caseInsensitive() throws Exception {
         Role role = roleDbFixture(databaseHelper).insertRole();
         int serviceId = serviceDbFixture(databaseHelper).insertService().getId();
+        String username = randomUuid();
+        String email = username + "@example.com";
         User user = userDbFixture(databaseHelper)
-                .withServiceRole(serviceId, role.getId()).insertUser();
+                .withServiceRole(serviceId, role.getId()).withUsername(username).withEmail(email).insertUser();
 
-        String username = user.getUsername();
         String otpKey = user.getOtpKey();
-        String email = user.getEmail();
 
         Optional<UserEntity> userEntityMaybe = userDao.findByEmail(username + "@EXAMPLE.com");
         assertTrue(userEntityMaybe.isPresent());
@@ -250,10 +270,12 @@ public class UserDaoTest extends DaoTestBase {
         serviceDbFixture(databaseHelper)
                 .withGatewayAccountIds(gatewayAccountId2).insertService();
 
-        User user = userDbFixture(databaseHelper)
-                .withServiceRole(service1, role1.getId()).insertUser();
+        String username = randomUuid();
+        String email = username + "@example.com";
 
-        String username = user.getUsername();
+        User user = userDbFixture(databaseHelper)
+                .withServiceRole(service1, role1.getId()).withUsername(username).withEmail(email).insertUser();
+
         UserEntity existingUser = userDao.findByUsername(username).get();
 
         assertThat(existingUser.getGatewayAccountId(), is(gatewayAccountId1));
@@ -288,12 +310,18 @@ public class UserDaoTest extends DaoTestBase {
 
         int serviceId = serviceDbFixture(databaseHelper).insertService().getId();
 
+        String username1 = "thomas" + randomUuid();
+        String email1 = username1 + "@example.com";
         User user1 = userDbFixture(databaseHelper)
-                .withUsername("thomas")
+                .withUsername(username1)
+                .withEmail(email1)
                 .withServiceRole(serviceId, role1.getId()).insertUser();
 
+        String username2 = "bob" + randomUuid();
+        String email2 = username2 + "@example.com";
         User user2 = userDbFixture(databaseHelper)
-                .withUsername("bob")
+                .withUsername(username2)
+                .withEmail(email2)
                 .withServiceRole(serviceId, role2.getId()).insertUser();
 
         List<UserEntity> users = userDao.findByServiceId(serviceId);

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoTest.java
@@ -130,7 +130,7 @@ public class UserDaoTest extends DaoTestBase {
         assertThat(foundUser.getUsername(), is(username));
         assertThat(foundUser.getEmail(), is(email));
         assertThat(foundUser.getOtpKey(), is(otpKey));
-        assertThat(foundUser.getTelephoneNumber(), is("374628482"));
+        assertThat(foundUser.getTelephoneNumber(), is("07700900000"));
         assertThat(foundUser.isDisabled(), is(false));
         assertThat(foundUser.getLoginCounter(), is(0));
         assertThat(foundUser.getSessionVersion(), is(0));
@@ -182,7 +182,7 @@ public class UserDaoTest extends DaoTestBase {
         assertThat(foundUser1.getUsername(), is(user1.getUsername()));
         assertThat(foundUser1.getEmail(), is(user1.getEmail()));
         assertThat(foundUser1.getOtpKey(), is(user1.getOtpKey()));
-        assertThat(foundUser1.getTelephoneNumber(), is("374628482"));
+        assertThat(foundUser1.getTelephoneNumber(), is("07700900000"));
         assertThat(foundUser1.isDisabled(), is(false));
         assertThat(foundUser1.getLoginCounter(), is(0));
         assertThat(foundUser1.getSessionVersion(), is(0));
@@ -195,7 +195,7 @@ public class UserDaoTest extends DaoTestBase {
         assertThat(foundUser2.getUsername(), is(user2.getUsername()));
         assertThat(foundUser2.getEmail(), is(user2.getEmail()));
         assertThat(foundUser2.getOtpKey(), is(user2.getOtpKey()));
-        assertThat(foundUser2.getTelephoneNumber(), is("374628482"));
+        assertThat(foundUser2.getTelephoneNumber(), is("07700900000"));
         assertThat(foundUser2.isDisabled(), is(false));
         assertThat(foundUser2.getLoginCounter(), is(0));
         assertThat(foundUser2.getSessionVersion(), is(0));
@@ -223,7 +223,7 @@ public class UserDaoTest extends DaoTestBase {
         assertThat(foundUser.getEmail(), is(email));
         assertThat(foundUser.getUsername(), is(username));
         assertThat(foundUser.getOtpKey(), is(otpKey));
-        assertThat(foundUser.getTelephoneNumber(), is("374628482"));
+        assertThat(foundUser.getTelephoneNumber(), is("07700900000"));
         assertThat(foundUser.isDisabled(), is(false));
         assertThat(foundUser.getLoginCounter(), is(0));
         assertThat(foundUser.getSessionVersion(), is(0));
@@ -249,7 +249,7 @@ public class UserDaoTest extends DaoTestBase {
         assertThat(foundUser.getUsername(), is(username));
         assertThat(foundUser.getEmail(), is(email));
         assertThat(foundUser.getOtpKey(), is(otpKey));
-        assertThat(foundUser.getTelephoneNumber(), is("374628482"));
+        assertThat(foundUser.getTelephoneNumber(), is("07700900000"));
         assertThat(foundUser.isDisabled(), is(false));
         assertThat(foundUser.getLoginCounter(), is(0));
         assertThat(foundUser.getSessionVersion(), is(0));

--- a/src/test/java/uk/gov/pay/adminusers/resources/ForgottenPasswordResourceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ForgottenPasswordResourceTest.java
@@ -4,9 +4,11 @@ import org.junit.Test;
 
 import static com.google.common.collect.ImmutableMap.of;
 import static com.jayway.restassured.http.ContentType.JSON;
-import static javax.ws.rs.core.Response.Status.*;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.ForgottenPasswordDbFixture.forgottenPasswordDbFixture;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
 
@@ -17,7 +19,9 @@ public class ForgottenPasswordResourceTest extends IntegrationTest {
     @Test
     public void shouldGetForgottenPasswordReference_whenCreate_forAnExistingUser() throws Exception {
 
-        String username = userDbFixture(databaseHelper).insertUser().getUsername();
+        String username = randomUuid();
+        String email = username + "@example.com";
+        userDbFixture(databaseHelper).withUsername(username).withEmail(email).insertUser().getUsername();
 
         givenSetup()
                 .when()
@@ -46,7 +50,9 @@ public class ForgottenPasswordResourceTest extends IntegrationTest {
     @Test
     public void shouldGetForgottenPassword_whenGetByCode_forAnExistingForgottenPassword() throws Exception {
 
-        int userId = userDbFixture(databaseHelper).insertUser().getId();
+        String username = randomUuid();
+        String email = username + "@example.com";
+        int userId = userDbFixture(databaseHelper).withUsername(username).withEmail(email).insertUser().getId();
         String forgottenPasswordCode = forgottenPasswordDbFixture(databaseHelper, userId).insertForgottenPassword();
 
         givenSetup()

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateServiceTest.java
@@ -6,11 +6,15 @@ import com.jayway.restassured.http.ContentType;
 import org.junit.Test;
 import uk.gov.pay.adminusers.fixtures.UserDbFixture;
 
-import static javax.ws.rs.core.Response.Status.*;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.CONFLICT;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 
 public class InviteResourceCreateServiceTest extends IntegrationTest {
 
@@ -19,7 +23,7 @@ public class InviteResourceCreateServiceTest extends IntegrationTest {
     @Test
     public void shouldSuccess_WhenAllRequiredFieldsAreProvidedAndValid() throws Exception {
         String email = "example@example.gov.uk";
-        String telephoneNumber = "088882345689";
+        String telephoneNumber = "07700900000";
         ImmutableMap<String, String> payload = ImmutableMap.of("telephone_number", telephoneNumber, "email", email, "password", "plain_text_password");
 
         givenSetup()
@@ -39,7 +43,7 @@ public class InviteResourceCreateServiceTest extends IntegrationTest {
 
     @Test
     public void shouldFail_WhenMandatoryFieldsAreMissing() throws Exception {
-        String telephoneNumber = "088882345689";
+        String telephoneNumber = "07700900000";
         ImmutableMap<String, String> payload = ImmutableMap.of("telephone_number", telephoneNumber, "password", "plain_text_password");
 
         givenSetup()
@@ -55,8 +59,8 @@ public class InviteResourceCreateServiceTest extends IntegrationTest {
 
     @Test
     public void shouldFail_WhenEmailIsNotPublicSectorDomain() throws Exception {
-        String email = "example@example.co.uk";
-        String telephoneNumber = "088882345689";
+        String email = "example@example.com";
+        String telephoneNumber = "07700900000";
         ImmutableMap<String, String> payload = ImmutableMap.of("telephone_number", telephoneNumber, "email", email, "password", "plain_text_password");
 
         givenSetup()
@@ -67,16 +71,17 @@ public class InviteResourceCreateServiceTest extends IntegrationTest {
                 .then()
                 .statusCode(FORBIDDEN.getStatusCode())
                 .body("errors", hasSize(1))
-                .body("errors", hasItems("Email [example@example.co.uk] is not a valid public sector email"));
+                .body("errors", hasItems("Email [" + email + "] is not a valid public sector email"));
     }
 
     @Test
     public void shouldFail_WhenEmailIsAlreadyRegistered() throws Exception {
 
-        String email = "example@example.gov.uk";
-        UserDbFixture.userDbFixture(databaseHelper).withEmail(email).insertUser();
+        String username = randomUuid();
+        String email = username + "@example.gov.uk";
+        UserDbFixture.userDbFixture(databaseHelper).withUsername(username).withEmail(email).insertUser();
 
-        String telephoneNumber = "088882345689";
+        String telephoneNumber = "07700900000";
         ImmutableMap<String, String> payload = ImmutableMap.of("telephone_number", telephoneNumber, "email", email, "password", "plain_text_password");
 
         givenSetup()
@@ -87,7 +92,7 @@ public class InviteResourceCreateServiceTest extends IntegrationTest {
                 .then()
                 .statusCode(CONFLICT.getStatusCode())
                 .body("errors", hasSize(1))
-                .body("errors", hasItems("email [example@example.gov.uk] already exists"));
+                .body("errors", hasItems("email [" + email + "] already exists"));
     }
 
 }

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceServiceCompleteTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceServiceCompleteTest.java
@@ -29,7 +29,7 @@ public class InviteResourceServiceCompleteTest extends IntegrationTest {
     @Test
     public void shouldReturn200withDisabledInviteLinkingToCreatedUser_WhenPassedAValidInviteCode_withoutGatewayAccountIds() {
         String email = format("%s@example.gov.uk", randomUuid());
-        String telephoneNumber = "088882345689";
+        String telephoneNumber = "07700900000";
         String password = "valid_password";
 
         String inviteCode = inviteDbFixture(databaseHelper)
@@ -64,7 +64,7 @@ public class InviteResourceServiceCompleteTest extends IntegrationTest {
     @Test
     public void shouldReturn200withDisabledInviteLinkingToCreatedUser_WhenPassedAValidInviteCode_withGatewayAccountIds() throws Exception {
         String email = format("%s@example.gov.uk", randomUuid());
-        String telephoneNumber = "088882345689";
+        String telephoneNumber = "07700900000";
         String password = "valid_password";
         String gatewayAccountId1 = String.valueOf(randomInt());
         String gatewayAccountId2 = String.valueOf(randomInt());
@@ -108,7 +108,7 @@ public class InviteResourceServiceCompleteTest extends IntegrationTest {
     @Test
     public void shouldReturn410_WhenSameInviteCodeCompletedTwice() {
         String email = format("%s@example.gov.uk", randomUuid());
-        String telephoneNumber = "088882345689";
+        String telephoneNumber = "07700900000";
         String password = "valid_password";
 
         String inviteCode = inviteDbFixture(databaseHelper)
@@ -134,7 +134,7 @@ public class InviteResourceServiceCompleteTest extends IntegrationTest {
     public void shouldReturn409_ifAUserExistsWithTheSameEmail_whenServiceInviteCompletes() {
         String email = format("%s@example.gov.uk", randomUuid());
         String username = email;
-        String telephoneNumber = "088882345689";
+        String telephoneNumber = "07700900000";
         String password = "valid_password";
 
         String inviteCode = inviteDbFixture(databaseHelper)
@@ -158,7 +158,7 @@ public class InviteResourceServiceCompleteTest extends IntegrationTest {
     @Test
     public void shouldReturn410_WheninviteIsDisabled() {
         String email = format("%s@example.gov.uk", randomUuid());
-        String telephoneNumber = "088882345689";
+        String telephoneNumber = "07700900000";
         String password = "valid_password";
 
         String inviteCode = inviteDbFixture(databaseHelper)

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceServiceCompleteTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceServiceCompleteTest.java
@@ -10,7 +10,9 @@ import java.util.Map;
 import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
-import static javax.ws.rs.core.Response.Status.*;
+import static javax.ws.rs.core.Response.Status.CONFLICT;
+import static javax.ws.rs.core.Response.Status.GONE;
+import static javax.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
@@ -131,6 +133,7 @@ public class InviteResourceServiceCompleteTest extends IntegrationTest {
     @Test
     public void shouldReturn409_ifAUserExistsWithTheSameEmail_whenServiceInviteCompletes() {
         String email = format("%s@example.gov.uk", randomUuid());
+        String username = email;
         String telephoneNumber = "088882345689";
         String password = "valid_password";
 
@@ -141,6 +144,7 @@ public class InviteResourceServiceCompleteTest extends IntegrationTest {
                 .insertServiceInvite();
 
         userDbFixture(databaseHelper)
+                .withUsername(username)
                 .withEmail(email)
                 .insertUser();
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceUserCompleteTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceUserCompleteTest.java
@@ -20,7 +20,7 @@ public class InviteResourceUserCompleteTest extends IntegrationTest {
     public void shouldReturn200WithDisabledInvite_whenExistingUserSubscribingToAnExistingService() throws Exception {
         String username = randomUuid();
         String email = format("%s@example.gov.uk", username);
-        String telephoneNumber = "088882345689";
+        String telephoneNumber = "07700900000";
         String password = "valid_password";
         String serviceExternalId = randomUuid();
         String userExternalId = randomUuid();
@@ -73,7 +73,7 @@ public class InviteResourceUserCompleteTest extends IntegrationTest {
     public void shouldReturn410_withDisabledInvite() throws Exception {
         String username = randomUuid();
         String email = format("%s@example.gov.uk", username);
-        String telephoneNumber = "088882345689";
+        String telephoneNumber = "07700900000";
         String password = "valid_password";
         String serviceExternalId = randomUuid();
         String userExternalId = randomUuid();

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceUserCompleteTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceUserCompleteTest.java
@@ -4,7 +4,9 @@ import org.junit.Test;
 
 import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
-import static javax.ws.rs.core.Response.Status.*;
+import static javax.ws.rs.core.Response.Status.GONE;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
@@ -16,7 +18,8 @@ public class InviteResourceUserCompleteTest extends IntegrationTest {
 
     @Test
     public void shouldReturn200WithDisabledInvite_whenExistingUserSubscribingToAnExistingService() throws Exception {
-        String email = format("%s@example.gov.uk", randomUuid());
+        String username = randomUuid();
+        String email = format("%s@example.gov.uk", username);
         String telephoneNumber = "088882345689";
         String password = "valid_password";
         String serviceExternalId = randomUuid();
@@ -25,6 +28,7 @@ public class InviteResourceUserCompleteTest extends IntegrationTest {
         userDbFixture(databaseHelper)
                 .withExternalId(userExternalId)
                 .withEmail(email)
+                .withUsername(username)
                 .insertUser();
 
         String inviteCode = inviteDbFixture(databaseHelper)
@@ -67,7 +71,8 @@ public class InviteResourceUserCompleteTest extends IntegrationTest {
 
     @Test
     public void shouldReturn410_withDisabledInvite() throws Exception {
-        String email = format("%s@example.gov.uk", randomUuid());
+        String username = randomUuid();
+        String email = format("%s@example.gov.uk", username);
         String telephoneNumber = "088882345689";
         String password = "valid_password";
         String serviceExternalId = randomUuid();
@@ -76,6 +81,7 @@ public class InviteResourceUserCompleteTest extends IntegrationTest {
         userDbFixture(databaseHelper)
                 .withExternalId(userExternalId)
                 .withEmail(email)
+                .withUsername(username)
                 .insertUser();
 
         String inviteCode = inviteDbFixture(databaseHelper)

--- a/src/test/java/uk/gov/pay/adminusers/resources/ResetPasswordResourceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ResetPasswordResourceTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.ForgottenPasswordDbFixture.forgottenPasswordDbFixture;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
 
@@ -24,7 +25,9 @@ public class ResetPasswordResourceTest extends IntegrationTest {
 
     @Before
     public void before() throws Exception {
-        userId = userDbFixture(databaseHelper).withPassword(CURRENT_PASSWORD).insertUser().getId();
+        String username = randomUuid();
+        String email = username + "@example.com";
+        userId = userDbFixture(databaseHelper).withPassword(CURRENT_PASSWORD).withUsername(username).withEmail(email).insertUser().getId();
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.adminusers.resources;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.Role;
@@ -38,19 +37,28 @@ public class ServiceResourceTest extends IntegrationTest {
         Service service = serviceDbFixture(databaseHelper).insertService();
         serviceExternalId = service.getExternalId();
 
+        String username1 = "c" + randomUuid();
+        String email1 = username1 + "@example.com";
         userWithRoleAdminInService1 = userDbFixture(databaseHelper)
                 .withServiceRole(service, roleAdmin.getId())
-                .withUsername("c" + RandomStringUtils.random(10))
+                .withUsername(username1)
+                .withEmail(email1)
                 .insertUser();
 
+        String username2 = "b" + randomUuid();
+        String email2 = username2 + "@example.com";
         user1WithRoleViewInService1 = userDbFixture(databaseHelper)
                 .withServiceRole(service, roleView.getId())
-                .withUsername("b" + RandomStringUtils.random(10))
+                .withUsername(username2)
+                .withEmail(email2)
                 .insertUser();
 
+        String username3 = "a" + randomUuid();
+        String email3 = username3 + "@example.com";
         user2WithRoleViewInService1 = userDbFixture(databaseHelper)
                 .withServiceRole(service, roleView.getId())
-                .withUsername("a" + RandomStringUtils.random(10))
+                .withUsername(username3)
+                .withEmail(email3)
                 .insertUser();
     }
 
@@ -66,17 +74,30 @@ public class ServiceResourceTest extends IntegrationTest {
         Service service1 = serviceDbFixture(databaseHelper).insertService();
         Service service2 = serviceDbFixture(databaseHelper).insertService();
 
+        String username1 = "zoe-" + randomUuid();
+        String email1 = username1 + "@example.com";
         User user1 = userDbFixture(databaseHelper)
-                .withUsername("zoe-" + randomUuid())
+                .withUsername(username1)
+                .withEmail(email1)
                 .withServiceRole(service1.getId(), role1.getId()).insertUser();
+        String username2 = "tim-" + randomUuid();
+        String email2 = username2 + "@example.com";
         User user2 = userDbFixture(databaseHelper)
-                .withUsername("tim-" + randomUuid())
+                .withUsername(username2)
+                .withEmail(email2)
                 .withServiceRole(service1.getId(), role2.getId()).insertUser();
+        String username3 = "bob-" + randomUuid();
+        String email3 = username3 + "@example.com";
         User user3 = userDbFixture(databaseHelper)
-                .withUsername("bob-" + randomUuid())
+                .withUsername(username3)
+                .withEmail(email3)
                 .withServiceRole(service1.getId(), role2.getId()).insertUser();
 
+        String username4 = randomUuid();
+        String email4 = username4 + "@example.com";
         userDbFixture(databaseHelper)
+                .withUsername(username4)
+                .withEmail(email4)
                 .withServiceRole(service2.getId(), role1.getId()).insertUser();
 
         givenSetup()

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationTest.java
@@ -11,8 +11,11 @@ import java.util.UUID;
 
 import static com.jayway.restassured.http.ContentType.JSON;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 
 public class UserResourceAuthenticationTest extends IntegrationTest {
@@ -53,12 +56,14 @@ public class UserResourceAuthenticationTest extends IntegrationTest {
 
     @Test
     public void shouldAuthenticateUser_onAValidUsernamePasswordCombination_whenUserDoesNotBelongToAService() throws Exception {
-        String username = randomAlphanumeric(10) + "example.com";
+        String username = randomUuid() + "@example.com";
+        String email = username;
         String password = "password-" + username;
         String encryptedPassword = (new PasswordHasher()).hash(password);
 
         UserDbFixture.userDbFixture(databaseHelper)
                 .withUsername(username)
+                .withEmail(email)
                 .withPassword(encryptedPassword).insertUser();
 
         ImmutableMap<Object, Object> authPayload = ImmutableMap.builder()

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateServiceRoleTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateServiceRoleTest.java
@@ -13,6 +13,7 @@ import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.RoleDbFixture.roleDbFixture;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
@@ -23,7 +24,9 @@ public class UserResourceCreateServiceRoleTest extends IntegrationTest {
     public void shouldSuccess_whenAddServiceRoleForUser() throws Exception {
         Role role = roleDbFixture(databaseHelper).insertAdmin();
         Service service = serviceDbFixture(databaseHelper).insertService();
-        User user = userDbFixture(databaseHelper).insertUser();
+        String username = randomUuid();
+        String email = username + "@example.com";
+        User user = userDbFixture(databaseHelper).withUsername(username).withEmail(email).insertUser();
 
         JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("service_external_id", service.getExternalId(), "role_name", role.getName()));
 
@@ -44,7 +47,9 @@ public class UserResourceCreateServiceRoleTest extends IntegrationTest {
     public void shouldError_whenAddServiceRoleForUser_ifMandatoryParamsMissing() throws Exception {
         Role role = roleDbFixture(databaseHelper).insertAdmin();
         serviceDbFixture(databaseHelper).insertService();
-        User user = userDbFixture(databaseHelper).insertUser();
+        String username = randomUuid();
+        String email = username + "@example.com";
+        User user = userDbFixture(databaseHelper).withUsername(username).withEmail(email).insertUser();
 
         JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("role_name", role.getName()));
 
@@ -65,7 +70,9 @@ public class UserResourceCreateServiceRoleTest extends IntegrationTest {
         String roleName = "view-and-refund";
         roleDbFixture(databaseHelper).withName(roleName).insertAdmin();
         Service service = serviceDbFixture(databaseHelper).insertService();
-        User user = userDbFixture(databaseHelper).withServiceRole(service.getId(), role.getId()).insertUser();
+        String username = randomUuid();
+        String email = username + "@example.com";
+        User user = userDbFixture(databaseHelper).withServiceRole(service.getId(), role.getId()).withUsername(username).withEmail(email).insertUser();
 
         JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("service_external_id", service.getExternalId(), "role_name", roleName));
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateTest.java
@@ -2,11 +2,8 @@ package uk.gov.pay.adminusers.resources;
 
 import com.google.common.collect.ImmutableMap;
 import com.jayway.restassured.response.ValidatableResponse;
-import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Test;
-import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.model.Service;
-import uk.gov.pay.adminusers.model.User;
 
 import java.util.List;
 import java.util.Map;
@@ -14,13 +11,13 @@ import java.util.Map;
 import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static java.lang.String.valueOf;
-import static java.util.UUID.randomUUID;
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.apache.commons.lang3.RandomUtils.nextInt;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static uk.gov.pay.adminusers.fixtures.RoleDbFixture.roleDbFixture;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
 
@@ -28,7 +25,7 @@ public class UserResourceCreateTest extends IntegrationTest {
 
     @Test
     public void shouldCreateAUser_Successfully() throws Exception {
-        String username = randomAlphanumeric(10) + randomUUID().toString();
+        String username = randomUuid();
         ImmutableMap<Object, Object> userPayload = ImmutableMap.builder()
                 .put("username", username)
                 .put("email", "user-" + username + "@example.com")
@@ -78,7 +75,7 @@ public class UserResourceCreateTest extends IntegrationTest {
         String gatewayAccount2 = valueOf(nextInt());
         Service service = serviceDbFixture(databaseHelper).withGatewayAccountIds(gatewayAccount1, gatewayAccount2).insertService();
         String serviceExternalId = service.getExternalId();
-        String username = randomAlphanumeric(10) + randomUUID().toString();
+        String username = randomUuid();
 
         ImmutableMap<Object, Object> userPayload = ImmutableMap.builder()
                 .put("username", username)
@@ -131,7 +128,7 @@ public class UserResourceCreateTest extends IntegrationTest {
 
     @Test
     public void shouldError400_IfRoleDoesNotExist() throws Exception {
-        String username = randomAlphanumeric(10) + randomUUID().toString();
+        String username = randomUuid();
         ImmutableMap<Object, Object> userPayload = ImmutableMap.builder()
                 .put("username", username)
                 .put("email", "user-" + username + "@example.com")
@@ -177,11 +174,13 @@ public class UserResourceCreateTest extends IntegrationTest {
     public void shouldError409_IfUsernameAlreadyExists() throws Exception {
         String gatewayAccount = valueOf(nextInt());
         serviceDbFixture(databaseHelper).withGatewayAccountIds(gatewayAccount).insertService();
-        String username = userDbFixture(databaseHelper).insertUser().getUsername();
+        String username = randomUuid();
+        String email = username + "@example.com";
+        userDbFixture(databaseHelper).withUsername(username).withEmail(email).insertUser();
 
         ImmutableMap<Object, Object> userPayload = ImmutableMap.builder()
                 .put("username", username)
-                .put("email", "user-" + username + "@example.com")
+                .put("email", email)
                 .put("gateway_account_ids", new String[]{gatewayAccount})
                 .put("telephone_number", "45334534634")
                 .put("role_name", "admin")

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceFindTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceFindTest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import static com.jayway.restassured.http.ContentType.JSON;
 import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
 
 public class UserResourceFindTest extends IntegrationTest {
@@ -17,8 +18,10 @@ public class UserResourceFindTest extends IntegrationTest {
 
     @Before
     public void createAUser() {
-        User user = userDbFixture(databaseHelper).insertUser();
-        username = user.getUsername();
+        String username = randomUuid();
+        String email = username + "@example.com";
+        User user = userDbFixture(databaseHelper).withUsername(username).withEmail(email).insertUser();
+        this.username = user.getUsername();
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceGetMultipleTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceGetMultipleTest.java
@@ -11,6 +11,7 @@ import static org.apache.commons.lang3.RandomUtils.nextInt;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.RoleDbFixture.roleDbFixture;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
@@ -25,14 +26,18 @@ public class UserResourceGetMultipleTest extends IntegrationTest {
         Service service = serviceDbFixture(databaseHelper).withGatewayAccountIds(gatewayAccount1, gatewayAccount2).insertService();
         String serviceExternalId = service.getExternalId();
         Role role = roleDbFixture(databaseHelper).insertRole();
-        User user1 = userDbFixture(databaseHelper).withServiceRole(service.getId(), role.getId()).insertUser();
-        User user2 = userDbFixture(databaseHelper).withServiceRole(service.getId(), role.getId()).insertUser();
+        String username1 = randomUuid();
+        String email1 = username1 + "@example.com";
+        User user1 = userDbFixture(databaseHelper).withServiceRole(service.getId(), role.getId()).withUsername(username1).withEmail(email1).insertUser();
+        String username2 = randomUuid();
+        String email2 = username2 + "@example.com";
+        User user2 = userDbFixture(databaseHelper).withServiceRole(service.getId(), role.getId()).withUsername(username2).withEmail(email2).insertUser();
 
         givenSetup()
                 .when()
                 .contentType(JSON)
                 .accept(JSON)
-                .get(USERS_RESOURCE +"?ids=" + user1.getExternalId() + "," + user2.getExternalId())
+                .get(USERS_RESOURCE + "?ids=" + user1.getExternalId() + "," + user2.getExternalId())
                 .then()
                 .statusCode(200)
                 .body("[0].external_id", is(user1.getExternalId()))
@@ -81,13 +86,15 @@ public class UserResourceGetMultipleTest extends IntegrationTest {
         Service service = serviceDbFixture(databaseHelper).withGatewayAccountIds(gatewayAccount1, gatewayAccount2).insertService();
         String serviceExternalId = service.getExternalId();
         Role role = roleDbFixture(databaseHelper).insertRole();
-        User user = userDbFixture(databaseHelper).withServiceRole(service.getId(), role.getId()).insertUser();
+        String username = randomUuid();
+        String email = username + "@example.com";
+        User user = userDbFixture(databaseHelper).withServiceRole(service.getId(), role.getId()).withUsername(username).withEmail(email).insertUser();
 
         givenSetup()
                 .when()
                 .contentType(JSON)
                 .accept(JSON)
-                .get(USERS_RESOURCE +"?ids=" + user.getExternalId())
+                .get(USERS_RESOURCE + "?ids=" + user.getExternalId())
                 .then()
                 .statusCode(200)
                 .body("[0].external_id", is(user.getExternalId()))
@@ -116,7 +123,7 @@ public class UserResourceGetMultipleTest extends IntegrationTest {
         givenSetup()
                 .when()
                 .accept(JSON)
-                .get(USERS_RESOURCE +"?ids=NON-EXISTENT-USER,ANOTHER_NON_EXISTENT_USER")
+                .get(USERS_RESOURCE + "?ids=NON-EXISTENT-USER,ANOTHER_NON_EXISTENT_USER")
                 .then()
                 .statusCode(404);
     }
@@ -127,13 +134,15 @@ public class UserResourceGetMultipleTest extends IntegrationTest {
         String gatewayAccount2 = valueOf(nextInt());
         Service service = serviceDbFixture(databaseHelper).withGatewayAccountIds(gatewayAccount1, gatewayAccount2).insertService();
         Role role = roleDbFixture(databaseHelper).insertRole();
-        User existingUser = userDbFixture(databaseHelper).withServiceRole(service.getId(), role.getId()).insertUser();
+        String username = randomUuid();
+        String email = username + "@example.com";
+        User existingUser = userDbFixture(databaseHelper).withServiceRole(service.getId(), role.getId()).withUsername(username).withEmail(email).insertUser();
 
         givenSetup()
                 .when()
                 .contentType(JSON)
                 .accept(JSON)
-                .get(USERS_RESOURCE +"?ids=" + existingUser.getExternalId() + ",NON-EXISTENT-USER")
+                .get(USERS_RESOURCE + "?ids=" + existingUser.getExternalId() + ",NON-EXISTENT-USER")
                 .then()
                 .statusCode(404);
     }

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceGetTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceGetTest.java
@@ -1,7 +1,5 @@
 package uk.gov.pay.adminusers.resources;
 
-import com.google.common.collect.ImmutableMap;
-import com.jayway.restassured.response.ValidatableResponse;
 import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.Role;
@@ -12,15 +10,15 @@ import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static java.lang.String.valueOf;
 import static org.apache.commons.lang3.RandomUtils.nextInt;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.RoleDbFixture.roleDbFixture;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
 
 public class UserResourceGetTest extends IntegrationTest {
-
-
 
     @Test
     public void shouldReturnUser_whenGetUserWithExternalId() throws Exception {
@@ -29,7 +27,9 @@ public class UserResourceGetTest extends IntegrationTest {
         Service service = serviceDbFixture(databaseHelper).withGatewayAccountIds(gatewayAccount1, gatewayAccount2).insertService();
         String serviceExternalId = service.getExternalId();
         Role role = roleDbFixture(databaseHelper).insertRole();
-        User user = userDbFixture(databaseHelper).withServiceRole(service.getId(), role.getId()).insertUser();
+        String username = randomUuid();
+        String email = username + "@example.com";
+        User user = userDbFixture(databaseHelper).withServiceRole(service.getId(), role.getId()).withUsername(username).withEmail(email).insertUser();
 
         givenSetup()
                 .when()

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourcePatchTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourcePatchTest.java
@@ -11,6 +11,7 @@ import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
 
 public class UserResourcePatchTest extends IntegrationTest {
@@ -19,7 +20,9 @@ public class UserResourcePatchTest extends IntegrationTest {
 
     @Before
     public void createAUser() {
-        User user = userDbFixture(databaseHelper).insertUser();
+        String username = randomUuid();
+        String email = username + "@example.com";
+        User user = userDbFixture(databaseHelper).withUsername(username).withEmail(email).insertUser();
 
         externalId = user.getExternalId();
     }
@@ -43,7 +46,7 @@ public class UserResourcePatchTest extends IntegrationTest {
     public void shouldUpdateTelephoneNumber_whenPatchAttempt() throws Exception {
 
         String newTelephoneNumber = "07700900001";
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace", "path", "telephone_number", "value",  newTelephoneNumber));
+        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace", "path", "telephone_number", "value", newTelephoneNumber));
 
         givenSetup()
                 .when()

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceSecondFactorAuthenticationTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceSecondFactorAuthenticationTest.java
@@ -10,6 +10,7 @@ import static com.google.common.io.BaseEncoding.base32;
 import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
 
 public class UserResourceSecondFactorAuthenticationTest extends IntegrationTest {
@@ -22,10 +23,12 @@ public class UserResourceSecondFactorAuthenticationTest extends IntegrationTest 
 
     @Before
     public void createValidUser() throws Exception {
-        User user = userDbFixture(databaseHelper).withOtpKey(OTP_KEY).insertUser();
+        String username = randomUuid();
+        String email = username + "@example.com";
+        User user = userDbFixture(databaseHelper).withOtpKey(OTP_KEY).withUsername(username).withEmail(email).insertUser();
 
-        externalId = user.getExternalId();
-        username = user.getUsername();
+        this.externalId = user.getExternalId();
+        this.username = user.getUsername();
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceUpdateServiceRoleTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceUpdateServiceRoleTest.java
@@ -12,6 +12,7 @@ import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.RoleDbFixture.roleDbFixture;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
@@ -23,8 +24,12 @@ public class UserResourceUpdateServiceRoleTest extends IntegrationTest {
         Role role = roleDbFixture(databaseHelper).insertAdmin();
         Service service = serviceDbFixture(databaseHelper).insertService();
         String serviceExternalId = service.getExternalId();
-        User user = userDbFixture(databaseHelper).withServiceRole(service, role.getId()).insertUser();
-        userDbFixture(databaseHelper).withServiceRole(service, role.getId()).insertUser();
+        String username1 = randomUuid();
+        String email1 = username1 + "@example.com";
+        User user = userDbFixture(databaseHelper).withServiceRole(service, role.getId()).withUsername(username1).withEmail(email1).insertUser();
+        String username2 = randomUuid();
+        String email2 = username2 + "@example.com";
+        userDbFixture(databaseHelper).withServiceRole(service, role.getId()).withUsername(username2).withEmail(email2).insertUser();
 
         JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("role_name", "view-and-refund"));
 
@@ -59,7 +64,9 @@ public class UserResourceUpdateServiceRoleTest extends IntegrationTest {
         Role role = roleDbFixture(databaseHelper).insertAdmin();
         Service service = serviceDbFixture(databaseHelper).insertService();
         String serviceExternalId = service.getExternalId();
-        User user = userDbFixture(databaseHelper).withServiceRole(service, role.getId()).insertUser();
+        String username = randomUuid();
+        String email = username + "@example.com";
+        User user = userDbFixture(databaseHelper).withServiceRole(service, role.getId()).withUsername(username).withEmail(email).insertUser();
 
         JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("role_name", "view-and-refund"));
 


### PR DESCRIPTION
## WHAT

- To generate `username`s and `email`s we were using `org.apache.commons.lang3.RandomStringUtils` which generated random, but sometimes not unique values.
- Also, we were sharing `UserDbFixture` with the same initial values

This PR fixes the errors like:
```
16:19:42 ERROR:  duplicate key value violates unique constraint "users_username_key"
16:19:42 DETAIL:  Key (username)=(ipjSodwJAl) already exists.
16:19:42 STATEMENT:  INSERT INTO users ("createdAt", disabled, email, external_id, features, login_counter, otp_key, password, session_version, telephone_number, "updatedAt", username, version) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
16:19:42 ERROR:  current transaction is aborted, commands ignored until end of transaction block
16:19:42 STATEMENT:  SELECT 1
```

Also, it contains small improvement for using test phone numbers