### PR TITLE
PP-3615 Contract testing maven profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ The GOV.UK Pay Admin Users Module in Java (Dropwizard)
 ****
 -----------------------------------------------------------------------------------------------------------
 
+## Maven profiles
+
+### Default profile
+By default, maven will run all the tests excluding contract tests 
+`mvn clean install`
+
+### Contract tests profile
+By specifying this profile, maven will run *only* the contract tests
+`mvn clean install -DrunContractTests -DPACT_BROKER_USERNAME=username -DPACT_BROKER_PASSWORD=password -DPACT_CONSUMER_TAG=tag`
+
 ## Licence
 
 [MIT License](LICENCE)

--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,8 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -178,9 +178,9 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>2.0.54-beta</version>
-                <scope>test</scope>
+            <artifactId>mockito-core</artifactId>
+            <version>2.0.54-beta</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.jayway.restassured</groupId>
@@ -237,7 +237,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>
@@ -246,16 +245,6 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12.4</version>
-                <configuration>
-                    <excludes>
-                        <exclude>**/*ContractTest.java</exclude>
-                        <exclude>**/*ContractTestSuite.java</exclude>
-                    </excludes>
                 </configuration>
             </plugin>
             <plugin>
@@ -359,4 +348,49 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <property>
+                    <name>!runContractTests</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.12.4</version>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/*ContractTest.java</exclude>
+                                <exclude>**/*ContractTestSuite.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>contract-tests</id>
+            <activation>
+                <property>
+                    <name>runContractTests</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.12.4</version>
+                        <configuration>
+                            <includes>
+                                <include>**/*ContractTestSuite.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
  - Prepare maven project for running contract testing on isolation.

  - `mvn clean install` excludes contract tests

  - Add new 'contract-tests' profile activated by the existence of a 'runContractTests'
  environment variable so `mvn clean install -DrunContractTests` would run the contract
  tests only. This will fit our requirements for running contract tests in pipeline with
  a single command.