### PR TITLE
PP-3602 Revert incorrectly removed e2e config and change smoke tests to DD

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ pipeline {
     stage('Tests') {
       failFast true
       parallel {
-        stage('Direct-Debit End-to-End Tests') {
+        stage('Card Payment End-to-End Tests') {
             when {
                 anyOf {
                   branch 'master'
@@ -66,7 +66,7 @@ pipeline {
                 }
             }
             steps {
-                runDirectDebitE2E("adminusers")
+                runCardPaymentsE2E("adminusers")
             }
         }
         stage('Accept Tests') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,7 +109,7 @@ pipeline {
         branch 'master'
       }
       steps {
-        runProductsSmokeTest()
+        runDirectDebitSmokeTest()
       }
     }
     stage('Complete') {


### PR DESCRIPTION
Reinstated e2e config removed
Changed smoke test to DD, products should only run after products and products-ui

solo @belindac 