### PR TITLE
PP-3576 Add endpoint for creating provisional OTP key

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The GOV.UK Pay Admin Users Module in Java (Dropwizard)
 | [```/v1/api/users/{externalId}```](/docs/api_specification.md#patch-v1apiusersexternalid)              | PATCH    |  amend a specific user attribute            |
 | [```/v1/api/users/{externalId}/services/{serviceId}```](/docs/api_specification.md#put-v1apiusersexternalidservicesserviceid)  | PUT    |  update user's role for a service            |
 | [```/v1/api/users/{externalId}/services```](/docs/api_specification.md#post-v1apiusersexternalidservicesserviceid)  | POST    |  assign a new service along with role to a user        |
+| [```/v1/api/users/{externalId}/second-factor/provision```](/docs/api_specification.md#post-v1apiusersexternalidsecondfactorprovision)  | POST    | Create a new provisional OTP key for a user |
 | [```/v1/api/users/authenticate```](/docs/api_specification.md#post-v1apiusersauthenticate)              | POST    |  Authenticate a given username/password            |
 | [```/v1/api/forgotten-passwords```](/docs/api_specification.md#post-v1apiforgottenpasswords)              | POST    |  Create a new forgotten password request            |
 | [```/v1/api/forgotten-passwords/{code}```](/docs/api_specification.md#get-v1apiforgottenpasswordscode)              | GET    |  GETs a forgotten password record by code            |

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -595,6 +595,43 @@ Content-Type: application/json
 }
 ```
 
+## POST /v1/api/users/`{externalId}`/second-factor/provision
+
+This endpoint provisions a new second-factor OTP key (secret used to generate OTP codes) for a user.
+
+Provisioning a new key does not change immediately change the user’s current key. Use the [```/v1/api/users/second-factor/configure```](#post-v1apiusersexternalidsecondfactorconfigure) endpoint to replace the user’s current key with the newly-provisioned one.
+
+### Request example
+
+```
+POST /v1/api/users/7d19aff33f8948deb97ed16b2912dcd3/second-factor/provision
+```
+
+### Response example
+
+```
+200 OK
+Content-Type: application/json
+{
+    "external_id": "7d19aff33f8948deb97ed16b2912dcd3",
+    "username": "abcd1234",
+    "email": "email@example.com",
+    "gateway_account_ids": ["1"],
+    "telephone_number": "447700900000",
+    "otp_key": "43c3c4t",
+    "sessionVersion": 2,
+    "role": {"admin","Administrator"},
+    "permissions":["perm-1","perm-2","perm-3"],
+    "provisional_otp_key": "5h8oe39",
+    "provisional_otp_key_created_at": "2018-04-03T17:52:03.123Z",
+    "_links": [{
+        "href": "http://adminusers.service/v1/api/users/7d19aff33f8948deb97ed16b2912dcd3",
+        "rel" : "self",
+        "method" : "GET"
+    }]
+}
+```
+
 -----------------------------------------------------------------------------------------------------------
 
 ## POST /v1/api/invites/service

--- a/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
@@ -14,16 +14,26 @@ import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.service.UserServices;
 import uk.gov.pay.adminusers.service.UserServicesFactory;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.Response.Status.*;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
+import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static uk.gov.pay.adminusers.model.User.FIELD_USERNAME;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.conflictingUsername;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.internalServerError;
@@ -40,6 +50,7 @@ public class UserResource {
     private static final String USER_RESOURCE = USERS_RESOURCE + "/{externalId}";
     private static final String SECOND_FACTOR_RESOURCE = USER_RESOURCE + "/second-factor";
     private static final String SECOND_FACTOR_AUTHENTICATE_RESOURCE = SECOND_FACTOR_RESOURCE + "/authenticate";
+    private static final String SECOND_FACTOR_PROVISION_RESOURCE = SECOND_FACTOR_RESOURCE + "/provision";
     private static final String USER_SERVICES_RESOURCE = USER_RESOURCE + "/services";
     private static final String USER_SERVICE_RESOURCE = USER_SERVICES_RESOURCE + "/{serviceExternalId}";
     private static final Splitter COMMA_SEPARATOR = Splitter.on(',').trimResults();
@@ -168,6 +179,17 @@ public class UserResource {
                         .map(user -> Response.status(OK).type(APPLICATION_JSON).entity(user).build())
                         .orElseGet(() -> Response.status(UNAUTHORIZED).build()));
 
+    }
+
+    @Path(SECOND_FACTOR_PROVISION_RESOURCE)
+    @POST
+    @Produces(APPLICATION_JSON)
+    @Consumes(APPLICATION_JSON)
+    public Response newSecondFactorOtpKey(@PathParam("externalId") String externalId) {
+        logger.info("User 2FA provision new OTP key request");
+        return userServices.provisionNewOtpKey(externalId)
+                .map(user -> Response.status(OK).type(APPLICATION_JSON).entity(user).build())
+                .orElseGet(() -> Response.status(NOT_FOUND).build());
     }
 
     @PATCH

--- a/src/main/java/uk/gov/pay/adminusers/service/SecondFactorAuthenticator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/SecondFactorAuthenticator.java
@@ -6,15 +6,19 @@ import com.warrenstrange.googleauth.GoogleAuthenticatorConfig;
 import org.slf4j.Logger;
 import uk.gov.pay.adminusers.logger.PayLoggerFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Clock;
+import java.util.regex.Pattern;
 
 import static com.google.common.io.BaseEncoding.base32;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
-
 public class SecondFactorAuthenticator {
 
     private static final Logger logger = PayLoggerFactory.getLogger(SecondFactorAuthenticator.class);
+
+    private static final Pattern BASE32_ALPHABET = Pattern.compile("[A-Z2-7]+");
+
     private final GoogleAuthenticator authenticator;
     private final Clock clock;
 
@@ -26,12 +30,25 @@ public class SecondFactorAuthenticator {
 
     public int newPassCode(String secret) {
         checkNull(secret);
-        return authenticator.getTotpPassword(base32().encode(secret.getBytes()), clock.millis());
+        String base32EncodedSecret = BASE32_ALPHABET.matcher(secret).matches() ? secret : base32EncodedUtf8BytesOfSecret(secret);
+        return authenticator.getTotpPassword(base32EncodedSecret, clock.millis());
     }
 
     public boolean authorize(String secret, int passcode) {
         checkNull(secret);
-        return authenticator.authorize(base32().encode(secret.getBytes()), passcode, clock.millis());
+        String base32EncodedSecret = BASE32_ALPHABET.matcher(secret).matches() ? secret : base32EncodedUtf8BytesOfSecret(secret);
+        return authenticator.authorize(base32EncodedSecret, passcode, clock.millis());
+    }
+
+    public String generateNewBase32EncodedSecret() {
+        return authenticator.createCredentials().getKey();
+    }
+
+    private String base32EncodedUtf8BytesOfSecret(String secret) {
+        // This seems to be to match the recommendations of notp, a
+        // Node.js package we used to use to do OTP in self-service
+        // https://github.com/guyht/notp/blob/master/Readme.md#google-authenticator
+        return base32().encode(secret.getBytes(StandardCharsets.UTF_8));
     }
 
     private void checkNull(String secret) {

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceSecondFactorProvisioningTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceSecondFactorProvisioningTest.java
@@ -1,0 +1,53 @@
+package uk.gov.pay.adminusers.resources;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.adminusers.model.User;
+
+import static java.lang.String.format;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
+import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
+
+public class UserResourceSecondFactorProvisioningTest extends IntegrationTest {
+
+    private static final String USER_2FA_PROVISION_URL = USER_2FA_URL + "/provision";
+    private static final String ORIGINAL_OTP_KEY = "1111111111111111";
+
+    private String externalId;
+    private String username;
+
+    @Before
+    public void createValidUser() {
+        String username = randomUuid();
+        String email = username + "@example.com";
+        User user = userDbFixture(databaseHelper).withOtpKey(ORIGINAL_OTP_KEY).withUsername(username).withEmail(email).insertUser();
+
+        this.externalId = user.getExternalId();
+        this.username = user.getUsername();
+    }
+
+    @Test
+    public void shouldProvisionNewOtpKey() {
+        givenSetup()
+                .when()
+                .post(format(USER_2FA_PROVISION_URL, externalId))
+                .then()
+                .statusCode(200)
+                .body("username", is(username))
+                .body("otp_key", is(ORIGINAL_OTP_KEY))
+                .body("provisional_otp_key", is(notNullValue()))
+                .body("provisional_otp_key_created_at", is(notNullValue()));
+    }
+
+    @Test
+    public void shouldReturnNotFoundIfUserNotFoundWhenProvisionNewOtpKey() {
+        givenSetup()
+                .when()
+                .post(format(USER_2FA_PROVISION_URL, "this is not a valid user external ID"))
+                .then()
+                .statusCode(404);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/adminusers/service/SecondFactorAuthenticatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/SecondFactorAuthenticatorTest.java
@@ -1,84 +1,140 @@
 package uk.gov.pay.adminusers.service;
 
+import com.google.inject.persist.Transactional;
 import com.warrenstrange.googleauth.GoogleAuthenticatorConfig;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class SecondFactorAuthenticatorTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
     private static final String SECRET = "mysecret";
-    private static final Instant INITIAL_TIME = Instant.now();
+    private static final String BASE32_ENCODED_SECRET = "KPWXGUTNWOE7PMVK";
+
     private static final Duration TIME_STEP = Duration.of(30, SECONDS);
+
     private static final int PAST_OR_FUTURE_WINDOWS_TO_CHECK = 4;
     private static final int PAST_PRESENT_AND_FUTURE_WINDOWS_TO_CHECK = PAST_OR_FUTURE_WINDOWS_TO_CHECK * 2 + 1;
-    private static final GoogleAuthenticatorConfig authConfig = new GoogleAuthenticatorConfig.GoogleAuthenticatorConfigBuilder()
+
+    private static final GoogleAuthenticatorConfig AUTH_CONFIG = new GoogleAuthenticatorConfig.GoogleAuthenticatorConfigBuilder()
             .setWindowSize(PAST_PRESENT_AND_FUTURE_WINDOWS_TO_CHECK)
             .setTimeStepSizeInMillis(TIME_STEP.toMillis())
             .build();
 
-
-
-    private Integer passcode;
-    private SecondFactorAuthenticator secondFactorAuthenticator;
+    @Mock
     private Clock clock;
 
+    private Instant initialTime;
+
+    private SecondFactorAuthenticator secondFactorAuthenticator;
 
     @Before
-    public void before() throws Exception {
-        clock = mock(Clock.class);
-        when(clock.millis()).thenReturn(INITIAL_TIME.toEpochMilli());
-        secondFactorAuthenticator = new SecondFactorAuthenticator(authConfig, clock);
-        passcode = secondFactorAuthenticator.newPassCode(SECRET);
-        
+    public void before() {
+        initialTime = Instant.now();
+        when(clock.millis()).thenReturn(initialTime.toEpochMilli());
+        secondFactorAuthenticator = new SecondFactorAuthenticator(AUTH_CONFIG, clock);
     }
 
     @Test
-    public void shouldGenerateAndValidate2FAPasscode() throws Exception {
-        assertTrue(secondFactorAuthenticator.authorize(SECRET, passcode));
-        assertFalse(secondFactorAuthenticator.authorize("incorrectSecret", passcode));
+    public void shouldGenerateAndValidate2FAPasscode() {
+        int passCode = secondFactorAuthenticator.newPassCode(SECRET);
+
+        assertTrue(secondFactorAuthenticator.authorize(SECRET, passCode));
+        assertFalse(secondFactorAuthenticator.authorize("incorrectSecret", passCode));
     }
 
     @Test
-    public void shouldSuccess_ifAskedToValidateImmediateLastSteps2FAPasscode() throws Exception {
-        when(clock.millis()).thenReturn(INITIAL_TIME.plus(TIME_STEP).toEpochMilli());
+    public void shouldGenerateAndValidate2FAPasscodeFromBase32EncodedSecret() {
+        int passCode = secondFactorAuthenticator.newPassCode(BASE32_ENCODED_SECRET);
 
-        assertTrue(secondFactorAuthenticator.authorize(SECRET, passcode));
+        assertTrue(secondFactorAuthenticator.authorize(BASE32_ENCODED_SECRET, passCode));
     }
 
     @Test
-    public void shouldSuccess_ifAskedToValidateAValidPastSteps2FAPasscode() throws Exception {
-        when(clock.millis()).thenReturn(INITIAL_TIME.plus(TIME_STEP.multipliedBy(PAST_OR_FUTURE_WINDOWS_TO_CHECK)).toEpochMilli());
+    public void shouldSuccess_ifAskedToValidateImmediateLastSteps2FAPasscode() {
+        int passCode = secondFactorAuthenticator.newPassCode(SECRET);
 
-        assertTrue(secondFactorAuthenticator.authorize(SECRET, passcode));
+        when(clock.millis()).thenReturn(initialTime.plus(TIME_STEP).toEpochMilli());
+
+        assertTrue(secondFactorAuthenticator.authorize(SECRET, passCode));
     }
 
     @Test
-    public void shouldError_ifAskedToValidate2FAPasscodeOlderThanLastValidStep() throws Exception {
-        when(clock.millis()).thenReturn(INITIAL_TIME.plus(TIME_STEP.multipliedBy(PAST_OR_FUTURE_WINDOWS_TO_CHECK + 1)).toEpochMilli());
+    public void shouldSuccess_ifAskedToValidateImmediateLastSteps2FAPasscode_fromBase32EncodedSecret() {
+        int passCode = secondFactorAuthenticator.newPassCode(BASE32_ENCODED_SECRET);
 
-        assertFalse(secondFactorAuthenticator.authorize(SECRET, passcode));
+        when(clock.millis()).thenReturn(initialTime.plus(TIME_STEP).toEpochMilli());
+
+        assertTrue(secondFactorAuthenticator.authorize(BASE32_ENCODED_SECRET, passCode));
     }
 
     @Test
-    public void shouldError_IfPasscodeIsNull_WhenCreate() throws Exception {
+    public void shouldSuccess_ifAskedToValidateAValidPastSteps2FAPasscode() {
+        int passCode = secondFactorAuthenticator.newPassCode(SECRET);
+
+        when(clock.millis()).thenReturn(initialTime.plus(TIME_STEP.multipliedBy(PAST_OR_FUTURE_WINDOWS_TO_CHECK)).toEpochMilli());
+
+        assertTrue(secondFactorAuthenticator.authorize(SECRET, passCode));
+    }
+
+    @Test
+    public void shouldSuccess_ifAskedToValidateAValidPastSteps2FAPasscode_fromBase32EncodedSecret() {
+        int passCode = secondFactorAuthenticator.newPassCode(BASE32_ENCODED_SECRET);
+
+        when(clock.millis()).thenReturn(initialTime.plus(TIME_STEP.multipliedBy(PAST_OR_FUTURE_WINDOWS_TO_CHECK)).toEpochMilli());
+
+        assertTrue(secondFactorAuthenticator.authorize(BASE32_ENCODED_SECRET, passCode));
+    }
+
+    @Test
+    public void shouldError_ifAskedToValidate2FAPasscodeOlderThanLastValidStep() {
+        int passCode = secondFactorAuthenticator.newPassCode(SECRET);
+
+        when(clock.millis()).thenReturn(initialTime.plus(TIME_STEP.multipliedBy(PAST_OR_FUTURE_WINDOWS_TO_CHECK + 1)).toEpochMilli());
+
+        assertFalse(secondFactorAuthenticator.authorize(SECRET, passCode));
+    }
+
+    @Test
+    public void shouldError_ifAskedToValidate2FAPasscodeOlderThanLastValidStep_fromBase32EncodedSecret() {
+        int passCode = secondFactorAuthenticator.newPassCode(BASE32_ENCODED_SECRET);
+
+        when(clock.millis()).thenReturn(initialTime.plus(TIME_STEP.multipliedBy(PAST_OR_FUTURE_WINDOWS_TO_CHECK + 1)).toEpochMilli());
+
+        assertFalse(secondFactorAuthenticator.authorize(BASE32_ENCODED_SECRET, passCode));
+    }
+
+    @Test
+    public void shouldError_IfPasscodeIsNull_WhenCreate() {
         thrown.expect(RuntimeException.class);
         thrown.expectMessage("supplied a null/empty otpKey for second factor");
 
         secondFactorAuthenticator.newPassCode(null);
     }
+
+    @Test
+    public void shouldGenerateNewBase32EncodedSecret() {
+        String sixteenCharacterBase32Regex = "[A-Z2-7]{16}";
+        assertThat(secondFactorAuthenticator.generateNewBase32EncodedSecret(), matchesPattern(sixteenCharacterBase32Regex));
+    }
+
 }


### PR DESCRIPTION
Add endpoint to add a provisional Base32 OTP key to a user. This will be part one of the process for configuring a user to use a 2FA authenticator app instead of text message codes for signing in. Part two will confirm the user has set up the app correctly and will permanently change the key.

Currently, when we need to generate an OTP key (i.e. what’s stored alongside each user in the database), we use one of the methods in `RandomIdGenerator` (we’re not consistent: we use different methods for direct new user creation versus invitations) to get a string.

However, the GoogleAuth library we use requires input secrets to be Base32-encoded. To meet this requirement, we currently (unconditionally) convert the string by taking its UTF-8 bytes and then Base32-encoding them. This somewhat bizarre behaviour appears to be used in order to match the behaviour of notp, a Node.js package we used to use when we did OTP in self-service[1].

It would be more straightforward to just generate an OTP key that’s already Base32-encoded. This commit adds such a method (not used anywhere yet), deferring to the GoogleAuth library, which has built-in functionality to do this (it’s unclear why we weren’t using it before). When creating a new provisional OTP key, we use this functionality (but we keep key generation for new users and invitations the same for now in order to avoid compatibility issues and ripple effects).

In addition, this commit makes it so that OTP code generation and authorisation skips the somewhat bizarre encoding step if it detects the key is already Base32-encoded (this changes the codes generated and considered valid for some keys but since we currently generate all codes ourselves, this is safe — except for period of a few minutes during deployment where if we’re really unlucky a subset of users may be unable to log in).

The ready Base32-encoded strings produced by the GoogleAuth library use 80 bits of randomness to produce a sixteen-character string. This is shorter and with less randomness than some of the methods in the `RandomIdGenerator` class but it’s still quite a lot and most OTP secrets issued by major sites seem to be sixteen characters long (in Base32 form), so we’ll be in good company.

The motivation for doing this now is that supporting 2FA apps will involve distributing OTP secrets outside of our systems (thus making it incredibly difficult to change them subsequently). If we did not do this, we would have to replicate the somewhat bizarre encoding step in self-service when we generate QR codes, and if we present the secret for manual entry, it would be too long (whereas sixteen characters is just about manageable).

[1] https://github.com/guyht/notp/blob/master/Readme.md#google-authenticator