### PR TITLE
Change status of ADR 001 from “Proposed” to “Accepted”

### DIFF
--- a/docs/arch/adr-001-merchant-details-and-sending-emails.md
+++ b/docs/arch/adr-001-merchant-details-and-sending-emails.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 


### PR DESCRIPTION
All feedback was in favour of the ADR, which also had broad support in the meeting that spawned it.