### PR TITLE
PP-3669 Add endpoint for sending direct debit emails

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/app/AdminUsersApp.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/AdminUsersApp.java
@@ -23,7 +23,15 @@ import uk.gov.pay.adminusers.app.healthchecks.Ping;
 import uk.gov.pay.adminusers.app.util.TrustingSSLSocketFactory;
 import uk.gov.pay.adminusers.exception.ServiceNotFoundExceptionMapper;
 import uk.gov.pay.adminusers.exception.ValidationExceptionMapper;
-import uk.gov.pay.adminusers.resources.*;
+import uk.gov.pay.adminusers.resources.EmailResource;
+import uk.gov.pay.adminusers.resources.ForgottenPasswordResource;
+import uk.gov.pay.adminusers.resources.HealthCheckResource;
+import uk.gov.pay.adminusers.resources.InvalidEmailRequestExceptionMapper;
+import uk.gov.pay.adminusers.resources.InvalidMerchantDetailsExceptionMapper;
+import uk.gov.pay.adminusers.resources.InviteResource;
+import uk.gov.pay.adminusers.resources.ResetPasswordResource;
+import uk.gov.pay.adminusers.resources.ServiceResource;
+import uk.gov.pay.adminusers.resources.UserResource;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
@@ -75,10 +83,13 @@ public class AdminUsersApp extends Application<AdminUsersConfig> {
         environment.jersey().register(injector.getInstance(InviteResource.class));
         environment.jersey().register(injector.getInstance(ResetPasswordResource.class));
         environment.jersey().register(injector.getInstance(HealthCheckResource.class));
+        environment.jersey().register(injector.getInstance(EmailResource.class));
 
         // Register the custom ExceptionMapper(s)
         environment.jersey().register(new ValidationExceptionMapper());
         environment.jersey().register(new ServiceNotFoundExceptionMapper());
+        environment.jersey().register(new InvalidEmailRequestExceptionMapper());
+        environment.jersey().register(new InvalidMerchantDetailsExceptionMapper());
 
         setGlobalProxies(configuration);
     }

--- a/src/main/java/uk/gov/pay/adminusers/app/config/NotifyConfiguration.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/NotifyConfiguration.java
@@ -9,7 +9,11 @@ public class NotifyConfiguration extends Configuration {
 
     @Valid
     @NotNull
-    private String apiKey;
+    private String cardApiKey;
+
+    @Valid
+    @NotNull
+    private String directDebitApiKey;
 
     @Valid
     @NotNull
@@ -43,8 +47,37 @@ public class NotifyConfiguration extends Configuration {
     @NotNull
     private String inviteServiceUserDisabledEmailTemplateId;
 
-    public String getApiKey() {
-        return apiKey;
+    // direct-debit specific templates
+    @Valid
+    @NotNull
+    private String mandateFailedTemplateId;
+
+    @Valid
+    @NotNull
+    private String mandateCancelledTemplateId;
+
+    @Valid
+    @NotNull
+    private String paymentConfirmedTemplateId;
+
+    public String getMandateFailedTemplateId() {
+        return mandateFailedTemplateId;
+    }
+
+    public String getMandateCancelledTemplateId() {
+        return mandateCancelledTemplateId;
+    }
+
+    public String getPaymentConfirmedTemplateId() {
+        return paymentConfirmedTemplateId;
+    }
+
+    public String getCardApiKey() {
+        return cardApiKey;
+    }
+
+    public String getDirectDebitApiKey() {
+        return directDebitApiKey;
     }
 
     public String getNotificationBaseURL() {

--- a/src/main/java/uk/gov/pay/adminusers/model/PaymentType.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/PaymentType.java
@@ -1,0 +1,6 @@
+package uk.gov.pay.adminusers.model;
+
+public enum PaymentType {
+    CARD,
+    DIRECT_DEBIT
+}

--- a/src/main/java/uk/gov/pay/adminusers/resources/EmailRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/EmailRequest.java
@@ -1,0 +1,34 @@
+package uk.gov.pay.adminusers.resources;
+
+import java.util.Map;
+
+public class EmailRequest {
+
+    private final String emailAddress;
+    private final String gatewayAccountId;
+    private final EmailTemplate template;
+    private final Map<String, String> personalisation;
+
+    public EmailRequest(String emailAddress, String gatewayAccountId, EmailTemplate template, Map<String, String> personalisation) {
+        this.emailAddress = emailAddress;
+        this.gatewayAccountId = gatewayAccountId;
+        this.template = template;
+        this.personalisation = personalisation;
+    }
+
+    public String getGatewayAccountId() {
+        return gatewayAccountId;
+    }
+
+    public String getEmailAddress() {
+        return emailAddress;
+    }
+
+    public EmailTemplate getTemplate() {
+        return template;
+    }
+
+    public Map<String, String> getPersonalisation() {
+        return personalisation;
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/resources/EmailRequestParser.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/EmailRequestParser.java
@@ -22,7 +22,7 @@ public class EmailRequestParser {
     EmailRequest parse(JsonNode payload) throws InvalidEmailRequestException {
         try {
             String emailAddress = payload.get("address").asText();
-            String gatewayAccountId = payload.get("gateway_account_id").asText();
+            String gatewayAccountId = payload.get("gateway_account_external_id").asText();
             EmailTemplate template = EmailTemplate.fromString(payload.get("template").asText());
             Map<String, String> personalisation = mapper.convertValue(payload.get("personalisation"), Map.class);
             return new EmailRequest(emailAddress, gatewayAccountId, template, personalisation);

--- a/src/main/java/uk/gov/pay/adminusers/resources/EmailRequestParser.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/EmailRequestParser.java
@@ -2,17 +2,24 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
 import org.slf4j.Logger;
 import uk.gov.pay.adminusers.logger.PayLoggerFactory;
 
 import java.util.Map;
 
 public class EmailRequestParser {
+
     private static final Logger LOGGER = PayLoggerFactory.getLogger(EmailRequestParser.class);
 
-    private static ObjectMapper mapper = new ObjectMapper();
+    private ObjectMapper mapper;
 
-    public static EmailRequest parse(JsonNode payload) throws InvalidEmailRequestException {
+    @Inject
+    public EmailRequestParser(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    EmailRequest parse(JsonNode payload) throws InvalidEmailRequestException {
         try {
             String emailAddress = payload.get("address").asText();
             String gatewayAccountId = payload.get("gateway_account_id").asText();
@@ -24,4 +31,5 @@ public class EmailRequestParser {
             throw new InvalidEmailRequestException("Error while parsing email request body");
         }
     }
+
 }

--- a/src/main/java/uk/gov/pay/adminusers/resources/EmailRequestParser.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/EmailRequestParser.java
@@ -1,0 +1,27 @@
+package uk.gov.pay.adminusers.resources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import uk.gov.pay.adminusers.logger.PayLoggerFactory;
+
+import java.util.Map;
+
+public class EmailRequestParser {
+    private static final Logger LOGGER = PayLoggerFactory.getLogger(EmailRequestParser.class);
+
+    private static ObjectMapper mapper = new ObjectMapper();
+
+    public static EmailRequest parse(JsonNode payload) throws InvalidEmailRequestException {
+        try {
+            String emailAddress = payload.get("address").asText();
+            String gatewayAccountId = payload.get("gateway_account_id").asText();
+            EmailTemplate template = EmailTemplate.fromString(payload.get("template").asText());
+            Map<String, String> personalisation = mapper.convertValue(payload.get("personalisation"), Map.class);
+            return new EmailRequest(emailAddress, gatewayAccountId, template, personalisation);
+        } catch (Exception exc) {
+            LOGGER.error("Error while parsing email request, exception: {}", exc.getMessage());
+            throw new InvalidEmailRequestException("Error while parsing email request body");
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/resources/EmailResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/EmailResource.java
@@ -1,0 +1,43 @@
+package uk.gov.pay.adminusers.resources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import uk.gov.pay.adminusers.logger.PayLoggerFactory;
+import uk.gov.pay.adminusers.service.EmailService;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("/")
+public class EmailResource {
+
+    private static final Logger logger = PayLoggerFactory.getLogger(EmailResource.class);
+
+    private final EmailService notificationService;
+
+    @Inject
+    public EmailResource(EmailService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    @Path("/v1/emails/send")
+    @POST
+    @Produces(APPLICATION_JSON)
+    @Consumes(APPLICATION_JSON)
+    public Response sendEmail(JsonNode payload) throws InvalidEmailRequestException, InvalidMerchantDetailsException {
+        logger.info("Received email request");
+        EmailRequest emailRequest = EmailRequestParser.parse(payload);
+        notificationService.sendEmail(
+                emailRequest.getEmailAddress(),
+                emailRequest.getGatewayAccountId(),
+                emailRequest.getTemplate(),
+                emailRequest.getPersonalisation());
+        return Response.status(Response.Status.OK).build();
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/resources/EmailResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/EmailResource.java
@@ -20,10 +20,12 @@ public class EmailResource {
     private static final Logger logger = PayLoggerFactory.getLogger(EmailResource.class);
 
     private final EmailService notificationService;
+    private final EmailRequestParser emailRequestParser;
 
     @Inject
-    public EmailResource(EmailService notificationService) {
+    public EmailResource(EmailService notificationService, EmailRequestParser emailRequestParser) {
         this.notificationService = notificationService;
+        this.emailRequestParser = emailRequestParser;
     }
 
     @Path("/v1/emails/send")
@@ -32,7 +34,7 @@ public class EmailResource {
     @Consumes(APPLICATION_JSON)
     public Response sendEmail(JsonNode payload) throws InvalidEmailRequestException, InvalidMerchantDetailsException {
         logger.info("Received email request");
-        EmailRequest emailRequest = EmailRequestParser.parse(payload);
+        EmailRequest emailRequest = emailRequestParser.parse(payload);
         notificationService.sendEmail(
                 emailRequest.getEmailAddress(),
                 emailRequest.getGatewayAccountId(),

--- a/src/main/java/uk/gov/pay/adminusers/resources/EmailTemplate.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/EmailTemplate.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.adminusers.resources;
+
+import org.slf4j.Logger;
+import uk.gov.pay.adminusers.logger.PayLoggerFactory;
+
+public enum EmailTemplate {
+    MANDATE_CANCELLED,
+    MANDATE_FAILED,
+    PAYMENT_CONFIRMED;
+
+    private static final Logger LOGGER = PayLoggerFactory.getLogger(EmailTemplate.class);
+
+
+    public static EmailTemplate fromString(String type) {
+        for (EmailTemplate typeEnum : values()) {
+            if (typeEnum.toString().equalsIgnoreCase(type)) {
+                return typeEnum;
+            }
+        }
+        LOGGER.warn("Unknown email template: {}", type);
+        return null;
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/resources/InvalidEmailRequestException.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InvalidEmailRequestException.java
@@ -1,0 +1,7 @@
+package uk.gov.pay.adminusers.resources;
+
+public class InvalidEmailRequestException extends Exception {
+    public InvalidEmailRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/resources/InvalidEmailRequestExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InvalidEmailRequestExceptionMapper.java
@@ -1,0 +1,15 @@
+package uk.gov.pay.adminusers.resources;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+
+public class InvalidEmailRequestExceptionMapper implements ExceptionMapper<InvalidEmailRequestException> {
+
+    @Override
+    public Response toResponse(InvalidEmailRequestException exception) {
+        return Response.status(BAD_REQUEST).build();
+    }
+
+}

--- a/src/main/java/uk/gov/pay/adminusers/resources/InvalidMerchantDetailsException.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InvalidMerchantDetailsException.java
@@ -1,0 +1,7 @@
+package uk.gov.pay.adminusers.resources;
+
+public class InvalidMerchantDetailsException extends Exception {
+    public InvalidMerchantDetailsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/resources/InvalidMerchantDetailsExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InvalidMerchantDetailsExceptionMapper.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.adminusers.resources;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+
+public class InvalidMerchantDetailsExceptionMapper implements ExceptionMapper<InvalidMerchantDetailsException> {
+
+    @Override
+    public Response toResponse(InvalidMerchantDetailsException exception) {
+        return Response.status(INTERNAL_SERVER_ERROR).build();
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/service/EmailService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/EmailService.java
@@ -1,0 +1,107 @@
+package uk.gov.pay.adminusers.service;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import liquibase.exception.ServiceNotFoundException;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import uk.gov.pay.adminusers.logger.PayLoggerFactory;
+import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
+import uk.gov.pay.adminusers.persistence.entity.MerchantDetailsEntity;
+import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
+import uk.gov.pay.adminusers.resources.EmailTemplate;
+import uk.gov.pay.adminusers.resources.InvalidMerchantDetailsException;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+
+import static uk.gov.pay.adminusers.model.PaymentType.DIRECT_DEBIT;
+
+public class EmailService {
+
+    private static final Logger LOGGER = PayLoggerFactory.getLogger(EmailService.class);
+
+    private NotificationService notificationService;
+    private ServiceDao serviceDao;
+
+    @Inject
+    public EmailService(NotificationService notificationService, ServiceDao serviceDao) {
+        this.serviceDao = serviceDao;
+        this.notificationService = notificationService;
+    }
+
+    private String formatMerchantAddress(MerchantDetailsEntity merchantDetails) {
+        StringJoiner merchantAddress = new StringJoiner(", ", "","");
+        merchantAddress.add(merchantDetails.getName());
+        merchantAddress.add(merchantDetails.getAddressLine1());
+        if (!StringUtils.isBlank(merchantDetails.getAddressLine2())) {
+            merchantAddress.add(merchantDetails.getAddressLine2());
+        }
+        merchantAddress.add(merchantDetails.getAddressCity());
+        merchantAddress.add(merchantDetails.getAddressPostcode());
+        merchantAddress.add(merchantDetails.getAddressCountry());
+        return merchantAddress.toString();
+    }
+
+    private boolean isMissingMandatoryFields(MerchantDetailsEntity merchantDetails) {
+        return Stream.of(
+                merchantDetails.getName(),
+                merchantDetails.getTelephoneNumber(),
+                merchantDetails.getAddressLine1(),
+                merchantDetails.getAddressCity(),
+                merchantDetails.getAddressCountry(),
+                merchantDetails.getAddressPostcode()
+        ).anyMatch(StringUtils::isBlank);
+    }
+
+    private Map<EmailTemplate, StaticEmailContent> getTemplateMappingsFor(String gatewayAccountId) throws InvalidMerchantDetailsException {
+        ServiceEntity service = getServiceFor(gatewayAccountId);
+        MerchantDetailsEntity merchantDetails = service.getMerchantDetailsEntity();
+
+        if (merchantDetails == null || isMissingMandatoryFields(merchantDetails)) {
+            LOGGER.error("Merchant details are empty");
+            throw new InvalidMerchantDetailsException("Merchant details are empty, can't send email for account " + gatewayAccountId);
+        }
+        String merchantAddress = formatMerchantAddress(merchantDetails);
+
+        return ImmutableMap.of(
+                EmailTemplate.PAYMENT_CONFIRMED, new StaticEmailContent(
+                        notificationService.getNotifyConfiguration().getPaymentConfirmedTemplateId(),
+                        ImmutableMap.of(
+                                "service name", service.getName(),
+                                "merchant address", merchantAddress,
+                                "merchant phone number", merchantDetails.getTelephoneNumber())
+                        )
+                ,
+                EmailTemplate.MANDATE_CANCELLED, new StaticEmailContent(
+                        notificationService.getNotifyConfiguration().getMandateCancelledTemplateId(),
+                        ImmutableMap.of(
+                                "org name", merchantDetails.getName(),
+                                "org phone", merchantDetails.getTelephoneNumber()
+                        )
+                ),
+                EmailTemplate.MANDATE_FAILED, new StaticEmailContent(
+                        notificationService.getNotifyConfiguration().getMandateFailedTemplateId(),
+                        ImmutableMap.of(
+                                "org name", merchantDetails.getName(),
+                                "org phone", merchantDetails.getTelephoneNumber()
+                        ))
+        );
+    }
+    private ServiceEntity getServiceFor(String gatewayAccountId) {
+        return serviceDao.findByGatewayAccountId(gatewayAccountId)
+                .orElseThrow(() -> new ServiceNotFoundException("Service not found"));
+    }
+    public CompletableFuture<String> sendEmail(String email, String gatewayAccountId, EmailTemplate template, Map<String, String> dynamicContent) throws InvalidMerchantDetailsException {
+        Map<EmailTemplate, StaticEmailContent> templateMappingsFor = getTemplateMappingsFor(gatewayAccountId);
+        Map<String, String> staticContent = templateMappingsFor.get(template).getPersonalisation();
+        Map<String, String> allContent = new HashMap<>();
+        allContent.putAll(staticContent);
+        allContent.putAll(dynamicContent);
+        LOGGER.info("Sending direct debit email for " + template.toString());
+        return notificationService.sendEmailAsync(DIRECT_DEBIT, templateMappingsFor.get(template).getTemplateId(), email, allContent);
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/service/NotifyClientProvider.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NotifyClientProvider.java
@@ -1,12 +1,12 @@
 package uk.gov.pay.adminusers.service;
 
-import com.google.inject.Provider;
 import uk.gov.pay.adminusers.app.config.NotifyConfiguration;
+import uk.gov.pay.adminusers.model.PaymentType;
 import uk.gov.service.notify.NotificationClient;
 
 import javax.net.ssl.SSLContext;
 
-public class NotifyClientProvider implements Provider<NotificationClient> {
+public class NotifyClientProvider {
 
     private NotifyConfiguration configuration;
     private final SSLContext sslContext;
@@ -16,8 +16,14 @@ public class NotifyClientProvider implements Provider<NotificationClient> {
         this.sslContext = sslContext;
     }
 
-    @Override
-    public NotificationClient get() {
-        return new NotificationClient(configuration.getApiKey(), configuration.getNotificationBaseURL(), null, sslContext);
+    public NotificationClient get(PaymentType paymentType) {
+        switch (paymentType) {
+            case DIRECT_DEBIT:
+                return new NotificationClient(configuration.getDirectDebitApiKey(), configuration.getNotificationBaseURL(), null, sslContext);
+            case CARD:
+            default:
+                return new NotificationClient(configuration.getCardApiKey(), configuration.getNotificationBaseURL(), null, sslContext);
+        }
     }
+
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/StaticEmailContent.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/StaticEmailContent.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.adminusers.service;
+
+import java.util.Map;
+
+public class StaticEmailContent {
+    private String templateId;
+    private Map<String, String> personalisation;
+
+    public StaticEmailContent(String templateId, Map<String, String> personalisation) {
+        this.templateId = templateId;
+        this.personalisation = personalisation;
+    }
+
+    public String getTemplateId() {
+        return templateId;
+    }
+
+    public Map<String, String> getPersonalisation() {
+        return personalisation;
+    }
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -60,7 +60,8 @@ proxy:
   port: ${HTTP_PROXY_PORT}
 
 notify:
-  apiKey: ${NOTIFY_API_KEY:-api_key-pay-notify-service-id-pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs}
+  cardApiKey: ${NOTIFY_API_KEY:-api_key-pay-notify-service-id-pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs}
+  directDebitApiKey: ${NOTIFY_DIRECT_DEBIT_API_KEY:-api_key-pay-notify-service-id-pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs}
   notificationBaseURL: ${NOTIFY_BASE_URL:-https://stubs.pymnt.localdomain/notify}
   secondFactorSmsTemplateId: ${NOTIFY_2FA_TEMPLATE_ID:-pay-notify-two-factor-template-id}
   inviteUserEmailTemplateId: ${NOTIFY_INVITE_USER_EMAIL_TEMPLATE_ID:-pay-notify-invite-user-email-template-id}
@@ -69,6 +70,9 @@ notify:
   inviteServiceEmailTemplateId: ${NOTIFY_INVITE_SERVICE_EMAIL_TEMPLATE_ID:-pay-notify-invite-service-email-template-id}
   inviteServiceUserExistsEmailTemplateId: ${NOTIFY_INVITE_SERVICE_USER_EXITS_EMAIL_TEMPLATE_ID:-pay-notify-invite-service-user-exists-email-template-id}
   inviteServiceUserDisabledEmailTemplateId: ${NOTIFY_INVITE_SERVICE_USER_DISABLED_EMAIL_TEMPLATE_ID:-pay-notify-invite-service-user-disabled-email-template-id}
+  mandateFailedTemplateId: ${NOTIFY_MANDATE_FAILED_TEMPLATE_ID:-pay-mandate-failed-id}
+  mandateCancelledTemplateId: ${NOTIFY_MANDATE_CANCELLED_TEMPLATE_ID:-pay-mandate-cancelled-id}
+  paymentConfirmedTemplateId: ${NOTIFY_PAYMENT_CONFIRMED_TEMPLATE_ID:-pay-payment-confirmed-id}
 
 forgottenPasswordExpiryMinutes: ${FORGOTTEN_PASSWORD_EXPIRY_MINUTES:-90}
 

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/ServiceDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/ServiceDbFixture.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.adminusers.fixtures;
 
+import uk.gov.pay.adminusers.model.MerchantDetails;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.utils.DatabaseTestHelper;
 
@@ -14,7 +15,7 @@ public class ServiceDbFixture {
     private Integer id;
     private String externalId;
     private String name = Service.DEFAULT_NAME_VALUE;
-
+    private MerchantDetails merchantDetails = new MerchantDetails("name", null, "line1",  null, "city", "postcode", "country");
     private ServiceDbFixture(DatabaseTestHelper databaseHelper) {
         this.databaseHelper = databaseHelper;
     }
@@ -28,11 +29,17 @@ public class ServiceDbFixture {
         return this;
     }
 
+    public ServiceDbFixture withMerchantDetails(MerchantDetails merchantDetails) {
+        this.merchantDetails = merchantDetails;
+        return this;
+    }
+
     public Service insertService() {
         int serviceId = id == null ? nextInt() : id;
         String extId = externalId == null ? randomUuid() : externalId;
 
         Service service = Service.from(serviceId, extId, name);
+        service.setMerchantDetails(merchantDetails);
         databaseHelper.addService(service, gatewayAccountIds);
 
         return service;

--- a/src/test/java/uk/gov/pay/adminusers/resources/EmailRequestParserTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/EmailRequestParserTest.java
@@ -1,0 +1,57 @@
+package uk.gov.pay.adminusers.resources;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class EmailRequestParserTest {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void shouldCreateAnEmailRequestForAValidPayload() throws InvalidEmailRequestException {
+        Map<String, Object> body = ImmutableMap.of(
+          "address", "aaa@bbb.test",
+          "gateway_account_id", "DIRECT_DEBIT:23847roidfghdkkj",
+          "template", "MANDATE_CANCELLED",
+          "personalisation", ImmutableMap.of(
+                  "field 1", "theValueOfField1",
+                  "field 2", "theValueOfField2"
+                )
+        );
+
+        EmailRequest emailRequest = EmailRequestParser.parse(objectMapper.valueToTree(body));
+        assertThat(emailRequest.getEmailAddress(), is("aaa@bbb.test"));
+        assertThat(emailRequest.getGatewayAccountId(), is("DIRECT_DEBIT:23847roidfghdkkj"));
+        assertThat(emailRequest.getTemplate(), is(EmailTemplate.MANDATE_CANCELLED));
+        assertThat(emailRequest.getPersonalisation(), is(ImmutableMap.of(
+                "field 1", "theValueOfField1",
+                "field 2", "theValueOfField2"
+        )));
+    }
+
+    @Test
+    public void shouldThrowAnExceptionForAnInvalidPayload() throws InvalidEmailRequestException {
+        Map<String, Object> body = ImmutableMap.of(
+                "template", "MANDATE_CANCELLED",
+                "personalisation", ImmutableMap.of(
+                        "field 1", "theValueOfField1",
+                        "field 2", "theValueOfField2"
+                )
+        );
+        thrown.expect(InvalidEmailRequestException.class);
+        thrown.expectMessage("Error while parsing email request body");
+        thrown.reportMissingExceptionWithMessage("InvalidEmailRequestException expected");
+        EmailRequestParser.parse(objectMapper.valueToTree(body));
+
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/resources/EmailRequestParserTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/EmailRequestParserTest.java
@@ -2,6 +2,7 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -17,6 +18,13 @@ public class EmailRequestParserTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
+    private EmailRequestParser parser;
+
+    @Before
+    public void setUp() {
+        parser = new EmailRequestParser(objectMapper);
+    }
+
     @Test
     public void shouldCreateAnEmailRequestForAValidPayload() throws InvalidEmailRequestException {
         Map<String, Object> body = ImmutableMap.of(
@@ -29,7 +37,7 @@ public class EmailRequestParserTest {
                 )
         );
 
-        EmailRequest emailRequest = EmailRequestParser.parse(objectMapper.valueToTree(body));
+        EmailRequest emailRequest = parser.parse(objectMapper.valueToTree(body));
         assertThat(emailRequest.getEmailAddress(), is("aaa@bbb.test"));
         assertThat(emailRequest.getGatewayAccountId(), is("DIRECT_DEBIT:23847roidfghdkkj"));
         assertThat(emailRequest.getTemplate(), is(EmailTemplate.MANDATE_CANCELLED));
@@ -51,7 +59,6 @@ public class EmailRequestParserTest {
         thrown.expect(InvalidEmailRequestException.class);
         thrown.expectMessage("Error while parsing email request body");
         thrown.reportMissingExceptionWithMessage("InvalidEmailRequestException expected");
-        EmailRequestParser.parse(objectMapper.valueToTree(body));
-
+        parser.parse(objectMapper.valueToTree(body));
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/resources/EmailRequestParserTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/EmailRequestParserTest.java
@@ -29,7 +29,7 @@ public class EmailRequestParserTest {
     public void shouldCreateAnEmailRequestForAValidPayload() throws InvalidEmailRequestException {
         Map<String, Object> body = ImmutableMap.of(
           "address", "aaa@bbb.test",
-          "gateway_account_id", "DIRECT_DEBIT:23847roidfghdkkj",
+          "gateway_account_external_id", "DIRECT_DEBIT:23847roidfghdkkj",
           "template", "MANDATE_CANCELLED",
           "personalisation", ImmutableMap.of(
                   "field 1", "theValueOfField1",

--- a/src/test/java/uk/gov/pay/adminusers/resources/EmailResourceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/EmailResourceTest.java
@@ -16,7 +16,7 @@ public class EmailResourceTest extends IntegrationTest {
     private static final String GATEWAY_ACCOUNT_ID = "DIRECT_DEBIT:mdshfsehdtfsdtjg";
     private Map<String, Object> validEmailRequest = ImmutableMap.of(
             "address", "cake@directdebitteam.test",
-            "gateway_account_id", GATEWAY_ACCOUNT_ID,
+            "gateway_account_external_id", GATEWAY_ACCOUNT_ID,
             "template", "MANDATE_CANCELLED",
             "personalisation", ImmutableMap.of(
                     "mandate reference", "mandatereference",

--- a/src/test/java/uk/gov/pay/adminusers/resources/EmailResourceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/EmailResourceTest.java
@@ -1,0 +1,43 @@
+package uk.gov.pay.adminusers.resources;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import uk.gov.pay.adminusers.fixtures.ServiceDbFixture;
+import uk.gov.pay.adminusers.model.MerchantDetails;
+
+import java.util.Map;
+
+import static com.jayway.restassured.http.ContentType.JSON;
+
+public class EmailResourceTest extends IntegrationTest {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private static final String GATEWAY_ACCOUNT_ID = "DIRECT_DEBIT:mdshfsehdtfsdtjg";
+    private Map<String, Object> validEmailRequest = ImmutableMap.of(
+            "address", "cake@directdebitteam.test",
+            "gateway_account_id", GATEWAY_ACCOUNT_ID,
+            "template", "MANDATE_CANCELLED",
+            "personalisation", ImmutableMap.of(
+                    "mandate reference", "mandatereference",
+                    "org name", "cake service"
+            )
+    );
+
+    @Test
+    public void shouldReceiveAPayloadAndSendEmail() {
+        ServiceDbFixture.serviceDbFixture(databaseHelper)
+                .withGatewayAccountIds(GATEWAY_ACCOUNT_ID)
+                .withMerchantDetails(new MerchantDetails("name", "number", "line1",  null, "city", "postcode", "country"))
+                .insertService();
+        String body = objectMapper.valueToTree(validEmailRequest).toString();
+        givenSetup()
+                .when()
+                .accept(JSON)
+                .body(body)
+                .post("/v1/emails/send")
+                .then()
+                .statusCode(200);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/adminusers/resources/EmailTemplateTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/EmailTemplateTest.java
@@ -1,0 +1,32 @@
+package uk.gov.pay.adminusers.resources;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class EmailTemplateTest {
+
+    @Test
+    public void shouldDeserialiseEnumFromUppercaseString() {
+        EmailTemplate mandateCancelled = EmailTemplate.fromString("MANDATE_CANCELLED");
+        EmailTemplate mandateFailed = EmailTemplate.fromString("MANDATE_FAILED");
+        EmailTemplate paymentConfirmed = EmailTemplate.fromString("PAYMENT_CONFIRMED");
+
+        assertThat(mandateCancelled, is(EmailTemplate.MANDATE_CANCELLED));
+        assertThat(mandateFailed, is(EmailTemplate.MANDATE_FAILED));
+        assertThat(paymentConfirmed, is(EmailTemplate.PAYMENT_CONFIRMED));
+    }
+
+    @Test
+    public void shouldDeserialiseEnumFromLowercaseString() {
+        EmailTemplate mandateCancelled = EmailTemplate.fromString("mandate_cancelled");
+        EmailTemplate mandateFailed = EmailTemplate.fromString("mandate_failed");
+        EmailTemplate paymentConfirmed = EmailTemplate.fromString("payment_confirmed");
+
+        assertThat(mandateCancelled, is(EmailTemplate.MANDATE_CANCELLED));
+        assertThat(mandateFailed, is(EmailTemplate.MANDATE_FAILED));
+        assertThat(paymentConfirmed, is(EmailTemplate.PAYMENT_CONFIRMED));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/adminusers/service/EmailServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/EmailServiceTest.java
@@ -1,0 +1,160 @@
+package uk.gov.pay.adminusers.service;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.pay.adminusers.app.config.NotifyConfiguration;
+import uk.gov.pay.adminusers.model.PaymentType;
+import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
+import uk.gov.pay.adminusers.persistence.entity.MerchantDetailsEntity;
+import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
+import uk.gov.pay.adminusers.resources.EmailTemplate;
+import uk.gov.pay.adminusers.resources.InvalidMerchantDetailsException;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EmailServiceTest {
+
+    private static final String MERCHANT_NAME = "merchant name";
+    private static final String TELEPHONE_NUMBER = "call me maybe";
+    private static final String ADDRESS_LINE_1 = "address line 1";
+    private static final String CITY = "city";
+    private static final String POSTCODE = "postcode";
+    private static final String ADDRESS_COUNTRY = "cake";
+    private EmailService emailService;
+
+    @Mock
+    private NotificationService mockNotificationService;
+
+    @Mock
+    private ServiceDao mockServiceDao;
+
+    @Mock
+    private NotifyConfiguration mockNotificationConfiguration;
+
+    @Mock
+    private ServiceEntity mockServiceEntity;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private final static String EMAIL_ADDRESS = "aaa@bbb.test";
+    private final static String GATEWAY_ACCOUNT_ID = "DIRECT_DEBIT:sfksdjweg45w";
+
+    @Before
+    public void setUp() {
+        given(mockNotificationService.getNotifyConfiguration()).willReturn(mockNotificationConfiguration);
+        given(mockNotificationConfiguration.getPaymentConfirmedTemplateId()).willReturn("PAYMENT CONFIRMED");
+        given(mockNotificationConfiguration.getMandateCancelledTemplateId()).willReturn("MANDATE CANCELLED");
+        given(mockNotificationConfiguration.getMandateFailedTemplateId()).willReturn("MANDATE FAILED");
+        emailService = new EmailService(mockNotificationService, mockServiceDao);
+    }
+
+
+    @Test
+    public void shouldSendAnEmailForPaymentConfirmed() throws InvalidMerchantDetailsException {
+        EmailTemplate template = EmailTemplate.PAYMENT_CONFIRMED;
+        Map<String, String> personalisation = ImmutableMap.of(
+                "field 1", "theValueOfField1",
+                "field 2", "theValueOfField2"
+        );
+        MerchantDetailsEntity merchantDetails = new MerchantDetailsEntity(
+                MERCHANT_NAME,
+                TELEPHONE_NUMBER,
+                ADDRESS_LINE_1,
+                null,
+                CITY,
+                POSTCODE,
+                ADDRESS_COUNTRY
+        );
+        given(mockServiceDao.findByGatewayAccountId(GATEWAY_ACCOUNT_ID)).willReturn(Optional.of(mockServiceEntity));
+        given(mockServiceEntity.getMerchantDetailsEntity()).willReturn(merchantDetails);
+        given(mockServiceEntity.getName()).willReturn("a service");
+        ArgumentCaptor<Map<String, String>> personalisationCaptor = forClass(Map.class);
+
+        emailService.sendEmail(EMAIL_ADDRESS, GATEWAY_ACCOUNT_ID, template, personalisation);
+
+        verify(mockNotificationService).sendEmailAsync(eq(PaymentType.DIRECT_DEBIT), eq("PAYMENT CONFIRMED"), eq(EMAIL_ADDRESS), personalisationCaptor.capture());
+        Map<String, String> allContent = personalisationCaptor.getValue();
+        assertThat(allContent.get("field 1"), is("theValueOfField1"));
+        assertThat(allContent.get("field 2"), is("theValueOfField2"));
+        assertThat(allContent.get("service name"), is("a service"));
+        assertThat(allContent.get("merchant address"), is("merchant name, address line 1, city, postcode, cake"));
+        assertThat(allContent.get("merchant phone number"), is(TELEPHONE_NUMBER));
+    }
+
+    @Test
+    public void shouldSendAnEmailForMandateFailed() throws InvalidMerchantDetailsException {
+        EmailTemplate template = EmailTemplate.MANDATE_FAILED;
+        Map<String, String> personalisation = ImmutableMap.of(
+                "field 1", "theValueOfField1",
+                "field 2", "theValueOfField2"
+        );
+        MerchantDetailsEntity merchantDetails = new MerchantDetailsEntity(
+                MERCHANT_NAME,
+                TELEPHONE_NUMBER,
+                ADDRESS_LINE_1,
+                "address line 2",
+                CITY,
+                POSTCODE,
+                ADDRESS_COUNTRY
+        );
+
+        given(mockServiceDao.findByGatewayAccountId(GATEWAY_ACCOUNT_ID)).willReturn(Optional.of(mockServiceEntity));
+        given(mockServiceEntity.getMerchantDetailsEntity()).willReturn(merchantDetails);
+        given(mockServiceEntity.getName()).willReturn("a service");
+        ArgumentCaptor<Map<String, String>> personalisationCaptor = forClass(Map.class);
+
+        emailService.sendEmail(EMAIL_ADDRESS, GATEWAY_ACCOUNT_ID, template, personalisation);
+
+        verify(mockNotificationService).sendEmailAsync(eq(PaymentType.DIRECT_DEBIT), eq("MANDATE FAILED"), eq(EMAIL_ADDRESS), personalisationCaptor.capture());
+        Map<String, String> allContent = personalisationCaptor.getValue();
+        assertThat(allContent.get("field 1"), is("theValueOfField1"));
+        assertThat(allContent.get("field 2"), is("theValueOfField2"));
+        assertThat(allContent.get("org name"), is(MERCHANT_NAME));
+        assertThat(allContent.get("org phone"), is(TELEPHONE_NUMBER));
+    }
+
+    @Test
+    public void shouldThrowAnExceptionIfMerchantDetailsAreMissing() throws InvalidMerchantDetailsException {
+        EmailTemplate template = EmailTemplate.MANDATE_FAILED;
+        Map<String, String> personalisation = ImmutableMap.of(
+                "field 1", "theValueOfField1",
+                "field 2", "theValueOfField2"
+        );
+        MerchantDetailsEntity merchantDetails = new MerchantDetailsEntity(
+                null,
+                TELEPHONE_NUMBER,
+                ADDRESS_LINE_1,
+                "address line 2",
+                CITY,
+                POSTCODE,
+                ADDRESS_COUNTRY
+        );
+
+        given(mockServiceDao.findByGatewayAccountId(GATEWAY_ACCOUNT_ID)).willReturn(Optional.of(mockServiceEntity));
+        given(mockServiceEntity.getMerchantDetailsEntity()).willReturn(merchantDetails);
+        given(mockServiceEntity.getName()).willReturn("a service");
+
+        thrown.expect(InvalidMerchantDetailsException.class);
+        thrown.expectMessage("Merchant details are empty, can't send email for account " + GATEWAY_ACCOUNT_ID);
+        thrown.reportMissingExceptionWithMessage("InvalidMerchantDetailsException expected");
+
+        emailService.sendEmail(EMAIL_ADDRESS, GATEWAY_ACCOUNT_ID, template, personalisation);
+    }
+}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -60,7 +60,8 @@ proxy:
   port: 1234
 
 notify:
-  apiKey: ${NOTIFY_API_KEY:-api_key-pay-notify-service-id-pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs}
+  directDebitApiKey: ${NOTIFY_DIRECT_DEBIT_API_KEY:-api_key-pay-notify-service-id-pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs}
+  cardApiKey: ${NOTIFY_API_KEY:-api_key-pay-notify-service-id-pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs}
   notificationBaseURL: ${NOTIFY_BASE_URL:-https://stubs.pymnt.localdomain/notify}
   secondFactorSmsTemplateId: ${NOTIFY_2FA_TEMPLATE_ID:-pay-notify-two-factor-template-id}
   inviteUserEmailTemplateId: ${NOTIFY_INVITE_USER_EMAIL_TEMPLATE_ID:-pay-notify-invite-user-email-template-id}
@@ -69,6 +70,9 @@ notify:
   inviteServiceEmailTemplateId: ${NOTIFY_INVITE_SERVICE_EMAIL_TEMPLATE_ID:-pay-notify-invite-service-email-template-id}
   inviteServiceUserExistsEmailTemplateId: ${NOTIFY_INVITE_SERVICE_USER_EXITS_EMAIL_TEMPLATE_ID:-pay-notify-invite-service-user-exists-email-template-id}
   inviteServiceUserDisabledEmailTemplateId: ${NOTIFY_INVITE_SERVICE_USER_DISABLED_EMAIL_TEMPLATE_ID:-pay-notify-invite-service-user-disabled-email-template-id}
+  mandateFailedTemplateId: ${NOTIFY_MANDATE_FAILED_TEMPLATE_ID:-pay-mandate-failed-id}
+  mandateCancelledTemplateId: ${NOTIFY_MANDATE_CANCELLED_TEMPLATE_ID:-pay-mandate-cancelled-id}
+  paymentConfirmedTemplateId: ${NOTIFY_PAYMENT_CONFIRMED_TEMPLATE_ID:-pay-payment-confirmed-id}
 
 forgottenPasswordExpiryMinutes: ${FORGOTTEN_PASSWORD_EXPIRY_MINUTES:-90}
 


### PR DESCRIPTION
 - Adminusers is now in charge of sending emails on behalf of direct debit connector.
   This PR adds and endpoint so that direct debit connector can send adminusers details about
   the email that needs to be sent.
 - Non direct debit specific information (like service name or merchant details) are already
   stored in Adminusers, so we need to "merge" the two personalisations to send emails.
 - Adding direct debit notify configurations (template ids and a different api keys)

with @alexbishop1