### PR TITLE
PP-3602 Change card payments to DD smoke tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ pipeline {
     stage('Tests') {
       failFast true
       parallel {
-        stage('Card Payment End-to-End Tests') {
+        stage('Direct-Debit End-to-End Tests') {
             when {
                 anyOf {
                   branch 'master'
@@ -66,7 +66,7 @@ pipeline {
                 }
             }
             steps {
-                runCardPaymentsE2E("adminusers")
+                runDirectDebitE2E("adminusers")
             }
         }
         stage('Accept Tests') {


### PR DESCRIPTION
When doing the selenium tests for staging we decided adminusers should
only run DD smoke tests. Updating the Jenkinsfile so that there is
consistency across all the environments

solo @belindac