### PR TITLE
PP-3657 Fix flaky tests. PingTest

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/app/healthchecks/Ping.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/healthchecks/Ping.java
@@ -5,7 +5,7 @@ import com.codahale.metrics.health.HealthCheck;
 public class Ping extends HealthCheck {
 
     @Override
-    protected Result check() throws Exception {
+    protected Result check() {
         return Result.healthy();
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/app/healthchecks/PingTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/app/healthchecks/PingTest.java
@@ -3,13 +3,14 @@ package uk.gov.pay.adminusers.app.healthchecks;
 import com.codahale.metrics.health.HealthCheck;
 import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 
 public class PingTest {
 
     @Test
     public void testPing() {
-        assertThat(new Ping().execute(), is(HealthCheck.Result.healthy()));
+        HealthCheck.Result pingExecution = new Ping().execute();
+        assertThat(pingExecution.isHealthy(), is(true));
     }
 }


### PR DESCRIPTION
## WHAT
- Equals operation unreliable since there is a time component involved. Running these tests multiple times eventually fails due to timestamp comparison in the healthcheck:

 Ping: `<Result{isHealthy=true, timestamp=2018-04-18T12:05:02.688+0100}>`
 Expected: `<Result{isHealthy=true, timestamp=2018-04-18T12:05:02.687+0100}>`

- Modified the test to check only for _isHealthy_ result