### PR TITLE
PP-3959 Do not return not found when an empty body suffices

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
@@ -106,11 +106,7 @@ public class UserResource {
 
         List<User> users = userServices.findUsersByExternalIds(externalIdsList);
 
-        if (users.size() == externalIdsList.size()) {
-            return Response.status(OK).type(APPLICATION_JSON).entity(users).build();
-        } else {
-            return Response.status(NOT_FOUND).build();
-        }
+        return Response.status(OK).type(APPLICATION_JSON).entity(users).build();
     }
 
     @Path(USERS_RESOURCE)


### PR DESCRIPTION
 - We can now have duplicated external ids in the list, so returning not found is not a great ideas as it will always return not found if the same user has issued multiple refunds