### PR TITLE
PP-4096 Do not return empty or blank multilingual service names

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/model/Service.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Service.java
@@ -8,6 +8,7 @@ import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +29,7 @@ public class Service {
     private List<String> gatewayAccountIds = new ArrayList<>();
     private Map<String, Object> customBranding;
     private MerchantDetails merchantDetails;
-    private Map<String, String> serviceNameMap = new LinkedHashMap<>();
+    private Map<String, String> serviceNames;
 
     public static Service from() {
         return from(DEFAULT_NAME_VALUE);
@@ -38,16 +39,29 @@ public class Service {
         return from(randomInt(), randomUuid(), name);
     }
 
+    public static Service from(String name, Map<SupportedLanguage, ServiceNameEntity> multilingualServiceNames) {
+        return from(randomInt(), randomUuid(), name, multilingualServiceNames);
+    }
+
     public static Service from(Integer id, String externalId, String name) {
-        return new Service(id, externalId, name);
+        return new Service(id, externalId, name, Collections.emptyMap());
+    }
+
+    public static Service from(Integer id, String externalId, String name, Map<SupportedLanguage, ServiceNameEntity> multilingualServiceNames) {
+        return new Service(id, externalId, name, multilingualServiceNames);
     }
 
     private Service(@JsonProperty("id") Integer id,
                     @JsonProperty("external_id") String externalId,
-                    @JsonProperty("name") String name) {
+                    @JsonProperty("name") String name,
+                    Map<SupportedLanguage, ServiceNameEntity> multilingualServiceNames) {
         this.id = id;
         this.externalId = externalId;
         this.name = name;
+
+        this.serviceNames = new LinkedHashMap<>();
+        serviceNames.put(SupportedLanguage.ENGLISH.toString(), name);
+        multilingualServiceNames.forEach((k, v) -> serviceNames.put(k.toString(), v.getName()));
     }
 
     public String getExternalId() {
@@ -116,12 +130,8 @@ public class Service {
     }
 
     @JsonProperty("service_name")
-    public Map<String, String> getServiceNameMap() {
-        return serviceNameMap;
+    public Map<String, String> getServiceNames() {
+        return serviceNames;
     }
 
-    public void setServiceNameMap(Map<SupportedLanguage, ServiceNameEntity> nameEntities) {
-        this.serviceNameMap.put(SupportedLanguage.ENGLISH.toString(), name);
-        nameEntities.forEach((k, v) -> this.serviceNameMap.put(k.toString(), v.getName()));
-    }
 }

--- a/src/main/java/uk/gov/pay/adminusers/model/Service.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Service.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
@@ -61,7 +62,9 @@ public class Service {
 
         this.serviceNames = new LinkedHashMap<>();
         serviceNames.put(SupportedLanguage.ENGLISH.toString(), name);
-        multilingualServiceNames.forEach((k, v) -> serviceNames.put(k.toString(), v.getName()));
+        multilingualServiceNames.entrySet().stream()
+                .filter(entry -> StringUtils.isNotBlank(entry.getValue().getName()))
+                .forEach(entry -> serviceNames.put(entry.getKey().toString(), entry.getValue().getName()));
     }
 
     public String getExternalId() {

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
@@ -125,7 +125,7 @@ public class ServiceEntity {
     }
 
     public Service toService() {
-        Service service = Service.from(id, externalId, name);
+        Service service = Service.from(id, externalId, name, getServiceNames());
         service.setGatewayAccountIds(gatewayAccountIds.stream()
                 .map(GatewayAccountIdEntity::getGatewayAccountId)
                 .collect(Collectors.toList()));
@@ -133,7 +133,6 @@ public class ServiceEntity {
         if (this.merchantDetailsEntity != null) {
             service.setMerchantDetails(this.merchantDetailsEntity.toMerchantDetails());
         }
-        service.setServiceNameMap(getServiceNames());
         return service;
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/model/ServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/ServiceTest.java
@@ -7,6 +7,7 @@ import uk.gov.pay.commons.model.SupportedLanguage;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
 
 public class ServiceTest {
 
@@ -18,6 +19,24 @@ public class ServiceTest {
         
         assertThat(service.getServiceNames().get(SupportedLanguage.ENGLISH.toString()), is("Service Name"));
         assertThat(service.getServiceNames().get(SupportedLanguage.WELSH.toString()), is("Welsh Service Name"));
+    }
+
+    @Test
+    public void setServiceNameMapWithEmptyWelshServiceNameDoesNotSetWelshServiceName() {
+        ServiceNameEntity welshServiceName = ServiceNameEntity.from(SupportedLanguage.WELSH, "");
+
+        Service service = Service.from("Service Name", ImmutableMap.of(SupportedLanguage.WELSH, welshServiceName));
+        
+        assertThat(service.getServiceNames().get(SupportedLanguage.WELSH.toString()), is(nullValue()));
+    }
+
+    @Test
+    public void setServiceNameMapWithBlankWelshServiceNameDoesNotSetWelshServiceName() {
+        ServiceNameEntity welshServiceName = ServiceNameEntity.from(SupportedLanguage.WELSH, "   ");
+
+        Service service = Service.from("Service Name", ImmutableMap.of(SupportedLanguage.WELSH, welshServiceName));
+        
+        assertThat(service.getServiceNames().get(SupportedLanguage.WELSH.toString()), is(nullValue()));
     }
 
 }

--- a/src/test/java/uk/gov/pay/adminusers/model/ServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/ServiceTest.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.adminusers.model;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
+import uk.gov.pay.commons.model.SupportedLanguage;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class ServiceTest {
+
+    @Test
+    public void fromWithNoEnglishServiceNameSetsNameAsEnglishServiceName() {
+        ServiceNameEntity welshServiceName = ServiceNameEntity.from(SupportedLanguage.WELSH, "Welsh Service Name");
+        
+        Service service = Service.from("Service Name", ImmutableMap.of(SupportedLanguage.WELSH, welshServiceName));
+        
+        assertThat(service.getServiceNames().get(SupportedLanguage.ENGLISH.toString()), is("Service Name"));
+        assertThat(service.getServiceNames().get(SupportedLanguage.WELSH.toString()), is("Welsh Service Name"));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceCreatorTest.java
@@ -100,8 +100,8 @@ public class ServiceCreatorTest {
         List<GatewayAccountIdEntity> persistedGatewayIds = persistedServiceEntity.getValue().getGatewayAccountIds();
         assertThat(persistedGatewayIds.size(), is(0));
         assertEnServiceNameMap(service, EN_SERVICE_NAME);
-        assertThat(service.getServiceNameMap(), hasKey(SupportedLanguage.WELSH.toString()));
-        assertThat(service.getServiceNameMap(), hasValue(CY_SERVICE_NAME));
+        assertThat(service.getServiceNames(), hasKey(SupportedLanguage.WELSH.toString()));
+        assertThat(service.getServiceNames(), hasValue(CY_SERVICE_NAME));
         assertSelfLink(service);
     }
 
@@ -159,8 +159,8 @@ public class ServiceCreatorTest {
     }
 
     private void assertEnServiceNameMap(Service service, String serviceName) {
-        assertThat(service.getServiceNameMap(), hasKey(SupportedLanguage.ENGLISH.toString()));
-        assertThat(service.getServiceNameMap(), hasValue(serviceName));
+        assertThat(service.getServiceNames(), hasKey(SupportedLanguage.ENGLISH.toString()));
+        assertThat(service.getServiceNames(), hasValue(serviceName));
     }
 
     private void assertSelfLink(Service service) {


### PR DESCRIPTION
The `Service` object contains a `serviceNames` map, which basically only exists to get returned as JSON like this:

```json
"service_names": {
  "en": "English Service Name",
  "cy": "Welsh Service Name"
}
```

Change the way the `serviceNames` map is constructed so that a multilingual name is not included if the name is either the empty string or all whitespace, as if the name were not set for that language.

This makes it easier for upstream consumers of the JSON to determine that there is no meaningful service name for a particular language and fall back to something sensible (such as using the English name, which will almost always be set).

In addition, remove `Service.setServiceNameMap(Map)` method and instead allow multilingual service names to be specified when constructing the object via a new variant of the `Service.from` method.

Multilingual service names were only ever set once (just after the object had been constructed), so making them a constructor argument makes it clearer that they will never change.