### PR TITLE
BAU: Add services/list endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/persistence/dao/ServiceDao.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/dao/ServiceDao.java
@@ -19,6 +19,13 @@ public class ServiceDao extends JpaDao<ServiceEntity> {
         super(entityManager, ServiceEntity.class);
     }
 
+    public List<ServiceEntity> listAll() {
+        String query = "SELECT s FROM ServiceEntity as s";
+        return entityManager.get()
+                .createQuery(query, ServiceEntity.class)
+                .getResultList();
+    }
+
     public Optional<ServiceEntity> findByGatewayAccountId(String gatewayAccountId) {
 
         String query = "SELECT ga FROM GatewayAccountIdEntity ga " +

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
@@ -73,6 +73,20 @@ public class ServiceResource {
     }
 
     @GET
+    @Path("/list")
+    @Produces(APPLICATION_JSON)
+    public Response getServices() {
+        LOGGER.info("Get Services request");
+        return Response
+          .status(OK)
+          .entity(
+            serviceDao.listAll().stream().map(
+              serviceEntity -> linksBuilder.decorate(serviceEntity.toService())
+            ).collect(Collectors.toList())
+          ).build();
+    }
+
+    @GET
     @Path("/{serviceExternalId}")
     @Produces(APPLICATION_JSON)
     public Response findService(@PathParam("serviceExternalId") String serviceExternalId) {


### PR DESCRIPTION
This endpoint gets all the services.

IMO It should be implemented as:
```
/services
```

but instead it has to be implemented as:
```
/services/list
```
(we should never have a service id which is `list`)

This is because the current `/services` endpoint is a find endpoint that
returns a single service (when you pass in `gatewayAccountId` as a query
param)

I feel like the path I chose is the lesser of two evils.

solo @tlwr