### PR TITLE
PP-3576 Add ability to send 2FA SMS with security code from provisional OTP key

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
@@ -225,6 +225,8 @@ public class UserEntity extends AbstractEntity {
         userEntity.setOtpKey(user.getOtpKey());
         userEntity.setTelephoneNumber(user.getTelephoneNumber());
         userEntity.setSecondFactor(user.getSecondFactor());
+        userEntity.setProvisionalOtpKey(user.getProvisionalOtpKey());
+        userEntity.setProvisionalOtpKeyCreatedAt(user.getProvisionalOtpKeyCreatedAt());
         userEntity.setLoginCounter(user.getLoginCounter());
         userEntity.setFeatures(user.getFeatures());
         userEntity.setDisabled(user.isDisabled());

--- a/src/main/java/uk/gov/pay/adminusers/resources/UserRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/UserRequestValidator.java
@@ -15,8 +15,15 @@ import java.util.function.Function;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.String.format;
-import static uk.gov.pay.adminusers.model.User.*;
-import static uk.gov.pay.adminusers.validations.UserPatchValidations.*;
+import static uk.gov.pay.adminusers.model.User.FIELD_EMAIL;
+import static uk.gov.pay.adminusers.model.User.FIELD_PASSWORD;
+import static uk.gov.pay.adminusers.model.User.FIELD_ROLE_NAME;
+import static uk.gov.pay.adminusers.model.User.FIELD_SERVICE_EXTERNAL_ID;
+import static uk.gov.pay.adminusers.model.User.FIELD_TELEPHONE_NUMBER;
+import static uk.gov.pay.adminusers.model.User.FIELD_USERNAME;
+import static uk.gov.pay.adminusers.validations.UserPatchValidations.getUserPatchPathValidations;
+import static uk.gov.pay.adminusers.validations.UserPatchValidations.isAllowedOpForPath;
+import static uk.gov.pay.adminusers.validations.UserPatchValidations.isPathAllowed;
 
 public class UserRequestValidator {
 
@@ -44,6 +51,13 @@ public class UserRequestValidator {
         }
         Optional<List<String>> invalidLength = requestValidations.checkMaxLength(payload, MAX_LENGTH_FIELD_USERNAME, FIELD_USERNAME);
         return invalidLength.map(Errors::from);
+    }
+
+    public Optional<Errors> validateNewSecondFactorPasscodeRequest(JsonNode payload) {
+        if (payload != null && payload.get("provisional") != null) {
+            return requestValidations.checkIsBoolean(payload, "provisional").map(Errors::from);
+        }
+        return Optional.empty();
     }
 
     public Optional<Errors> validate2FAAuthRequest(JsonNode payload) {

--- a/src/main/java/uk/gov/pay/adminusers/validations/RequestValidations.java
+++ b/src/main/java/uk/gov/pay/adminusers/validations/RequestValidations.java
@@ -20,6 +20,10 @@ public class RequestValidations {
         return applyCheck(payload, isNotNumeric(), fieldNames, "Field [%s] must be a number");
     }
 
+    public Optional<List<String>> checkIsBoolean(JsonNode payload, String... fieldNames) {
+        return applyCheck(payload, isNotBoolean(), fieldNames, "Field [%s] must be a boolean");
+    }
+
     public Optional<List<String>> checkIfExistsOrEmpty(JsonNode payload, String... fieldNames) {
         return applyCheck(payload, notExistOrEmpty(), fieldNames, "Field [%s] is required");
     }

--- a/src/test/java/uk/gov/pay/adminusers/resources/RequestValidationsTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/RequestValidationsTest.java
@@ -52,4 +52,25 @@ public class RequestValidationsTest {
         assertThat(errors.isPresent(), is(true));
     }
 
+    @Test
+    public void checkNotBoolean_shouldSuccess_whenFieldsAreTrueOrFalse() {
+        ObjectNode payload = JsonNodeFactory.instance.objectNode();
+        payload.put(FIELD_1, "true");
+        payload.put(FIELD_2, "false");
+
+        Optional<List<String>> errors = requestValidations.checkIsBoolean(payload, FIELD_1, FIELD_2);
+
+        assertThat(errors.isPresent(), is(false));
+    }
+
+    @Test
+    public void checkNotBoolean_shouldFail_whenFieldsAreNotTrueOrFalse() {
+        ObjectNode payload = JsonNodeFactory.instance.objectNode();
+        payload.put(FIELD_1, "maybe");
+
+        Optional<List<String>> errors = requestValidations.checkIsBoolean(payload, FIELD_1);
+
+        assertThat(errors.isPresent(), is(true));
+    }
+
 }

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserRequestValidatorTest.java
@@ -11,6 +11,7 @@ import uk.gov.pay.adminusers.utils.Errors;
 import uk.gov.pay.adminusers.validations.RequestValidations;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Optional;
 
 import static junit.framework.TestCase.assertFalse;
@@ -261,6 +262,53 @@ public class UserRequestValidatorTest {
         Optional<Errors> optionalErrors = validator.validateFindRequest(payload);
 
         assertThat(optionalErrors.isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldSuccess_ifNoBody_whenValidateNewSecondFactorPasscodeRequest() {
+        Optional<Errors> optionalErrors = validator.validateNewSecondFactorPasscodeRequest(null);
+
+        assertThat(optionalErrors.isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldSuccess_ifProvisionalNotPresent_whenValidateNewSecondFactorPasscodeRequest() {
+        JsonNode payload = new ObjectMapper().valueToTree(Collections.emptyMap());
+
+        Optional<Errors> optionalErrors = validator.validateNewSecondFactorPasscodeRequest(payload);
+
+        assertThat(optionalErrors.isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldSuccess_ifProvisionalTrue_whenValidateNewSecondFactorPasscodeRequest() {
+        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("provisional", true));
+
+        Optional<Errors> optionalErrors = validator.validateNewSecondFactorPasscodeRequest(payload);
+
+        assertThat(optionalErrors.isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldSuccess_ifProvisionalFalse_whenValidateNewSecondFactorPasscodeRequest() {
+        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("provisional", false));
+
+        Optional<Errors> optionalErrors = validator.validateNewSecondFactorPasscodeRequest(payload);
+
+        assertThat(optionalErrors.isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldError_ifProvisionalNotBoolean_whenValidateNewSecondFactorPasscodeRequest() {
+        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("provisional", "maybe"));
+
+        Optional<Errors> optionalErrors = validator.validateNewSecondFactorPasscodeRequest(payload);
+
+        assertTrue(optionalErrors.isPresent());
+        Errors errors = optionalErrors.get();
+
+        assertThat(errors.getErrors().size(), is(1));
+        assertThat(errors.getErrors(), hasItems("Field [provisional] must be a boolean"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
@@ -96,6 +96,19 @@ public class DatabaseTestHelper {
         return this;
     }
 
+    public DatabaseTestHelper updateProvisionalOtpKey(String username, String provisionalOtpKey) {
+        jdbi.withHandle(handle ->
+                handle
+                        .createStatement("UPDATE users SET provisional_otp_key = :provisionalOtpKey, " +
+                                "provisional_otp_key_created_at = NOW() " +
+                                "WHERE username = :username")
+                        .bind("provisionalOtpKey", provisionalOtpKey)
+                        .bind("username", username)
+                        .execute()
+        );
+        return this;
+    }
+
     public DatabaseTestHelper add(User user) {
         Timestamp now = from(ZonedDateTime.now(ZoneId.of("UTC")).toInstant());
         jdbi.withHandle(handle ->


### PR DESCRIPTION
Make it so that a call to `/v1/api/users/{externalId}/second-factor` with a body of `{"provisional": true}` causes the provisional OTP key to be used when generating the security code sent via text message (error if there isn’t a provisional OTP key).

Requests without a body continue to use the regular OTP key as before.