### PR TITLE
PP-3576 Add new 2FA properties to user

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/model/SecondFactorMethod.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/SecondFactorMethod.java
@@ -1,0 +1,19 @@
+package uk.gov.pay.adminusers.model;
+
+public enum SecondFactorMethod {
+
+    SMS {
+        @Override
+        public String toString() {
+            return "sms";
+        }
+    },
+
+    APP {
+        @Override
+        public String toString() {
+            return "app";
+        };
+    }
+
+}

--- a/src/main/java/uk/gov/pay/adminusers/model/User.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/User.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -39,18 +40,29 @@ public class User {
     private List<ServiceRole> serviceRoles = new ArrayList<>();
     @Deprecated // Use serviceRoles instead
     private List<Role> roles = new ArrayList<>();
+    private SecondFactorMethod secondFactor;
+    private String provisionalOtpKey;
+    private ZonedDateTime provisionalOtpKeyCreatedAt;
     private List<Link> links = new ArrayList<>();
     private Integer sessionVersion = 0;
 
     public static User from(Integer id, String externalId, String username, String password, String email,
-                            List<String> gatewayAccountIds, List<Service> services, String otpKey, String telephoneNumber, List<ServiceRole> serviceRoles, String features) {
-        return new User(id, externalId, username, password, email, gatewayAccountIds, services, otpKey, telephoneNumber, serviceRoles, features);
+                            List<String> gatewayAccountIds, List<Service> services, String otpKey, String telephoneNumber,
+                            List<ServiceRole> serviceRoles, String features, SecondFactorMethod secondFactor, String provisionalOtpKey,
+                            ZonedDateTime provisionalOtpKeyCreatedAt) {
+        User user = new User(id, externalId, username, password, email, gatewayAccountIds, services, otpKey, telephoneNumber,
+                serviceRoles, features, secondFactor, provisionalOtpKey, provisionalOtpKeyCreatedAt);
+        return user;
     }
 
-    private User(Integer id, @JsonProperty("external_id") String externalId, @JsonProperty("username") String username, @JsonProperty("password") String password,
-                 @JsonProperty("email") String email, @JsonProperty("gateway_account_ids") List<String> gatewayAccountIds,
-                 List<Service> services, @JsonProperty("otp_key") String otpKey, @JsonProperty("telephone_number") String telephoneNumber,
-                 @JsonProperty("service_roles") List<ServiceRole> serviceRoles, @JsonProperty("features") String features) {
+    private User(Integer id, @JsonProperty("external_id") String externalId, @JsonProperty("username") String username,
+                 @JsonProperty("password") String password, @JsonProperty("email") String email,
+                 @JsonProperty("gateway_account_ids") List<String> gatewayAccountIds, List<Service> services,
+                 @JsonProperty("otp_key") String otpKey, @JsonProperty("telephone_number") String telephoneNumber,
+                 @JsonProperty("service_roles") List<ServiceRole> serviceRoles, @JsonProperty("features") String features,
+                 @JsonProperty("second_factor") SecondFactorMethod secondFactor,
+                 @JsonProperty("provisional_otp_key") String provisionalOtpKey,
+                 @JsonProperty("provisional_otp_key_created_at") ZonedDateTime provisionalOtpKeyCreatedAt) {
         this.id = id;
         this.externalId = externalId;
         this.username = username;
@@ -62,6 +74,9 @@ public class User {
         this.telephoneNumber = telephoneNumber;
         this.serviceRoles = serviceRoles;
         this.features = features;
+        this.secondFactor = secondFactor;
+        this.provisionalOtpKey = provisionalOtpKey;
+        this.provisionalOtpKeyCreatedAt = provisionalOtpKeyCreatedAt;
     }
 
     @JsonIgnore
@@ -139,6 +154,30 @@ public class User {
         return services.stream().map(service -> String.valueOf(service.getId())).collect(Collectors.toList());
     }
 
+    public SecondFactorMethod getSecondFactor() {
+        return secondFactor;
+    }
+
+    public void setSecondFactor(SecondFactorMethod secondFactor) {
+        this.secondFactor = secondFactor;
+    }
+
+    public String getProvisionalOtpKey() {
+        return provisionalOtpKey;
+    }
+
+    public void setProvisionalOtpKey(String provisionalOtpKey) {
+        this.provisionalOtpKey = provisionalOtpKey;
+    }
+
+    public ZonedDateTime getProvisionalOtpKeyCreatedAt() {
+        return provisionalOtpKeyCreatedAt;
+    }
+
+    public void setProvisionalOtpKeyCreatedAt(ZonedDateTime provisionalOtpKeyCreatedAt) {
+        this.provisionalOtpKeyCreatedAt = provisionalOtpKeyCreatedAt;
+    }
+
     /**
      * We've agreed that given we are currently supporting only 1 role per user we will not json output a list of 1 role
      * instead the flat role attribute below.
@@ -185,7 +224,7 @@ public class User {
     }
 
     /**
-     * its probably not a good idea to toString() password / otpKey
+     * it’s definitely not a good idea to toString() password / otpKey
      *
      * @return
      */
@@ -193,6 +232,7 @@ public class User {
     public String toString() {
         return "User{" +
                 "externalId=" + externalId +
+                ", secondFactor=" + secondFactor +
                 ", gatewayAccountIds=[" + String.join(", ", gatewayAccountIds) + ']' +
                 ", disabled=" + disabled +
                 ", serviceRoles=" + serviceRoles +

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
@@ -3,8 +3,14 @@ package uk.gov.pay.adminusers.persistence.entity;
 import uk.gov.pay.adminusers.app.util.RandomIdGenerator;
 import uk.gov.pay.adminusers.model.Invite;
 import uk.gov.pay.adminusers.model.InviteType;
+import uk.gov.pay.adminusers.model.SecondFactorMethod;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
@@ -229,6 +235,7 @@ public class InviteEntity extends AbstractEntity {
         userEntity.setEmail(email);
         userEntity.setOtpKey(otpKey);
         userEntity.setTelephoneNumber(telephoneNumber);
+        userEntity.setSecondFactor(SecondFactorMethod.SMS);
         userEntity.setLoginCounter(0);
         userEntity.setDisabled(Boolean.FALSE);
         userEntity.setSessionVersion(0);

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/SecondFactorMethodConverter.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/SecondFactorMethodConverter.java
@@ -1,0 +1,26 @@
+package uk.gov.pay.adminusers.persistence.entity;
+
+import uk.gov.pay.adminusers.model.SecondFactorMethod;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter
+public class SecondFactorMethodConverter implements AttributeConverter<SecondFactorMethod, String> {
+
+    @Override
+    public String convertToDatabaseColumn(SecondFactorMethod secondFactor) {
+        return secondFactor.toString();
+    }
+
+    @Override
+    public SecondFactorMethod convertToEntityAttribute(String string) {
+        for (SecondFactorMethod secondFactorMethod : SecondFactorMethod.values()) {
+            if (secondFactorMethod.toString().equals(string)) {
+                return secondFactorMethod;
+            }
+        }
+        return SecondFactorMethod.SMS;
+    }
+
+}

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/UTCDateTimeConverter.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/UTCDateTimeConverter.java
@@ -13,6 +13,9 @@ public class UTCDateTimeConverter implements AttributeConverter<ZonedDateTime, T
 
     @Override
     public Timestamp convertToDatabaseColumn(ZonedDateTime dateTime) {
+        if (dateTime == null) {
+            return null;
+        }
         return Timestamp.from(dateTime.toInstant());
     }
 
@@ -20,8 +23,7 @@ public class UTCDateTimeConverter implements AttributeConverter<ZonedDateTime, T
     public ZonedDateTime convertToEntityAttribute(Timestamp s) {
         if (s == null) {
             return null;
-        } else {
-            return ZonedDateTime.ofInstant(s.toInstant(), UTC);
         }
+        return ZonedDateTime.ofInstant(s.toInstant(), UTC);
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
@@ -2,11 +2,18 @@ package uk.gov.pay.adminusers.persistence.entity;
 
 import uk.gov.pay.adminusers.app.util.RandomIdGenerator;
 import uk.gov.pay.adminusers.model.CreateUserRequest;
+import uk.gov.pay.adminusers.model.SecondFactorMethod;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.ServiceRole;
 import uk.gov.pay.adminusers.model.User;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.OneToMany;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -63,6 +70,17 @@ public class UserEntity extends AbstractEntity {
 
     @Column(name = "session_version", columnDefinition = "int default 0")
     private Integer sessionVersion;
+
+    @Column(name = "second_factor", nullable = false)
+    @Convert(converter = SecondFactorMethodConverter.class)
+    private SecondFactorMethod secondFactor;
+
+    @Column(name = "provisional_otp_key")
+    private String provisionalOtpKey;
+
+    @Column(name = "provisional_otp_key_created_at")
+    @Convert(converter = UTCDateTimeConverter.class)
+    private ZonedDateTime provisionalOtpKeyCreatedAt;
 
     public UserEntity() {
         //for jpa
@@ -168,6 +186,30 @@ public class UserEntity extends AbstractEntity {
         this.sessionVersion = sessionVersion;
     }
 
+    public SecondFactorMethod getSecondFactor() {
+        return secondFactor;
+    }
+
+    public void setSecondFactor(SecondFactorMethod secondFactor) {
+        this.secondFactor = secondFactor;
+    }
+
+    public String getProvisionalOtpKey() {
+        return provisionalOtpKey;
+    }
+
+    public void setProvisionalOtpKey(String provisionalOtpKey) {
+        this.provisionalOtpKey = provisionalOtpKey;
+    }
+
+    public ZonedDateTime getProvisionalOtpKeyCreatedAt() {
+        return provisionalOtpKeyCreatedAt;
+    }
+
+    public void setProvisionalOtpKeyCreatedAt(ZonedDateTime provisionalOtpKeyCreatedAt) {
+        this.provisionalOtpKeyCreatedAt = provisionalOtpKeyCreatedAt;
+    }
+
     /**
      * Note: this constructor will not copy <b>id</b> from the User model. It will always assign a new one internally (by JPA)
      *
@@ -182,6 +224,7 @@ public class UserEntity extends AbstractEntity {
         userEntity.setEmail(user.getEmail());
         userEntity.setOtpKey(user.getOtpKey());
         userEntity.setTelephoneNumber(user.getTelephoneNumber());
+        userEntity.setSecondFactor(user.getSecondFactor());
         userEntity.setLoginCounter(user.getLoginCounter());
         userEntity.setFeatures(user.getFeatures());
         userEntity.setDisabled(user.isDisabled());
@@ -206,6 +249,7 @@ public class UserEntity extends AbstractEntity {
         userEntity.setEmail(createUserRequest.getEmail());
         userEntity.setOtpKey(createUserRequest.getOtpKey());
         userEntity.setTelephoneNumber(createUserRequest.getTelephoneNumber());
+        userEntity.setSecondFactor(SecondFactorMethod.SMS);
         userEntity.setLoginCounter(0);
         userEntity.setFeatures(createUserRequest.getFeatures());
         userEntity.setDisabled(Boolean.FALSE);
@@ -228,7 +272,8 @@ public class UserEntity extends AbstractEntity {
             serviceRoles = this.servicesRoles.stream().map(serviceRoleEntity -> serviceRoleEntity.toServiceRole()).collect(toList());
         }
 
-        User user = User.from(getId(), externalId, username, password, email, gatewayAccountIds, services, otpKey, telephoneNumber, serviceRoles, features);
+        User user = User.from(getId(), externalId, username, password, email, gatewayAccountIds, services, otpKey, telephoneNumber,
+                serviceRoles, features, secondFactor, provisionalOtpKey, provisionalOtpKeyCreatedAt);
         user.setLoginCounter(loginCounter);
         user.setDisabled(disabled);
         user.setSessionVersion(sessionVersion);

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
@@ -3,6 +3,7 @@ package uk.gov.pay.adminusers.fixtures;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import uk.gov.pay.adminusers.model.Role;
+import uk.gov.pay.adminusers.model.SecondFactorMethod;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.ServiceRole;
 import uk.gov.pay.adminusers.model.User;
@@ -39,7 +40,8 @@ public class UserDbFixture {
     public User insertUser() {
         List<Service> services = serviceRolePairs.stream().map(servicePair -> servicePair.getLeft()).collect(Collectors.toList());
         List<ServiceRole> serviceRoles = serviceRolePairs.stream().map(servicePair -> ServiceRole.from(servicePair.getLeft(), servicePair.getRight())).collect(Collectors.toList());
-        User user = User.from(randomInt(), externalId, username, password, email, gatewayAccountIds, services, otpKey, telephoneNumber, serviceRoles, features);
+        User user = User.from(randomInt(), externalId, username, password, email, gatewayAccountIds, services, otpKey, telephoneNumber,
+                serviceRoles, features, SecondFactorMethod.SMS, null, null);
 
         databaseTestHelper.add(user);
         serviceRoles.forEach(serviceRole -> databaseTestHelper.addUserServiceRole(user.getId(), serviceRole.getService().getId(), serviceRole.getRole().getId()));

--- a/src/test/java/uk/gov/pay/adminusers/model/UserEntityTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/UserEntityTest.java
@@ -37,6 +37,7 @@ public class UserEntityTest {
         assertEquals(createUserRequest.getOtpKey(), userEntity.getOtpKey());
         assertEquals(createUserRequest.getTelephoneNumber(), userEntity.getTelephoneNumber());
         assertEquals(createUserRequest.getEmail(), userEntity.getEmail());
+        assertEquals(SecondFactorMethod.SMS, userEntity.getSecondFactor());
         assertThat(userEntity.getCreatedAt(), is(notNullValue()));
         assertThat(userEntity.getUpdatedAt(), is(notNullValue()));
         // Since role and gatewayAccountId will be set up after won't be unit-testing from JSON to entity.

--- a/src/test/java/uk/gov/pay/adminusers/model/UserTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/UserTest.java
@@ -18,8 +18,10 @@ public class UserTest {
     @Test
     public void shouldFlatten_permissionsOfAUser() throws Exception {
         Service service = Service.from(1, "3487347gb67", Service.DEFAULT_NAME_VALUE);
-        User user = User.from(randomInt(), randomUuid(), "name", "password", "email@example.com", asList("1"), asList(service), "ewrew", "453453",
-                asList(ServiceRole.from(service, role(ADMIN.getId(), "Admin", "Administrator"))), null);
+        User user = User.from(randomInt(), randomUuid(), "name", "password", "email@example.com", asList("1"),
+                asList(service), "ewrew", "453453",
+                asList(ServiceRole.from(service, role(ADMIN.getId(), "Admin", "Administrator"))), null,
+                SecondFactorMethod.SMS, null, null);
         Role role1 = Role.role(1, "role1", "role1 description");
         Role role2 = Role.role(2, "role2", "role2 description");
         role1.setPermissions(ImmutableList.of(aPermission(), aPermission(), aPermission()));

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoTest.java
@@ -4,6 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.adminusers.app.util.RandomIdGenerator;
 import uk.gov.pay.adminusers.model.Role;
+import uk.gov.pay.adminusers.model.SecondFactorMethod;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
@@ -65,6 +66,7 @@ public class UserDaoTest extends DaoTestBase {
         userEntity.setEmail(username + "@example.com");
         userEntity.setOtpKey(randomInt().toString());
         userEntity.setTelephoneNumber("876284762");
+        userEntity.setSecondFactor(SecondFactorMethod.SMS);
         userEntity.setSessionVersion(0);
         ZonedDateTime timeNow = ZonedDateTime.now(ZoneId.of("UTC"));
         userEntity.setCreatedAt(timeNow);

--- a/src/test/java/uk/gov/pay/adminusers/persistence/entity/SecondFactorMethodConverterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/entity/SecondFactorMethodConverterTest.java
@@ -1,0 +1,43 @@
+package uk.gov.pay.adminusers.persistence.entity;
+
+import org.junit.Test;
+import uk.gov.pay.adminusers.model.SecondFactorMethod;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class SecondFactorMethodConverterTest {
+
+    private final SecondFactorMethodConverter secondFactorMethodConverter = new SecondFactorMethodConverter();
+
+    @Test
+    public void smsEnumVariantConvertToDatabaseColumnReturnsSmsString() {
+        String databaseColumnValue = secondFactorMethodConverter.convertToDatabaseColumn(SecondFactorMethod.SMS);
+        assertThat(databaseColumnValue, is("sms"));
+    }
+
+    @Test
+    public void appEnumVariantConvertToDatabaseColumnReturnsAppString() {
+        String databaseColumnValue = secondFactorMethodConverter.convertToDatabaseColumn(SecondFactorMethod.APP);
+        assertThat(databaseColumnValue, is("app"));
+    }
+
+    @Test
+    public void smsStringConvertToEntityAttributeReturnsSmsEnumVariant() {
+        SecondFactorMethod entityAttribute = secondFactorMethodConverter.convertToEntityAttribute("sms");
+        assertThat(entityAttribute, is(SecondFactorMethod.SMS));
+    }
+
+    @Test
+    public void appStringConvertToEntityAttributeReturnsAppEnumVariant() {
+        SecondFactorMethod entityAttribute = secondFactorMethodConverter.convertToEntityAttribute("app");
+        assertThat(entityAttribute, is(SecondFactorMethod.APP));
+    }
+
+    @Test
+    public void unhandledStringConvertToEntityAttributeReturnsSmsEnumVariant() {
+        SecondFactorMethod entityAttribute = secondFactorMethodConverter.convertToEntityAttribute("Someone went wild in the DB!");
+        assertThat(entityAttribute, is(SecondFactorMethod.SMS));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/adminusers/service/LinksBuilderTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/LinksBuilderTest.java
@@ -2,7 +2,12 @@ package uk.gov.pay.adminusers.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
-import uk.gov.pay.adminusers.model.*;
+import uk.gov.pay.adminusers.model.ForgottenPassword;
+import uk.gov.pay.adminusers.model.Role;
+import uk.gov.pay.adminusers.model.SecondFactorMethod;
+import uk.gov.pay.adminusers.model.Service;
+import uk.gov.pay.adminusers.model.ServiceRole;
+import uk.gov.pay.adminusers.model.User;
 
 import java.time.ZonedDateTime;
 
@@ -21,7 +26,8 @@ public class LinksBuilderTest {
         Service service = Service.from(2, "34783g87ebg764r", Service.DEFAULT_NAME_VALUE);
         Role role = Role.role(2, "blah", "blah");
         User user = User.from(randomInt(), randomUuid(), "a-username", "a-password", "email@example.com",
-                asList("1"), asList(service), "4wrwef", "123435", asList(ServiceRole.from(service, role)), null);
+                asList("1"), asList(service), "4wrwef", "123435", asList(ServiceRole.from(service, role)),
+                null, SecondFactorMethod.SMS, null, null);
         User decoratedUser = linksBuilder.decorate(user);
 
         String linkJson = new ObjectMapper().writeValueAsString(decoratedUser.getLinks().get(0));

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceRoleCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceRoleCreatorTest.java
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.pay.adminusers.model.Role;
+import uk.gov.pay.adminusers.model.SecondFactorMethod;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.persistence.dao.RoleDao;
@@ -129,6 +130,8 @@ public class ServiceRoleCreatorTest {
     }
 
     private User aUser(String externalId) {
-        return User.from(randomInt(), externalId, "random-name", "random-password", "random@example.com", asList("1"), newArrayList(), "784rh", "8948924", newArrayList(), null);
+        return User.from(randomInt(), externalId, "random-name", "random-password", "random@example.com",
+                asList("1"), newArrayList(), "784rh", "8948924", newArrayList(), null,
+                SecondFactorMethod.SMS, null, null);
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceRoleUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceRoleUpdaterTest.java
@@ -8,6 +8,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.pay.adminusers.model.Role;
+import uk.gov.pay.adminusers.model.SecondFactorMethod;
 import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.persistence.dao.RoleDao;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
@@ -161,6 +162,8 @@ public class ServiceRoleUpdaterTest {
     }
 
     private User aUser(String externalId) {
-        return User.from(randomInt(), externalId, "random-name", "random-password", "random@example.com", asList("1"), newArrayList(), "784rh", "8948924", newArrayList(), null);
+        return User.from(randomInt(), externalId, "random-name", "random-password", "random@example.com",
+                asList("1"), newArrayList(), "784rh", "8948924", newArrayList(), null,
+                SecondFactorMethod.SMS, null, null);
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/service/UserCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserCreatorTest.java
@@ -9,6 +9,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.pay.adminusers.model.CreateUserRequest;
+import uk.gov.pay.adminusers.model.SecondFactorMethod;
 import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.persistence.dao.RoleDao;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
@@ -23,7 +24,9 @@ import java.util.Optional;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 @RunWith(MockitoJUnitRunner.class)
@@ -60,6 +63,7 @@ public class UserCreatorTest {
         verify(mockUserDao).persist(expectedUser.capture());
         assertThat(expectedUser.getValue().getEmail(), is("email@example.com"));
         assertThat(user.getEmail(), is("email@example.com"));
+        assertThat(user.getSecondFactor(), is(SecondFactorMethod.SMS));
         assertThat(user.getServiceRoles().size(), is(0));
     }
 
@@ -75,6 +79,7 @@ public class UserCreatorTest {
         verify(mockUserDao).persist(expectedUser.capture());
         assertThat(expectedUser.getValue().getEmail(), is("email@example.com"));
         assertThat(user.getEmail(), is("email@example.com"));
+        assertThat(user.getSecondFactor(), is(SecondFactorMethod.SMS));
         assertThat(user.getServiceRoles().size(), is(2));
     }
 
@@ -90,6 +95,7 @@ public class UserCreatorTest {
         verify(mockUserDao).persist(expectedUser.capture());
         assertThat(expectedUser.getValue().getEmail(), is("email@example.com"));
         assertThat(user.getEmail(), is("email@example.com"));
+        assertThat(user.getSecondFactor(), is(SecondFactorMethod.SMS));
         assertThat(user.getServiceRoles().size(), is(1));
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/service/UserInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserInviteCompleterTest.java
@@ -8,10 +8,19 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import uk.gov.pay.adminusers.model.*;
+import uk.gov.pay.adminusers.model.InviteCompleteResponse;
+import uk.gov.pay.adminusers.model.InviteType;
+import uk.gov.pay.adminusers.model.SecondFactorMethod;
+import uk.gov.pay.adminusers.model.Service;
+import uk.gov.pay.adminusers.model.ServiceRole;
+import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
-import uk.gov.pay.adminusers.persistence.entity.*;
+import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
+import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
+import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
+import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
+import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 
 import javax.ws.rs.WebApplicationException;
 import java.time.ZonedDateTime;
@@ -188,6 +197,7 @@ public class UserInviteCompleterTest {
     private User aUser(String email) {
         Service service = Service.from(serviceId, serviceExternalId, Service.DEFAULT_NAME_VALUE);
         return User.from(randomInt(), randomUuid(), "a-username", "random-password", email, asList("1"), asList(service), "784rh", "8948924",
-                asList(ServiceRole.from(service, role(ADMIN.getId(), "Admin", "Administrator"))), null);
+                asList(ServiceRole.from(service, role(ADMIN.getId(), "Admin", "Administrator"))), null,
+                SecondFactorMethod.SMS, null, null);
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
@@ -10,12 +10,21 @@ import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import uk.gov.pay.adminusers.app.config.AdminUsersConfig;
 import uk.gov.pay.adminusers.app.config.LinksConfig;
-import uk.gov.pay.adminusers.model.*;
+import uk.gov.pay.adminusers.model.Invite;
+import uk.gov.pay.adminusers.model.InviteUserRequest;
+import uk.gov.pay.adminusers.model.SecondFactorMethod;
+import uk.gov.pay.adminusers.model.Service;
+import uk.gov.pay.adminusers.model.ServiceRole;
+import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.dao.RoleDao;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
-import uk.gov.pay.adminusers.persistence.entity.*;
+import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
+import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
+import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
+import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
+import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 
 import javax.ws.rs.WebApplicationException;
 import java.time.ZonedDateTime;
@@ -31,7 +40,10 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.matches;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.model.InviteRequest.FIELD_EMAIL;
@@ -355,7 +367,8 @@ public class UserInviteCreatorTest {
     private User aUser(String email) {
         Service service = Service.from(serviceId, serviceExternalId, Service.DEFAULT_NAME_VALUE);
         return User.from(randomInt(), randomUuid(), "a-username", "random-password", email, asList("1"),
-                asList(service), "784rh", "8948924", asList(ServiceRole.from(service, role(ADMIN.getId(), "Admin", "Administrator"))), null);
+                asList(service), "784rh", "8948924", asList(ServiceRole.from(service, role(ADMIN.getId(),
+                        "Admin", "Administrator"))), null, SecondFactorMethod.SMS, null, null);
     }
 
 }

--- a/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
@@ -11,7 +11,12 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import uk.gov.pay.adminusers.model.*;
+import uk.gov.pay.adminusers.model.PatchRequest;
+import uk.gov.pay.adminusers.model.Permission;
+import uk.gov.pay.adminusers.model.Role;
+import uk.gov.pay.adminusers.model.SecondFactorMethod;
+import uk.gov.pay.adminusers.model.SecondFactorToken;
+import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
 import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
@@ -32,7 +37,11 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.model.Permission.permission;
@@ -450,10 +459,14 @@ public class UserServicesTest {
     }
 
     private User aUser() {
-        return User.from(randomInt(), USER_EXTERNAL_ID, USER_USERNAME, "random-password", "email@example.com", asList("1"), newArrayList(), "784rh", "8948924", newArrayList(), null);
+        return User.from(randomInt(), USER_EXTERNAL_ID, USER_USERNAME, "random-password", "email@example.com", asList("1"),
+                newArrayList(), "784rh", "8948924", newArrayList(), null, SecondFactorMethod.SMS,
+                null, null);
     }
     private User anotherUser() {
-        return User.from(randomInt(), ANOTHER_USER_EXTERNAL_ID, ANOTHER_USER_USERNAME, "random-password", "email@example.com", asList("1"), newArrayList(), "784rh", "8948924", newArrayList(), null);
+        return User.from(randomInt(), ANOTHER_USER_EXTERNAL_ID, ANOTHER_USER_USERNAME, "random-password",
+                "email@example.com", asList("1"), newArrayList(), "784rh", "8948924", newArrayList(),
+                null, SecondFactorMethod.SMS, null, null);
     }
 
     private Role aRole() {

--- a/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
@@ -101,8 +101,11 @@ public class DatabaseTestHelper {
         jdbi.withHandle(handle ->
                 handle
                         .createStatement("INSERT INTO users(" +
-                                "id, external_id, username, password, email, otp_key, telephone_number, disabled, login_counter, version, \"createdAt\", \"updatedAt\", session_version) " +
-                                "VALUES (:id, :externalId, :username, :password, :email, :otpKey, :telephoneNumber, :disabled, :loginCounter, :version, :createdAt, :updatedAt, :session_version)")
+                                "id, external_id, username, password, email, otp_key, telephone_number, " +
+                                    "second_factor, disabled, login_counter, version, " +
+                                    "\"createdAt\", \"updatedAt\", session_version) " +
+                                "VALUES (:id, :externalId, :username, :password, :email, :otpKey, :telephoneNumber, " +
+                                    ":secondFactor, :disabled, :loginCounter, :version, :createdAt, :updatedAt, :session_version)")
                         .bind("id", user.getId())
                         .bind("externalId", user.getExternalId())
                         .bind("username", user.getUsername())
@@ -110,6 +113,7 @@ public class DatabaseTestHelper {
                         .bind("email", user.getEmail())
                         .bind("otpKey", user.getOtpKey())
                         .bind("telephoneNumber", user.getTelephoneNumber())
+                        .bind("secondFactor", user.getSecondFactor().toString())
                         .bind("disabled", user.isDisabled())
                         .bind("loginCounter", user.getLoginCounter())
                         .bind("version", 0)


### PR DESCRIPTION
Add properties for second factor, provisional OTP key and provisional OTP key created at timestamp, to match the new database columns in the users table.

When creating a new user, default the second factor to be SMS and have the other two properties be null.