### PR TITLE
PP-3712 Allow alphabetic gateway account ids when finding services

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
@@ -119,9 +119,6 @@ public class ServiceRequestValidator {
         if (isBlank(gatewayAccountId)) {
             return Optional.of(Errors.from("Find services currently support only by gatewayAccountId"));
         }
-        if (!isNumeric(gatewayAccountId)) {
-            return Optional.of(Errors.from("Query param [gatewayAccountId] must be numeric"));
-        }
         return Optional.empty();
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceRequestValidatorTest.java
@@ -25,7 +25,7 @@ public class ServiceRequestValidatorTest {
     private ServiceRequestValidator serviceRequestValidator = new ServiceRequestValidator(new RequestValidations());
 
     @Test
-    public void shouldSuccess_whenUpdate_whenAllFieldPresentAndValid() throws Exception {
+    public void shouldSuccess_whenUpdate_whenAllFieldPresentAndValid() {
         ImmutableMap<String, String> payload = ImmutableMap.of("path", "name", "op", "replace", "value", "example-name");
 
         Optional<Errors> errors = serviceRequestValidator.validateUpdateAttributeRequest(mapper.valueToTree(payload));
@@ -33,6 +33,12 @@ public class ServiceRequestValidatorTest {
         assertFalse(errors.isPresent());
     }
 
+    @Test
+    public void shouldAllowNonNumericGatewayAccounts_whenFindingServices() {
+        Optional<Errors> errors = serviceRequestValidator.validateFindRequest("non-numeric-id");
+        assertThat(errors.isPresent(), is(false));
+    }
+    
     @Test
     public void shouldFail_whenUpdate_whenServiceNameFieldPresentAndItIsTooLong() throws Exception {
         ImmutableMap<String, String> payload = ImmutableMap.of("path", "name", "op", "replace", "value", RandomStringUtils.randomAlphanumeric(51));
@@ -46,7 +52,7 @@ public class ServiceRequestValidatorTest {
     }
 
     @Test
-    public void shouldFail_whenUpdate_whenMissingRequiredField() throws Exception {
+    public void shouldFail_whenUpdate_whenMissingRequiredField() {
         ImmutableMap<String, String> payload = ImmutableMap.of("value", "example-name");
 
         Optional<Errors> errors = serviceRequestValidator.validateUpdateAttributeRequest(mapper.valueToTree(payload));
@@ -59,7 +65,7 @@ public class ServiceRequestValidatorTest {
     }
 
     @Test
-    public void shouldFail_whenUpdate_whenInvalidPath() throws Exception {
+    public void shouldFail_whenUpdate_whenInvalidPath() {
         ImmutableMap<String, String> payload = ImmutableMap.of("path", "xyz", "op", "replace", "value", "example-name");
 
         Optional<Errors> errors = serviceRequestValidator.validateUpdateAttributeRequest(mapper.valueToTree(payload));
@@ -71,7 +77,7 @@ public class ServiceRequestValidatorTest {
     }
 
     @Test
-    public void shouldFail_whenUpdate_whenInvalidOperationForSuppliedPath() throws Exception {
+    public void shouldFail_whenUpdate_whenInvalidOperationForSuppliedPath() {
         ImmutableMap<String, String> payload = ImmutableMap.of("path", "name", "op", "add", "value", "example-name");
 
         Optional<Errors> errors = serviceRequestValidator.validateUpdateAttributeRequest(mapper.valueToTree(payload));

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceFindTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceFindTest.java
@@ -66,19 +66,7 @@ public class ServiceResourceFindTest extends IntegrationTest {
     }
 
     @Test
-    public void shouldError_whenFindByGatewayAccountId_ifIdNotNumeric() throws Exception {
-
-        givenSetup()
-                .when()
-                .accept(JSON)
-                .get(format("/v1/api/services?gatewayAccountId=%s", "some-id"))
-                .then()
-                .statusCode(400);
-
-    }
-
-    @Test
-    public void shouldReturn404_whenFindByGatewayAccountId_ifNotFound() throws Exception {
+    public void shouldReturn404_whenFindByGatewayAccountId_ifNotFound() {
 
         givenSetup()
                 .when()


### PR DESCRIPTION
 - We were assuming that gateway account ids are numeric. This has changed
   since introducing Direct Debit. We need to allow searching by external
   gateway account id, so this PR removes the validation rules which requires
   ids to be numeric.