### PR TITLE
PP-3713 Update direct debit email personalisation

### DIFF
--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceRequestValidatorTest.java
@@ -29,7 +29,6 @@ public class ServiceRequestValidatorTest {
         ImmutableMap<String, String> payload = ImmutableMap.of("path", "name", "op", "replace", "value", "example-name");
 
         Optional<Errors> errors = serviceRequestValidator.validateUpdateAttributeRequest(mapper.valueToTree(payload));
-
         assertFalse(errors.isPresent());
     }
 
@@ -40,7 +39,7 @@ public class ServiceRequestValidatorTest {
     }
     
     @Test
-    public void shouldFail_whenUpdate_whenServiceNameFieldPresentAndItIsTooLong() throws Exception {
+    public void shouldFail_whenUpdate_whenServiceNameFieldPresentAndItIsTooLong()  {
         ImmutableMap<String, String> payload = ImmutableMap.of("path", "name", "op", "replace", "value", RandomStringUtils.randomAlphanumeric(51));
 
         Optional<Errors> errors = serviceRequestValidator.validateUpdateAttributeRequest(mapper.valueToTree(payload));

--- a/src/test/java/uk/gov/pay/adminusers/service/EmailServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/EmailServiceTest.java
@@ -96,9 +96,9 @@ public class EmailServiceTest {
         assertThat(allContent.get("field 1"), is("theValueOfField1"));
         assertThat(allContent.get("field 2"), is("theValueOfField2"));
         assertThat(allContent.get("service name"), is("a service"));
-        assertThat(allContent.get("merchant address"), is("merchant name, address line 1, city, postcode, cake"));
-        assertThat(allContent.get("merchant phone number"), is(TELEPHONE_NUMBER));
-        assertThat(allContent.get("merchant email"), is(MERCHANT_EMAIL));
+        assertThat(allContent.get("organisation address"), is("merchant name, address line 1, city, postcode, cake"));
+        assertThat(allContent.get("organisation phone number"), is(TELEPHONE_NUMBER));
+        assertThat(allContent.get("organisation email address"), is(MERCHANT_EMAIL));
     }
 
     @Test
@@ -130,8 +130,8 @@ public class EmailServiceTest {
         Map<String, String> allContent = personalisationCaptor.getValue();
         assertThat(allContent.get("field 1"), is("theValueOfField1"));
         assertThat(allContent.get("field 2"), is("theValueOfField2"));
-        assertThat(allContent.get("org name"), is(MERCHANT_NAME));
-        assertThat(allContent.get("org phone"), is(TELEPHONE_NUMBER));
+        assertThat(allContent.get("organisation name"), is(MERCHANT_NAME));
+        assertThat(allContent.get("organisation phone number"), is(TELEPHONE_NUMBER));
     }
 
     @Test
@@ -163,9 +163,9 @@ public class EmailServiceTest {
         Map<String, String> allContent = personalisationCaptor.getValue();
         assertThat(allContent.get("field 1"), is("theValueOfField1"));
         assertThat(allContent.get("field 2"), is("theValueOfField2"));
-        assertThat(allContent.get("org name"), is(MERCHANT_NAME));
-        assertThat(allContent.get("org phone"), is(TELEPHONE_NUMBER));
-        assertThat(allContent.get("merchant email"), is(MERCHANT_EMAIL));
+        assertThat(allContent.get("organisation name"), is(MERCHANT_NAME));
+        assertThat(allContent.get("organisation phone number"), is(TELEPHONE_NUMBER));
+        assertThat(allContent.get("organisation email address"), is(MERCHANT_EMAIL));
     }
 
     @Test


### PR DESCRIPTION
 - General renaming and sanity check of variables. Turns out adminusers will always send service name and merchant details along with the email, so this simplifies things quite a bit.