### PR TITLE
PP-3669 Log gateway account ID if empty merchant details error

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/service/EmailService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/EmailService.java
@@ -62,8 +62,8 @@ public class EmailService {
         MerchantDetailsEntity merchantDetails = service.getMerchantDetailsEntity();
 
         if (merchantDetails == null || isMissingMandatoryFields(merchantDetails)) {
-            LOGGER.error("Merchant details are empty");
-            throw new InvalidMerchantDetailsException("Merchant details are empty, can't send email for account " + gatewayAccountId);
+            LOGGER.error("Merchant details are empty: can't send email for account {}", gatewayAccountId);
+            throw new InvalidMerchantDetailsException("Merchant details are empty: can't send email for account " + gatewayAccountId);
         }
         String merchantAddress = formatMerchantAddress(merchantDetails);
 

--- a/src/test/java/uk/gov/pay/adminusers/service/EmailServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/EmailServiceTest.java
@@ -152,7 +152,7 @@ public class EmailServiceTest {
         given(mockServiceEntity.getName()).willReturn("a service");
 
         thrown.expect(InvalidMerchantDetailsException.class);
-        thrown.expectMessage("Merchant details are empty, can't send email for account " + GATEWAY_ACCOUNT_ID);
+        thrown.expectMessage("Merchant details are empty: can't send email for account " + GATEWAY_ACCOUNT_ID);
         thrown.reportMissingExceptionWithMessage("InvalidMerchantDetailsException expected");
 
         emailService.sendEmail(EMAIL_ADDRESS, GATEWAY_ACCOUNT_ID, template, personalisation);


### PR DESCRIPTION
If we cannot send an email due to merchant details not being configured, log the gateway account ID