### PR TITLE
PP-4082: Refresh database

### DIFF
--- a/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
@@ -398,4 +398,8 @@ public class DatabaseTestHelper {
         serviceEntity.getServiceName().forEach(name -> addServiceName(name, serviceEntity.getId()));
         return this;
     }
+
+    public void truncateAllData() {
+        jdbi.withHandle(handle -> handle.createStatement("TRUNCATE TABLE users CASCADE").execute());
+    }
 }


### PR DESCRIPTION
Because we need to run the contract tests multiple times (using pacts tagged
with 'master', 'test', 'staging' and 'production') we need to refresh the
database by deleting data, otherwise provider states like "a user exists with
the given external id 7d19aff33f8948deb97ed16b2912dcd3" (see
UsersApiContractTest.java) would fail on the next re-run.

@oswaldquek