### PR TITLE
PP-3635 Whitelist National History Museum on account creation

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
@@ -36,7 +36,8 @@ public class EmailValidator {
                 "scotent\\.co\\.uk",
                 "slc\\.co\\.uk",
                 "ucds\\.email",
-                "acas\\.org\\.uk"
+                "acas\\.org\\.uk",
+                "nhm\\.ac\\.uk"
                 ));
     }
     private static final Pattern PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERN;

--- a/src/test/java/uk/gov/pay/adminusers/utils/email/EmailValidatorIsPublicSectorEmailTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/email/EmailValidatorIsPublicSectorEmailTest.java
@@ -78,6 +78,7 @@ public class EmailValidatorIsPublicSectorEmailTest {
                 {"valid@slc.co.uk", true},
                 {"valid@ucds.email", true},
                 {"valid@acas.org.uk", true},
+                {"valid@nhm.ac.uk", true},
 
 
                 // all valid emails with subdomains
@@ -99,7 +100,8 @@ public class EmailValidatorIsPublicSectorEmailTest {
                 {"valid@subdomain.police.uk", true},
                 {"valid@subdomain.scotent.co.uk", true},
                 {"valid@subdomain.slc.co.uk", true},
-                {"valid@subdomain.ucds.email", true}
+                {"valid@subdomain.ucds.email", true},
+                {"valid@subdomain.nhm.ac.uk", true}
         });
     }
 


### PR DESCRIPTION
## WHAT
    
- Whitelisting all '@nhm.ac.uk' addresses to pass the email validation.