### PR TITLE
PP-3842: Upgrade pact jvm provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
         <dependency>
             <groupId>au.com.dius</groupId>
             <artifactId>pact-jvm-provider-junit_2.12</artifactId>
-            <version>3.5.14</version>
+            <version>3.5.18</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Upgrading so pact verification don't get published by default. See
https://github.com/DiUS/pact-jvm/issues/695. This is to prevent development
machines from accidentally publishing verifications to the pact broker.

@oswaldquek