### PR TITLE
PP-4096 Change the API for multilingual service name updates

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
@@ -13,17 +13,13 @@ import java.util.Optional;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public class ServiceRequestValidator {
-    
-    public static final String FIELD_NAME = "name";
-    public static final String FIELD_GATEWAY_ACCOUNT_IDS = "gateway_account_ids";
-    public static final String FIELD_CUSTOM_BRANDING = "custom_branding";
+
     static final String FIELD_MERCHANT_DETAILS_NAME = "name";
     static final String FIELD_MERCHANT_DETAILS_ADDRESS_LINE1 = "address_line1";
     static final String FIELD_MERCHANT_DETAILS_ADDRESS_CITY = "address_city";
     static final String FIELD_MERCHANT_DETAILS_ADDRESS_POSTCODE = "address_postcode";
     static final String FIELD_MERCHANT_DETAILS_ADDRESS_COUNTRY = "address_country";
     static final String FIELD_MERCHANT_DETAILS_EMAIL = "email";
-    public static final String FIELD_SERVICE_SERVICE_NAME = "service_name";
     private static final int FIELD_MERCHANT_DETAILS_EMAIL_MAX_LENGTH = 255;
 
     private final RequestValidations requestValidations;

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
@@ -45,9 +45,9 @@ import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static uk.gov.pay.adminusers.resources.ServiceRequestValidator.FIELD_GATEWAY_ACCOUNT_IDS;
-import static uk.gov.pay.adminusers.resources.ServiceRequestValidator.FIELD_NAME;
 import static uk.gov.pay.adminusers.resources.ServiceResource.SERVICES_RESOURCE;
+import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_GATEWAY_ACCOUNT_IDS;
+import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_NAME;
 
 @Path(SERVICES_RESOURCE)
 public class ServiceResource {

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.adminusers.service;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 import uk.gov.pay.adminusers.exception.ServiceNotFoundException;
@@ -10,32 +11,37 @@ import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
 import uk.gov.pay.adminusers.persistence.entity.MerchantDetailsEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
+import uk.gov.pay.adminusers.persistence.entity.service.SupportedLanguage;
 
+import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
-import static uk.gov.pay.adminusers.resources.ServiceRequestValidator.FIELD_CUSTOM_BRANDING;
-import static uk.gov.pay.adminusers.resources.ServiceRequestValidator.FIELD_GATEWAY_ACCOUNT_IDS;
-import static uk.gov.pay.adminusers.resources.ServiceRequestValidator.FIELD_NAME;
-import static uk.gov.pay.adminusers.resources.ServiceRequestValidator.FIELD_SERVICE_SERVICE_NAME;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.conflictingServiceGatewayAccounts;
 
 public class ServiceUpdater {
+ 
+    public static final String FIELD_NAME = "name";
+    public static final String FIELD_GATEWAY_ACCOUNT_IDS = "gateway_account_ids";
+    public static final String FIELD_CUSTOM_BRANDING = "custom_branding";
+    public static final String FIELD_SERVICE_NAME_PREFIX = "service_name";
+
     private final ServiceDao serviceDao;
 
-    private final Map<String, BiConsumer<ServiceUpdateRequest, ServiceEntity>> attributeUpdaters = new HashMap<String, BiConsumer<ServiceUpdateRequest, ServiceEntity>>() {{
-        put(FIELD_NAME, updateServiceName());
-        put(FIELD_GATEWAY_ACCOUNT_IDS, assignGatewayAccounts());
-        put(FIELD_CUSTOM_BRANDING, updateCustomBranding());
-        put(FIELD_SERVICE_SERVICE_NAME, updateServiceNameObject());
-    }};
+    private final Map<String, BiConsumer<ServiceUpdateRequest, ServiceEntity>> attributeUpdaters;
 
     @Inject
     public ServiceUpdater(ServiceDao serviceDao) {
+        ImmutableMap.Builder<String, BiConsumer<ServiceUpdateRequest, ServiceEntity>> attributeUpdaters = ImmutableMap.builder();
+        attributeUpdaters.put(FIELD_NAME, updateServiceName());
+        attributeUpdaters.put(FIELD_GATEWAY_ACCOUNT_IDS, assignGatewayAccounts());
+        attributeUpdaters.put(FIELD_CUSTOM_BRANDING, updateCustomBranding());
+        Arrays.stream(SupportedLanguage.values())
+                .forEach(language -> attributeUpdaters.put(FIELD_SERVICE_NAME_PREFIX + '/' + language.toString(), updateMultilingualServiceName()));
+        this.attributeUpdaters = attributeUpdaters.build();
         this.serviceDao = serviceDao;
     }
 
@@ -87,9 +93,12 @@ public class ServiceUpdater {
         return (serviceUpdateRequest, serviceEntity) -> serviceEntity.setCustomBranding(serviceUpdateRequest.valueAsObject());
     }
 
-    private BiConsumer<ServiceUpdateRequest, ServiceEntity> updateServiceNameObject() {
+    private BiConsumer<ServiceUpdateRequest, ServiceEntity> updateMultilingualServiceName() {
         return (serviceUpdateRequest, serviceEntity) -> {
-            ServiceNameEntity serviceNameEntity = ServiceNameEntity.from(serviceUpdateRequest);
+            String path = serviceUpdateRequest.getPath();
+            assert path.matches(FIELD_SERVICE_NAME_PREFIX + "/[a-z]+") : "Path must be 'service_name/en' etc.";
+            SupportedLanguage language = SupportedLanguage.fromIso639AlphaTwoCode(serviceUpdateRequest.getPath().substring(path.indexOf('/') + 1));
+            ServiceNameEntity serviceNameEntity = ServiceNameEntity.from(language, serviceUpdateRequest.valueAsString());
             serviceEntity.addOrUpdateServiceName(serviceNameEntity);
         };
     }

--- a/src/test/java/uk/gov/pay/adminusers/model/ServiceUpdateRequestTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/ServiceUpdateRequestTest.java
@@ -49,7 +49,7 @@ public class ServiceUpdateRequestTest {
         assertThat(requests.get(0).getPath(), is("name"));
         assertThat(requests.get(0).getOp(), is("replace"));
 
-        assertThat(requests.get(1).getPath(), is("service_name"));
+        assertThat(requests.get(1).getPath(), is("service_name/cy"));
         assertThat(requests.get(1).getOp(), is("replace"));
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
@@ -14,11 +14,11 @@ import static org.hamcrest.core.Is.is;
 
 public class ServiceUpdateOperationValidatorTest {
 
-    private ObjectMapper mapper = new ObjectMapper();
-    private ServiceUpdateOperationValidator serviceUpdateOperationValidator = new ServiceUpdateOperationValidator(new RequestValidations());
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final ServiceUpdateOperationValidator serviceUpdateOperationValidator = new ServiceUpdateOperationValidator(new RequestValidations());
 
     @Test
-    public void shouldSuccess_whenUpdate_withAllFieldsPresentAndValid() {
+    public void shouldSuccess_whenUpdateName_withAllFieldsPresentAndValid() {
         ImmutableMap<String, String> payload = ImmutableMap.of("path", "name", "op", "replace", "value", "example-name");
 
         List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
@@ -27,8 +27,9 @@ public class ServiceUpdateOperationValidatorTest {
     }
 
     @Test
-    public void shouldFail_whenUpdate_whenServiceNameFieldPresentAndItIsTooLong() {
-        ImmutableMap<String, String> payload = ImmutableMap.of("path", "name", "op", "replace", "value", RandomStringUtils.randomAlphanumeric(51));
+    public void shouldFail_whenUpdateName_whenNameFieldPresentAndItIsTooLong() {
+        ImmutableMap<String, String> payload = ImmutableMap.of("path", "name", "op", "replace",
+                "value", RandomStringUtils.randomAlphanumeric(51));
 
         List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
 
@@ -69,7 +70,8 @@ public class ServiceUpdateOperationValidatorTest {
     
     @Test
     public void shouldSuccess_replacingCustomBranding() {
-        ImmutableMap<String, Object> payload = ImmutableMap.of("path", "custom_branding", "op", "replace", "value", ImmutableMap.of("image_url", "image url", "css_url", "css url"));
+        ImmutableMap<String, Object> payload = ImmutableMap.of("path", "custom_branding", "op", "replace",
+                "value", ImmutableMap.of("image_url", "image url", "css_url", "css url"));
 
         List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
 
@@ -113,6 +115,36 @@ public class ServiceUpdateOperationValidatorTest {
 
         assertThat(errors.size(), is(1));
         assertThat(errors, hasItem("Value for path [custom_branding] must be a JSON"));
+    }
+
+    @Test
+    public void shouldSuccess_whenUpdateServiceName_withAllFieldsPresentAndValid() {
+        ImmutableMap<String, String> payload = ImmutableMap.of("path", "service_name/en", "op", "replace", "value", "example-name");
+
+        List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
+
+        assertThat(errors.isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldFail_whenUpdateServiceName_whenServiceNameFieldPresentAndItIsTooLong() {
+        ImmutableMap<String, String> payload = ImmutableMap.of("path", "service_name/en", "op", "replace",
+                "value", RandomStringUtils.randomAlphanumeric(51));
+
+        List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
+
+        assertThat(errors.size(), is(1));
+        assertThat(errors, hasItem("Field [value] must have a maximum length of 50 characters"));
+    }
+
+    @Test
+    public void shouldFail_whenUpdateServiceName_whenPathContainsUnsupportedLanguage() {
+        ImmutableMap<String, String> payload = ImmutableMap.of("path", "service_name/xx", "op", "replace", "value", "example-name");
+
+        List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
+
+        assertThat(errors.size(), is(1));
+        assertThat(errors, hasItem("Path [service_name/xx] is invalid"));
     }
 
 }

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceUpdaterTest.java
@@ -7,7 +7,6 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
-import org.mockito.Mockito;
 import uk.gov.pay.adminusers.exception.ServiceNotFoundException;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.ServiceUpdateRequest;
@@ -196,12 +195,12 @@ public class ServiceUpdaterTest {
     }
 
     @Test
-    public void shouldUpdateServiceNameSuccessfully() {
+    public void shouldUpdateMultilingualServiceNameSuccessfully() {
         String serviceId = randomUuid();
         String nameToUpdate = "new-cy-name";
         ServiceUpdateRequest request = ServiceUpdateRequest.from(new ObjectNode(JsonNodeFactory.instance, ImmutableMap.of(
-                "path", new TextNode("service_name"),
-                "value", new ObjectNode(JsonNodeFactory.instance, ImmutableMap.of("cy", new TextNode(nameToUpdate))),
+                "path", new TextNode("service_name/cy"),
+                "value", new TextNode(nameToUpdate),
                 "op", new TextNode("replace"))));
         ServiceEntity serviceEntity = mock(ServiceEntity.class);
 

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceCreateTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceCreateTest.java
@@ -44,9 +44,9 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static uk.gov.pay.adminusers.resources.ServiceRequestValidator.FIELD_GATEWAY_ACCOUNT_IDS;
-import static uk.gov.pay.adminusers.resources.ServiceRequestValidator.FIELD_NAME;
 import static uk.gov.pay.adminusers.resources.ServiceResource.SERVICES_RESOURCE;
+import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_GATEWAY_ACCOUNT_IDS;
+import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_NAME;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ServiceResourceCreateTest extends ServiceResourceBaseTest {

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceUpdateTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceUpdateTest.java
@@ -181,6 +181,33 @@ public class ServiceResourceUpdateTest extends ServiceResourceBaseTest {
     }
 
     @Test
+    public void shouldSuccess_whenUpdateOnlyEnAndCyName() {
+
+        ServiceEntity thisServiceEntity = ServiceEntityBuilder.aServiceEntity()
+                .withServiceNameEntity(SupportedLanguage.ENGLISH, "old-en-name")
+                .withServiceNameEntity(SupportedLanguage.WELSH, "old-cy-name")
+                .build();
+        String externalId = thisServiceEntity.getExternalId();
+
+        String jsonPayload = fixture("fixtures/resource/service/patch/update-en-and-cy-name-only.json");
+        when(mockedServiceDao.findByExternalId(externalId)).thenReturn(Optional.of(thisServiceEntity));
+        when(mockedServiceDao.merge(thisServiceEntity)).thenReturn(thisServiceEntity);
+
+        Response response = resources.target(format(API_PATH, thisServiceEntity.getExternalId()))
+                .request()
+                .method("PATCH", Entity.json(jsonPayload));
+
+        assertThat(response.getStatus(), is(200));
+
+        String body = response.readEntity(String.class);
+        JsonPath json = JsonPath.from(body);
+
+        assertThat(json.get("name"), is("new-en-name"));
+        assertEnServiceNameJson("new-en-name", json);
+        assertCyServiceNameJson("new-cy-name", json);
+    }
+
+    @Test
     public void shouldSuccess_whenUpdateOnlyEnName_andDifferentValuesAreSentInFieldsNameAndServiceName_thenLastOperationSucceeds() {
 
         ServiceEntity thisServiceEntity = ServiceEntityBuilder.aServiceEntity().build();

--- a/src/test/resources/fixtures/resource/service/patch/update-cy-name-only.json
+++ b/src/test/resources/fixtures/resource/service/patch/update-cy-name-only.json
@@ -1,9 +1,7 @@
 [
   {
     "op": "replace",
-    "path": "service_name",
-    "value": {
-      "cy": "new-cy-name"
-    }
+    "path": "service_name/cy",
+    "value": "new-cy-name"
   }
 ]

--- a/src/test/resources/fixtures/resource/service/patch/update-en-and-cy-name-only.json
+++ b/src/test/resources/fixtures/resource/service/patch/update-en-and-cy-name-only.json
@@ -1,7 +1,7 @@
 [
   {
     "op": "replace",
-    "path": "name",
+    "path": "service_name/en",
     "value": "new-en-name"
   },
   {

--- a/src/test/resources/fixtures/resource/service/patch/update-name-and-update-cy-name.json
+++ b/src/test/resources/fixtures/resource/service/patch/update-name-and-update-cy-name.json
@@ -6,9 +6,7 @@
   },
   {
     "op": "replace",
-    "path": "service_name",
-    "value": {
-      "cy": "new-cy-name"
-    }
+    "path": "service_name/cy",
+    "value": "new-cy-name"
   }
 ]

--- a/src/test/resources/fixtures/resource/service/patch/update-name-service-name-different-values.json
+++ b/src/test/resources/fixtures/resource/service/patch/update-name-service-name-different-values.json
@@ -6,9 +6,7 @@
   },
   {
     "op": "replace",
-    "path": "service_name",
-    "value": {
-      "en": "newer-en-name"
-    }
+    "path": "service_name/en",
+    "value": "newer-en-name"
   }
 ]


### PR DESCRIPTION
For updating the multilingual service name, we used to expect requests like this:

```json
[
  {
    "op": "replace",
    "path": "service_name",
    "value": {
      "en": "Rectify your renal records"
    }
  }
]
```

Now we expect requests like this:

```json
[
  {
    "op": "replace",
    "path": "service_name/en",
    "value": "Rectify your renal records"
  }
]
```

In addition to being more in line with [JSON Patch](http://jsonpatch.com/) (but note we are still not strictly compliant), this also makes it easier to change multiple language variants of the service name at once in a natural fashion:

```json
[
  {
    "op": "replace",
    "path": "service_name/en",
    "value": "Rectify your renal records"
  },
  {
    "op": "replace",
    "path": "service_name/cy",
    "value": "Addaswch eich cofnodion arennol"
  }
]
```

Furthermore, it makes it simple to reuse our existing validation for service names (no longer than 50 characters), so we do that now. We also now validate that the specified language is actually one we support.

Although this change breaks compatibility, it’s safe to do because nothing is using the other API yet (it’s an internal API, not a public one).