### PR TITLE
PP-3576 Add endpoint for activating provisional OTP key

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The GOV.UK Pay Admin Users Module in Java (Dropwizard)
 | [```/v1/api/users/{externalId}/services/{serviceId}```](/docs/api_specification.md#put-v1apiusersexternalidservicesserviceid)  | PUT    |  update user's role for a service            |
 | [```/v1/api/users/{externalId}/services```](/docs/api_specification.md#post-v1apiusersexternalidservicesserviceid)  | POST    |  assign a new service along with role to a user        |
 | [```/v1/api/users/{externalId}/second-factor/provision```](/docs/api_specification.md#post-v1apiusersexternalidsecondfactorprovision)  | POST    | Create a new provisional OTP key for a user |
+| [```/v1/api/users/{externalId}/second-factor/activate```](/docs/api_specification.md#post-v1apiusersexternalidsecondfactoractivate)  | POST    | Activate a new OTP key and method for a user |
 | [```/v1/api/users/authenticate```](/docs/api_specification.md#post-v1apiusersauthenticate)              | POST    |  Authenticate a given username/password            |
 | [```/v1/api/forgotten-passwords```](/docs/api_specification.md#post-v1apiforgottenpasswords)              | POST    |  Create a new forgotten password request            |
 | [```/v1/api/forgotten-passwords/{code}```](/docs/api_specification.md#get-v1apiforgottenpasswordscode)              | GET    |  GETs a forgotten password record by code            |

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -599,7 +599,7 @@ Content-Type: application/json
 
 This endpoint provisions a new second-factor OTP key (secret used to generate OTP codes) for a user.
 
-Provisioning a new key does not change immediately change the user’s current key. Use the [```/v1/api/users/second-factor/configure```](#post-v1apiusersexternalidsecondfactorconfigure) endpoint to replace the user’s current key with the newly-provisioned one.
+Provisioning a new key does not change immediately change the user’s current key. Use the [```/v1/api/users/second-factor/activate```](#post-v1apiusersexternalidsecondfactoractivate) endpoint to replace the user’s current key with the newly-provisioned one.
 
 ### Request example
 
@@ -624,6 +624,54 @@ Content-Type: application/json
     "permissions":["perm-1","perm-2","perm-3"],
     "provisional_otp_key": "5h8oe39",
     "provisional_otp_key_created_at": "2018-04-03T17:52:03.123Z",
+    "_links": [{
+        "href": "http://adminusers.service/v1/api/users/7d19aff33f8948deb97ed16b2912dcd3",
+        "rel" : "self",
+        "method" : "GET"
+    }]
+}
+```
+
+## POST /v1/api/users/`{externalId}`/second-factor/activate
+
+This endpoint activates the provisional OTP key for a user and configures their second-factor authentication method.
+
+The user should have already a provisional OTP key created by the [```/v1/api/users/second-factor/provision```](#post-v1apiusersexternalidsecondfactorprovision) endpoint before this endpoint is called.
+
+### Request example
+
+```
+POST /v1/api/users/7d19aff33f8948deb97ed16b2912dcd3/second-factor/activate
+Content-Type: application/json
+{
+    "code": 123456,
+    "second_factor": "APP"
+}
+```
+
+#### Request body description
+
+| Field           | Required | Description                                    | Supported Values |
+| --------------- |:--------:| ---------------------------------------------- |------------------|
+| `code`          |   X      | OTP code valid for the provisional OTP key     |                  |
+| `second_factor` |   X      | the second-factor authentication method to use | `SMS`, `APP`     |
+
+### Response example
+
+```
+200 OK
+Content-Type: application/json
+{
+    "external_id": "7d19aff33f8948deb97ed16b2912dcd3",
+    "username": "abcd1234",
+    "email": "email@example.com",
+    "gateway_account_ids": ["1"],
+    "telephone_number": "447700900000",
+    "otp_key": "5h8oe39",
+    "second_factor": "APP",
+    "sessionVersion": 2,
+    "role": {"admin","Administrator"},
+    "permissions":["perm-1","perm-2","perm-3"],
     "_links": [{
         "href": "http://adminusers.service/v1/api/users/7d19aff33f8948deb97ed16b2912dcd3",
         "rel" : "self",

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserRequestValidatorTest.java
@@ -264,6 +264,60 @@ public class UserRequestValidatorTest {
     }
 
     @Test
+    public void shouldError_ifCodeMissing_whenValidate2faActivateRequest() {
+        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("second_factor", "SMS"));
+
+        Optional<Errors> optionalErrors = validator.validate2faActivateRequest(payload);
+
+        assertTrue(optionalErrors.isPresent());
+        Errors errors = optionalErrors.get();
+
+        assertThat(errors.getErrors().size(), is(1));
+        assertThat(errors.getErrors(), hasItems("Field [code] is required"));
+    }
+
+    @Test
+    public void shouldError_ifCodeNotNumeric_whenValidate2faActivateRequest() {
+        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("code", "I am not a number, I’m a free man!",
+                "second_factor", "SMS"));
+
+        Optional<Errors> optionalErrors = validator.validate2faActivateRequest(payload);
+
+        assertTrue(optionalErrors.isPresent());
+        Errors errors = optionalErrors.get();
+
+        assertThat(errors.getErrors().size(), is(1));
+        assertThat(errors.getErrors(), hasItems("Field [code] must be a number"));
+    }
+
+    @Test
+    public void shouldError_ifSecondFactorMissing_whenValidate2faActivateRequest() {
+        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("code", 123456));
+
+        Optional<Errors> optionalErrors = validator.validate2faActivateRequest(payload);
+
+        assertTrue(optionalErrors.isPresent());
+        Errors errors = optionalErrors.get();
+
+        assertThat(errors.getErrors().size(), is(1));
+        assertThat(errors.getErrors(), hasItems("Field [second_factor] is required"));
+    }
+
+    @Test
+    public void shouldError_ifSecondFactorInvalid_whenValidate2faActivateRequest() {
+        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("code", 123456,
+                "second_factor", "PINKY_SWEAR"));
+
+        Optional<Errors> optionalErrors = validator.validate2faActivateRequest(payload);
+
+        assertTrue(optionalErrors.isPresent());
+        Errors errors = optionalErrors.get();
+
+        assertThat(errors.getErrors().size(), is(1));
+        assertThat(errors.getErrors(), hasItems("Invalid second_factor [PINKY_SWEAR]"));
+    }
+
+    @Test
     public void shouldError_ifRequiredFieldsMissing_whenFindingAUser() throws Exception {
         JsonNode payload = new ObjectMapper().readTree("{}");
         Optional<Errors> optionalErrors = validator.validateFindRequest(payload);

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceSecondFactorProvisioningTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceSecondFactorProvisioningTest.java
@@ -1,10 +1,15 @@
 package uk.gov.pay.adminusers.resources;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.ImmutableMap;
+import com.warrenstrange.googleauth.GoogleAuthenticator;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.User;
 
+import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
@@ -13,6 +18,8 @@ import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
 public class UserResourceSecondFactorProvisioningTest extends IntegrationTest {
 
     private static final String USER_2FA_PROVISION_URL = USER_2FA_URL + "/provision";
+    private static final String USER_2FA_ACTIVATE_URL = USER_2FA_URL + "/activate";
+
     private static final String ORIGINAL_OTP_KEY = "1111111111111111";
 
     private String externalId;
@@ -48,6 +55,80 @@ public class UserResourceSecondFactorProvisioningTest extends IntegrationTest {
                 .post(format(USER_2FA_PROVISION_URL, "this is not a valid user external ID"))
                 .then()
                 .statusCode(404);
+    }
+
+    @Test
+    public void shouldActivateNewOtpKey() throws JsonProcessingException {
+        String newOtpKey = givenSetup()
+                .when()
+                .post(format(USER_2FA_PROVISION_URL, externalId))
+                .then().statusCode(200)
+                .extract()
+                .body()
+                .jsonPath()
+                .get("provisional_otp_key");
+
+        GoogleAuthenticator testAuthenticator = new GoogleAuthenticator();
+        int passCode = testAuthenticator.getTotpPassword(newOtpKey);
+
+        givenSetup()
+                .when()
+                .accept(JSON)
+                .body(mapper.writeValueAsString(ImmutableMap.of("second_factor", "APP", "code", passCode)))
+                .post(format(USER_2FA_ACTIVATE_URL, externalId))
+                .then()
+                .statusCode(200)
+                .body("username", is(username))
+                .body("second_factor", is("APP"))
+                .body("otp_key", is(newOtpKey))
+                .body("provisional_otp_key", is(nullValue()))
+                .body("provisional_otp_key_created_at", is(nullValue()));
+    }
+
+    @Test
+    public void shouldReturnBadRequestIfAttemptToActivateNewOtpKeyWithInvalidRequest() throws JsonProcessingException {
+        String newOtpKey = givenSetup()
+                .when()
+                .post(format(USER_2FA_PROVISION_URL, externalId))
+                .then().statusCode(200)
+                .extract()
+                .body()
+                .jsonPath()
+                .get("provisional_otp_key");
+
+        GoogleAuthenticator testAuthenticator = new GoogleAuthenticator();
+        int passCode = testAuthenticator.getTotpPassword(newOtpKey);
+
+        givenSetup()
+                .when()
+                .accept(JSON)
+                .body(mapper.writeValueAsString(ImmutableMap.of("second_factor", "NOT VALID", "code", passCode)))
+                .post(format(USER_2FA_ACTIVATE_URL, externalId))
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    public void shouldReturnUnauthorizedIfAttemptToActivateNewOtpKeyWithIncorrectCode() throws JsonProcessingException {
+        String newOtpKey = givenSetup()
+                .when()
+                .post(format(USER_2FA_PROVISION_URL, externalId))
+                .then().statusCode(200)
+                .extract()
+                .body()
+                .jsonPath()
+                .get("provisional_otp_key");
+
+        GoogleAuthenticator testAuthenticator = new GoogleAuthenticator();
+        int passCode = testAuthenticator.getTotpPassword(newOtpKey);
+
+        givenSetup()
+                .when()
+                .accept(JSON)
+                .body(mapper.writeValueAsString(ImmutableMap.of("second_factor", "APP", "code", passCode + 1)))
+                .post(format(USER_2FA_ACTIVATE_URL, externalId))
+                .then()
+                .statusCode(401);
     }
 
 }


### PR DESCRIPTION
• Activate previously provisioned OTP key (provisioned by endpoint added in PR #177)
• Ability to specify second factor method (SMS or app)