### PR TITLE
PP-3657 Fix flaky test. UserServicesTest.shouldReturn2FAToken_whenCreate2FA_evenIfNotifyThrowsAnError

### DIFF
--- a/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
@@ -387,7 +387,9 @@ public class UserServicesTest {
         assertTrue(tokenOptional.isPresent());
         assertThat(tokenOptional.get().getPasscode(), is("123456"));
 
-        assertTrue(errorPromise.isCompletedExceptionally());
+        assertThat(errorPromise
+                .whenComplete((result, ex)-> System.out.println("errorPromise completed"))
+                .isCompletedExceptionally(), is(true));
     }
 
     @Test


### PR DESCRIPTION
## WHAT
- UserServicesTest.shouldReturn2FAToken_whenCreate2FA_evenIfNotifyThrowsAnError. Verify the promise is completed exceptionally when it completes rather than immediately.