### PR TITLE
PP-3576 Add new columns to support logging in with 2FA apps

### DIFF
--- a/src/main/resources/migrations/00038_add_column_second_factor_to_users.sql
+++ b/src/main/resources/migrations/00038_add_column_second_factor_to_users.sql
@@ -1,0 +1,10 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_column_second_factor_to_users
+
+-- This will lock the users table (because NOT NULL and DEFAULT) but
+-- it only has ~650 rows and gets fairly light usage, so it shouldn’t
+-- cause any noticable impact
+ALTER TABLE users ADD COLUMN second_factor VARCHAR(16) NOT NULL DEFAULT 'sms';
+
+--rollback ALTER TABLE users DROP COLUMN second_factor;

--- a/src/main/resources/migrations/00039_add_column_provisional_otp_key_to_users.sql
+++ b/src/main/resources/migrations/00039_add_column_provisional_otp_key_to_users.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_column_provisional_otp_key
+
+ALTER TABLE users ADD COLUMN provisional_otp_key VARCHAR(255);
+
+--rollback ALTER TABLE users DROP COLUMN provisional_otp_key;

--- a/src/main/resources/migrations/00040_add_column_provisional_otp_key_created_at_to_users.sql
+++ b/src/main/resources/migrations/00040_add_column_provisional_otp_key_created_at_to_users.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_column_provisional_otp_key_created_at
+
+ALTER TABLE users ADD COLUMN provisional_otp_key_created_at TIMESTAMP WITH TIME ZONE;
+
+--rollback ALTER TABLE users DROP COLUMN provisional_otp_key_created_at;


### PR DESCRIPTION
* `second_factor` (defaults to `sms`)

* `provisional_otp_key` (will be used as a holding area to store a new OTP key while the user is setting it up)

* `provisional_otp_key_created_at` (will be used for a timestamp for when the new OTP key was created so we can expire it if the user does not complete the setup)