### PR TITLE
PP-3666 Remove no-op from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,9 @@
 FROM govukpay/openjdk:8-jre-alpine
 
-
 RUN apk update
 RUN apk upgrade
 
 RUN apk add --no-cache bash
-
-RUN apk add --no-cache openssl && \
-    mkdir -p bin && \
-    apk del --purge openssl
 
 ENV PORT 8080
 ENV ADMIN_PORT 8081
@@ -17,7 +12,6 @@ EXPOSE 8080
 EXPOSE 8081
 
 WORKDIR /app
-
 
 ADD target/*.yaml /app/
 ADD target/pay-*-allinone.jar /app/


### PR DESCRIPTION
When chamber moved into the base image, we didn't fully clean up. Remove this
stray code which adds and then removes openssl.