### PR TITLE
PP-4095 Refactor service update attribute request validation

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
@@ -1,34 +1,19 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.google.common.collect.ImmutableMap;
-import org.slf4j.Logger;
 import uk.gov.pay.adminusers.exception.ValidationException;
-import uk.gov.pay.adminusers.logger.PayLoggerFactory;
 import uk.gov.pay.adminusers.utils.Errors;
 import uk.gov.pay.adminusers.validations.RequestValidations;
 
 import javax.inject.Inject;
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
-import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static uk.gov.pay.adminusers.model.ServiceUpdateRequest.FIELD_OP;
-import static uk.gov.pay.adminusers.model.ServiceUpdateRequest.FIELD_PATH;
-import static uk.gov.pay.adminusers.model.ServiceUpdateRequest.FIELD_VALUE;
-
 
 public class ServiceRequestValidator {
-
-    private static final Logger LOGGER = PayLoggerFactory.getLogger(ServiceRequestValidator.class);
-
+    
     public static final String FIELD_NAME = "name";
     public static final String FIELD_GATEWAY_ACCOUNT_IDS = "gateway_account_ids";
     public static final String FIELD_CUSTOM_BRANDING = "custom_branding";
@@ -39,49 +24,28 @@ public class ServiceRequestValidator {
     static final String FIELD_MERCHANT_DETAILS_ADDRESS_COUNTRY = "address_country";
     static final String FIELD_MERCHANT_DETAILS_EMAIL = "email";
     public static final String FIELD_SERVICE_SERVICE_NAME = "service_name";
-    private static final String STRING_REPLACE = "replace";
-    private static final String STRING_ADD = "add";
-    private static final int SERVICE_NAME_MAX_LENGTH = 50;
     private static final int FIELD_MERCHANT_DETAILS_EMAIL_MAX_LENGTH = 255;
-    private static final Map<String, List<String>> VALID_ATTRIBUTE_UPDATE_OPERATIONS = ImmutableMap.of(
-            FIELD_NAME, Collections.singletonList(STRING_REPLACE),
-            FIELD_GATEWAY_ACCOUNT_IDS, Collections.singletonList(STRING_ADD),
-            FIELD_CUSTOM_BRANDING, Collections.singletonList(STRING_REPLACE),
-            FIELD_SERVICE_SERVICE_NAME, Collections.singletonList(STRING_REPLACE));
 
     private final RequestValidations requestValidations;
+    private final ServiceUpdateOperationValidator serviceUpdateOperationValidator;
 
     @Inject
-    public ServiceRequestValidator(RequestValidations requestValidations) {
+    public ServiceRequestValidator(RequestValidations requestValidations, ServiceUpdateOperationValidator serviceUpdateOperationValidator) {
         this.requestValidations = requestValidations;
+        this.serviceUpdateOperationValidator = serviceUpdateOperationValidator;
     }
 
     Optional<Errors> validateUpdateAttributeRequest(JsonNode payload) {
-
-        JsonNode operations;
-        try {
-            operations = new ObjectMapper().readTree(payload.toString());
-            if (!operations.isArray()) {
-                operations = new ObjectMapper().createArrayNode();
-                ((ArrayNode) operations).add(payload);
+        List<String> errors = new ArrayList<>();
+        if (!payload.isArray()) {
+            errors  = serviceUpdateOperationValidator.validate(payload);
+        } else {
+            for (JsonNode updateOperation : payload) {
+                errors.addAll(serviceUpdateOperationValidator.validate(updateOperation));
             }
-        } catch (IOException e) {
-            LOGGER.error("There was an exception processing update request [{}]", e.getMessage());
-            return Optional.of(Errors.from("There was an error processing update request"));
         }
-
-        List<String> finalErrors = validateOpAndPathIfExistOrEmpty(operations);
-        if (!finalErrors.isEmpty()) {
-            return Optional.of(Errors.from(finalErrors));
-        }
-        finalErrors = validatePath(operations);
-        if (!finalErrors.isEmpty()) {
-            return Optional.of(Errors.from(finalErrors));
-        }
-        finalErrors = validateOperations(operations);
-
-        if (!finalErrors.isEmpty()) {
-            return Optional.of(Errors.from(finalErrors));
+        if (!errors.isEmpty()) {
+            return Optional.of(Errors.from(errors));
         }
         return Optional.empty();
     }
@@ -121,55 +85,4 @@ public class ServiceRequestValidator {
         return Optional.empty();
     }
 
-    private static List<String> checkIfValidJson(JsonNode payload, String fieldName) {
-        if (payload == null || !payload.isObject()) {
-            return Collections.singletonList(format("Value for path [%s] must be a JSON", fieldName));
-        }
-        return Collections.emptyList();
-    }
-
-    private static List<String> validateOperations(JsonNode operations) {
-        List<String> finalErrors = new ArrayList<>();
-        operations.forEach(item -> {
-            String path = item.get(FIELD_PATH).asText();
-
-            if (!VALID_ATTRIBUTE_UPDATE_OPERATIONS.keySet().contains(path)) {
-                finalErrors.add(format("Path [%s] is invalid", path));
-                return;
-            }
-
-            String op = item.get("op").asText();
-            if (!VALID_ATTRIBUTE_UPDATE_OPERATIONS.get(path).contains(op)) {
-                finalErrors.add(format("Operation [%s] is invalid for path [%s]", op, path));
-            }
-        });
-
-        return finalErrors;
-    }
-
-    private List<String> validatePath(JsonNode operations) {
-        List<String> finalErrors = new ArrayList<>();
-        operations.forEach(item -> {
-            String path = item.get(FIELD_PATH).asText();
-
-            if (FIELD_CUSTOM_BRANDING.equals(path)) {
-                finalErrors.addAll(checkIfValidJson(item.get(FIELD_VALUE), FIELD_CUSTOM_BRANDING));
-            } else if (FIELD_NAME.equals(path)) {
-                requestValidations.checkIfExistsOrEmpty(item, FIELD_VALUE).ifPresent(finalErrors::addAll);
-                if (finalErrors.isEmpty()) {
-                    requestValidations.checkMaxLength(item, SERVICE_NAME_MAX_LENGTH, FIELD_VALUE).ifPresent(finalErrors::addAll);
-                }
-            }
-        });
-
-        return finalErrors;
-    }
-
-    private List<String> validateOpAndPathIfExistOrEmpty(JsonNode operations) {
-        List<String> finalErrors = new ArrayList<>();
-        operations.forEach(item ->
-                requestValidations.checkIfExistsOrEmpty(item, FIELD_OP, FIELD_PATH).ifPresent(finalErrors::addAll));
-
-        return finalErrors;
-    }
 }

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
@@ -1,0 +1,107 @@
+package uk.gov.pay.adminusers.resources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import uk.gov.pay.adminusers.validations.RequestValidations;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.String.format;
+import static uk.gov.pay.adminusers.model.ServiceUpdateRequest.FIELD_OP;
+import static uk.gov.pay.adminusers.model.ServiceUpdateRequest.FIELD_PATH;
+import static uk.gov.pay.adminusers.model.ServiceUpdateRequest.FIELD_VALUE;
+
+public class ServiceUpdateOperationValidator {
+    
+    static final String FIELD_NAME = "name";
+    static final String FIELD_GATEWAY_ACCOUNT_IDS = "gateway_account_ids";
+    static final String FIELD_CUSTOM_BRANDING = "custom_branding";
+    static final String FIELD_SERVICE_NAME = "service_name";
+    
+    private static final String REPLACE = "replace";
+    private static final String ADD = "add";
+    
+    private static final int SERVICE_NAME_MAX_LENGTH = 50;
+    
+    private static final Map<String, List<String>> VALID_ATTRIBUTE_UPDATE_OPERATIONS = ImmutableMap.of(
+            FIELD_NAME, Collections.singletonList(REPLACE),
+            FIELD_GATEWAY_ACCOUNT_IDS, Collections.singletonList(ADD),
+            FIELD_CUSTOM_BRANDING, Collections.singletonList(REPLACE),
+            FIELD_SERVICE_NAME, Collections.singletonList(REPLACE));
+
+    private final RequestValidations requestValidations;
+
+    @Inject
+    public ServiceUpdateOperationValidator(RequestValidations requestValidations) {
+        this.requestValidations = requestValidations;
+    }
+
+    List<String> validate(JsonNode operation) {
+        List<String> errors = validateOpAndPathExistAndNotEmpty(operation);
+        if (!errors.isEmpty()) {
+            return errors;
+        }
+
+        errors = validateValueIsValidForPath(operation);
+        if (!errors.isEmpty()) {
+            return errors;
+        }
+
+        errors = validateOperationIsValidForPath(operation);
+        if (!errors.isEmpty()) {
+            return errors;
+        }
+
+        return Collections.emptyList();
+    }
+
+    private List<String> validateOpAndPathExistAndNotEmpty(JsonNode operation) {
+        List<String> errors = new ArrayList<>();
+        requestValidations.checkIfExistsOrEmpty(operation, FIELD_OP, FIELD_PATH).ifPresent(errors::addAll);
+        return errors;
+    }
+
+    private List<String> validateValueIsValidForPath(JsonNode operation) {
+        List<String> errors = new ArrayList<>();
+
+        String path = operation.get(FIELD_PATH).asText();
+
+        if (FIELD_CUSTOM_BRANDING.equals(path)) {
+            errors.addAll(checkIfValidJson(operation.get(FIELD_VALUE), FIELD_CUSTOM_BRANDING));
+        } else if (FIELD_NAME.equals(path)) {
+            requestValidations.checkIfExistsOrEmpty(operation, FIELD_VALUE).ifPresent(errors::addAll);
+            if (errors.isEmpty()) {
+                requestValidations.checkMaxLength(operation, SERVICE_NAME_MAX_LENGTH, FIELD_VALUE).ifPresent(errors::addAll);
+            }
+        }
+
+        return errors;
+    }
+
+    private static List<String> validateOperationIsValidForPath(JsonNode operation) {
+        String path = operation.get(FIELD_PATH).asText();
+
+        if (!VALID_ATTRIBUTE_UPDATE_OPERATIONS.keySet().contains(path)) {
+            return Collections.singletonList(format("Path [%s] is invalid", path));
+        }
+
+        String op = operation.get("op").asText();
+        if (!VALID_ATTRIBUTE_UPDATE_OPERATIONS.get(path).contains(op)) {
+            return Collections.singletonList(format("Operation [%s] is invalid for path [%s]", op, path));
+        }
+
+        return Collections.emptyList();
+    }
+
+    private static List<String> checkIfValidJson(JsonNode payload, String fieldName) {
+        if (payload == null || !payload.isObject()) {
+            return Collections.singletonList(format("Value for path [%s] must be a JSON", fieldName));
+        }
+        return Collections.emptyList();
+    }
+
+}

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
@@ -1,0 +1,118 @@
+package uk.gov.pay.adminusers.resources;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Test;
+import uk.gov.pay.adminusers.validations.RequestValidations;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class ServiceUpdateOperationValidatorTest {
+
+    private ObjectMapper mapper = new ObjectMapper();
+    private ServiceUpdateOperationValidator serviceUpdateOperationValidator = new ServiceUpdateOperationValidator(new RequestValidations());
+
+    @Test
+    public void shouldSuccess_whenUpdate_withAllFieldsPresentAndValid() {
+        ImmutableMap<String, String> payload = ImmutableMap.of("path", "name", "op", "replace", "value", "example-name");
+
+        List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
+        
+        assertThat(errors.isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldFail_whenUpdate_whenServiceNameFieldPresentAndItIsTooLong() {
+        ImmutableMap<String, String> payload = ImmutableMap.of("path", "name", "op", "replace", "value", RandomStringUtils.randomAlphanumeric(51));
+
+        List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
+
+        assertThat(errors.size(), is(1));
+        assertThat(errors, hasItem("Field [value] must have a maximum length of 50 characters"));
+    }
+
+    @Test
+    public void shouldFail_whenUpdate_whenMissingRequiredField() {
+        ImmutableMap<String, String> payload = ImmutableMap.of("value", "example-name");
+
+        List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
+
+        assertThat(errors.size(), is(2));
+        assertThat(errors, hasItem("Field [path] is required"));
+        assertThat(errors, hasItem("Field [op] is required"));
+    }
+
+    @Test
+    public void shouldFail_whenUpdate_whenInvalidPath() {
+        ImmutableMap<String, String> payload = ImmutableMap.of("path", "xyz", "op", "replace", "value", "example-name");
+
+        List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
+
+        assertThat(errors.size(), is(1));
+        assertThat(errors, hasItem("Path [xyz] is invalid"));
+    }
+
+    @Test
+    public void shouldFail_whenUpdate_whenInvalidOperationForSuppliedPath() {
+        ImmutableMap<String, String> payload = ImmutableMap.of("path", "name", "op", "add", "value", "example-name");
+
+        List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
+
+        assertThat(errors.size(), is(1));
+        assertThat(errors, hasItem("Operation [add] is invalid for path [name]"));
+    }
+    
+    @Test
+    public void shouldSuccess_replacingCustomBranding() {
+        ImmutableMap<String, Object> payload = ImmutableMap.of("path", "custom_branding", "op", "replace", "value", ImmutableMap.of("image_url", "image url", "css_url", "css url"));
+
+        List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
+
+        assertThat(errors.isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldSuccess_replacingCustomBranding_forEmptyObject() {
+        ImmutableMap<String, Object> payload = ImmutableMap.of("path", "custom_branding", "op", "replace", "value", ImmutableMap.of());
+
+        List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
+
+        assertThat(errors.isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldError_ifCustomBrandingIsEmptyString() {
+        ImmutableMap<String, String> payload = ImmutableMap.of("path", "custom_branding", "op", "replace", "value", "");
+
+        List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
+
+        assertThat(errors.size(), is(1));
+        assertThat(errors, hasItem("Value for path [custom_branding] must be a JSON"));
+    }
+
+    @Test
+    public void shouldError_ifCustomBrandingIsNull() {
+        ImmutableMap<String, String> payload = ImmutableMap.of("path", "custom_branding", "op", "replace");
+
+        List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
+
+        assertThat(errors.size(), is(1));
+        assertThat(errors, hasItem("Value for path [custom_branding] must be a JSON"));
+    }
+
+    @Test
+    public void shouldError_replacingCustomBranding_ifValueIsNotJSON() {
+        ImmutableMap<String, String> payload = ImmutableMap.of("path", "custom_branding", "op", "replace", "value", "&*£&^(P%£");
+
+        List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
+
+        assertThat(errors.size(), is(1));
+        assertThat(errors, hasItem("Value for path [custom_branding] must be a JSON"));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceCreateTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceCreateTest.java
@@ -18,6 +18,7 @@ import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
 import uk.gov.pay.adminusers.persistence.entity.service.SupportedLanguage;
 import uk.gov.pay.adminusers.resources.ServiceRequestValidator;
 import uk.gov.pay.adminusers.resources.ServiceResource;
+import uk.gov.pay.adminusers.resources.ServiceUpdateOperationValidator;
 import uk.gov.pay.adminusers.service.ServiceCreator;
 import uk.gov.pay.adminusers.service.ServiceServicesFactory;
 import uk.gov.pay.adminusers.validations.RequestValidations;
@@ -57,8 +58,10 @@ public class ServiceResourceCreateTest extends ServiceResourceBaseTest {
 
     private static ServiceCreator serviceCreator = new ServiceCreator(mockedServiceDao, linksBuilder);
     private static ServiceCreator mockedServiceCreator = mock(ServiceCreator.class);
-    private static ServiceRequestValidator serviceRequestValidator = new ServiceRequestValidator(new RequestValidations());
 
+    private static RequestValidations requestValidations = new RequestValidations();
+    private static ServiceRequestValidator serviceRequestValidator = new ServiceRequestValidator(requestValidations, new ServiceUpdateOperationValidator(requestValidations));
+    
     @ClassRule
     public static final ResourceTestRule resources = ResourceTestRule.builder()
             .addResource(new ServiceResource(mockedUserDao, mockedServiceDao, linksBuilder, serviceRequestValidator, mockedServicesFactory))

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceFindTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceFindTest.java
@@ -42,7 +42,7 @@ public class ServiceResourceFindTest extends ServiceResourceBaseTest {
     private static ServiceServicesFactory mockedServicesFactory = mock(ServiceServicesFactory.class);
 
     private static ServiceFinder serviceFinder = new ServiceFinder(mockedServiceDao, linksBuilder);
-    private static ServiceRequestValidator serviceRequestValidator = new ServiceRequestValidator(new RequestValidations());
+    private static ServiceRequestValidator serviceRequestValidator = new ServiceRequestValidator(new RequestValidations(), null);
 
     @ClassRule
     public static final ResourceTestRule resources = ResourceTestRule.builder()

--- a/src/test/resources/fixtures/resource/service/patch/update-name-only-single-object.json
+++ b/src/test/resources/fixtures/resource/service/patch/update-name-only-single-object.json
@@ -1,0 +1,5 @@
+{
+  "op": "replace",
+  "path": "name",
+  "value": "new-en-name"
+}


### PR DESCRIPTION
When the update service attribute endpoint was changed to also accept an array of objects rather than just a single object, the `ServiceRequestValidator.validateUpdateAttributeRequest` method was modified to figure out if it was passed an array and validate every element in the array if so. This made the `ServiceRequestValidator` more complex. This commit simplifies things somewhat by doing the following (this is a conceptual description of a series of changes; the final result melds them all in to one):

- Change `ServiceRequestValidator.validateUpdateAttributeRequest` so it no longer tries to handle an array and assumes it just has a single object

- Move `ServiceRequestValidator.validateUpdateAttributeRequest` and its dependent private methods out in to its own `ServiceUpdateOperationValidator` class

- Change the old `ServiceRequestValidator.validateUpdateAttributeRequest` so that calls the new `ServiceUpdateOperationValidator.validate` method if it receives an object. If it receives an array, it calls that method repeatedly, once for each object in the array.

This does not (should not!) change the actual validation that’s performed but it changes the order of the checks performed on an array, which will change the errors that are returned in some cases.