### PR TITLE
PP-3937: Upgrade Dropwizard from 1.2.7 to 1.2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>pay-adminusers</artifactId>
 
     <properties>
-        <dropwizard.version>1.2.7</dropwizard.version>
+        <dropwizard.version>1.2.8</dropwizard.version>
         <hamcrest.version>1.3</hamcrest.version>
         <eclipselink.version>2.6.4</eclipselink.version>
         <guice.version>4.1.0</guice.version>


### PR DESCRIPTION
This upgrades Jetty from 9.4.10 to 9.4.11