### PR TITLE
PP-4096 Allow blank multilingual service names when updating

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/resources/InviteRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InviteRequestValidator.java
@@ -13,8 +13,13 @@ import java.util.List;
 import java.util.Optional;
 
 import static java.lang.String.format;
-import static uk.gov.pay.adminusers.model.InviteOtpRequest.*;
-import static uk.gov.pay.adminusers.model.InviteUserRequest.*;
+import static uk.gov.pay.adminusers.model.InviteOtpRequest.FIELD_CODE;
+import static uk.gov.pay.adminusers.model.InviteOtpRequest.FIELD_PASSWORD;
+import static uk.gov.pay.adminusers.model.InviteOtpRequest.FIELD_TELEPHONE_NUMBER;
+import static uk.gov.pay.adminusers.model.InviteUserRequest.FIELD_EMAIL;
+import static uk.gov.pay.adminusers.model.InviteUserRequest.FIELD_ROLE_NAME;
+import static uk.gov.pay.adminusers.model.InviteUserRequest.FIELD_SENDER;
+import static uk.gov.pay.adminusers.model.InviteUserRequest.FIELD_SERVICE_EXTERNAL_ID;
 import static uk.gov.pay.adminusers.model.InviteValidateOtpRequest.FIELD_OTP;
 import static uk.gov.pay.adminusers.utils.email.EmailValidator.isPublicSectorEmail;
 import static uk.gov.pay.adminusers.utils.email.EmailValidator.isValid;
@@ -32,17 +37,17 @@ public class InviteRequestValidator {
 
     @Deprecated // Use the validateCreateUserRequest method instead
     public Optional<Errors> validateCreateRequest(JsonNode payload) {
-        Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExistsOrEmpty(payload, FIELD_EMAIL, FIELD_ROLE_NAME, FIELD_SENDER);
+        Optional<List<String>> missingMandatoryFields = requestValidations.checkExistsAndNotEmpty(payload, FIELD_EMAIL, FIELD_ROLE_NAME, FIELD_SENDER);
         return missingMandatoryFields.map(Errors::from);
     }
 
     public Optional<Errors> validateCreateUserRequest(JsonNode payload) {
-        Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExistsOrEmpty(payload, FIELD_SERVICE_EXTERNAL_ID, FIELD_EMAIL, FIELD_ROLE_NAME, FIELD_SENDER);
+        Optional<List<String>> missingMandatoryFields = requestValidations.checkExistsAndNotEmpty(payload, FIELD_SERVICE_EXTERNAL_ID, FIELD_EMAIL, FIELD_ROLE_NAME, FIELD_SENDER);
         return missingMandatoryFields.map(Errors::from);
     }
 
     public Optional<Errors> validateGenerateOtpRequest(JsonNode payload) {
-        Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExistsOrEmpty(payload, FIELD_TELEPHONE_NUMBER, FIELD_PASSWORD);
+        Optional<List<String>> missingMandatoryFields = requestValidations.checkExistsAndNotEmpty(payload, FIELD_TELEPHONE_NUMBER, FIELD_PASSWORD);
         if (missingMandatoryFields.isPresent()) {
             return Optional.of(Errors.from(missingMandatoryFields.get()));
         }
@@ -55,7 +60,7 @@ public class InviteRequestValidator {
 
 
     public Optional<Errors> validateResendOtpRequest(JsonNode payload) {
-        Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExistsOrEmpty(payload, FIELD_CODE, FIELD_TELEPHONE_NUMBER);
+        Optional<List<String>> missingMandatoryFields = requestValidations.checkExistsAndNotEmpty(payload, FIELD_CODE, FIELD_TELEPHONE_NUMBER);
         if (missingMandatoryFields.isPresent()) {
             return Optional.of(Errors.from(missingMandatoryFields.get()));
         }
@@ -64,7 +69,7 @@ public class InviteRequestValidator {
     }
 
     public Optional<Errors> validateOtpValidationRequest(JsonNode payload) {
-        Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExistsOrEmpty(payload, InviteValidateOtpRequest.FIELD_CODE, FIELD_OTP);
+        Optional<List<String>> missingMandatoryFields = requestValidations.checkExistsAndNotEmpty(payload, InviteValidateOtpRequest.FIELD_CODE, FIELD_OTP);
         if (missingMandatoryFields.isPresent()) {
             return Optional.of(Errors.from(missingMandatoryFields.get()));
         }
@@ -73,7 +78,7 @@ public class InviteRequestValidator {
     }
 
     public Optional<Errors> validateCreateServiceRequest(JsonNode payload) {
-        Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExistsOrEmpty(payload, InviteServiceRequest.FIELD_EMAIL, InviteServiceRequest.FIELD_TELEPHONE_NUMBER, InviteServiceRequest.FIELD_PASSWORD);
+        Optional<List<String>> missingMandatoryFields = requestValidations.checkExistsAndNotEmpty(payload, InviteServiceRequest.FIELD_EMAIL, InviteServiceRequest.FIELD_TELEPHONE_NUMBER, InviteServiceRequest.FIELD_PASSWORD);
         if (missingMandatoryFields.isPresent()) {
             return Optional.of(Errors.from(missingMandatoryFields.get()));
         }

--- a/src/main/java/uk/gov/pay/adminusers/resources/ResetPasswordValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ResetPasswordValidator.java
@@ -28,7 +28,7 @@ public class ResetPasswordValidator {
             return Optional.of(Errors.from(of("invalid JSON")));
         }
 
-        Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExistsOrEmpty(payload, FIELD_CODE, FIELD_PASSWORD);
+        Optional<List<String>> missingMandatoryFields = requestValidations.checkExistsAndNotEmpty(payload, FIELD_CODE, FIELD_PASSWORD);
 
         if (missingMandatoryFields.isPresent()) {
             return Optional.of(Errors.from(missingMandatoryFields.get()));

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
@@ -47,7 +47,7 @@ public class ServiceRequestValidator {
     }
 
     void validateUpdateMerchantDetailsRequest(JsonNode payload) throws ValidationException {
-        Optional<List<String>> errors = requestValidations.checkIfExistsOrEmpty(payload,
+        Optional<List<String>> errors = requestValidations.checkExistsAndNotEmpty(payload,
                 FIELD_MERCHANT_DETAILS_NAME, FIELD_MERCHANT_DETAILS_ADDRESS_LINE1,
                 FIELD_MERCHANT_DETAILS_ADDRESS_CITY, FIELD_MERCHANT_DETAILS_ADDRESS_POSTCODE,
                 FIELD_MERCHANT_DETAILS_ADDRESS_COUNTRY);

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
@@ -77,7 +77,11 @@ public class ServiceUpdateOperationValidator {
         if (FIELD_CUSTOM_BRANDING.equals(path)) {
             errors.addAll(checkIfValidJson(operation.get(FIELD_VALUE), FIELD_CUSTOM_BRANDING));
         } else if (FIELD_NAME.equals(path) || path.startsWith(FIELD_SERVICE_NAME_PREFIX)) {
-            requestValidations.checkIfExistsOrEmpty(operation, FIELD_VALUE).ifPresent(errors::addAll);
+            if (FIELD_NAME.equals(path) || path.endsWith('/' + SupportedLanguage.ENGLISH.toString())) {
+                requestValidations.checkIfExistsOrEmpty(operation, FIELD_VALUE).ifPresent(errors::addAll);
+            } else {
+                requestValidations.checkExists(operation, FIELD_VALUE).ifPresent(errors::addAll);
+            }
             if (errors.isEmpty()) {
                 requestValidations.checkMaxLength(operation, SERVICE_NAME_MAX_LENGTH, FIELD_VALUE).ifPresent(errors::addAll);
             }

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
@@ -66,7 +66,7 @@ public class ServiceUpdateOperationValidator {
 
     private List<String> validateOpAndPathExistAndNotEmpty(JsonNode operation) {
         List<String> errors = new ArrayList<>();
-        requestValidations.checkIfExistsOrEmpty(operation, FIELD_OP, FIELD_PATH).ifPresent(errors::addAll);
+        requestValidations.checkExistsAndNotEmpty(operation, FIELD_OP, FIELD_PATH).ifPresent(errors::addAll);
         return errors;
     }
 
@@ -78,7 +78,7 @@ public class ServiceUpdateOperationValidator {
             errors.addAll(checkIfValidJson(operation.get(FIELD_VALUE), FIELD_CUSTOM_BRANDING));
         } else if (FIELD_NAME.equals(path) || path.startsWith(FIELD_SERVICE_NAME_PREFIX)) {
             if (FIELD_NAME.equals(path) || path.endsWith('/' + SupportedLanguage.ENGLISH.toString())) {
-                requestValidations.checkIfExistsOrEmpty(operation, FIELD_VALUE).ifPresent(errors::addAll);
+                requestValidations.checkExistsAndNotEmpty(operation, FIELD_VALUE).ifPresent(errors::addAll);
             } else {
                 requestValidations.checkExists(operation, FIELD_VALUE).ifPresent(errors::addAll);
             }

--- a/src/main/java/uk/gov/pay/adminusers/resources/UserRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/UserRequestValidator.java
@@ -36,12 +36,12 @@ public class UserRequestValidator {
     }
 
     public Optional<Errors> validateAuthenticateRequest(JsonNode payload) {
-        Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExistsOrEmpty(payload, FIELD_USERNAME, FIELD_PASSWORD);
+        Optional<List<String>> missingMandatoryFields = requestValidations.checkExistsAndNotEmpty(payload, FIELD_USERNAME, FIELD_PASSWORD);
         return missingMandatoryFields.map(Errors::from);
     }
 
     public Optional<Errors> validateCreateRequest(JsonNode payload) {
-        Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExistsOrEmpty(payload, FIELD_USERNAME, FIELD_EMAIL, FIELD_TELEPHONE_NUMBER, FIELD_ROLE_NAME);
+        Optional<List<String>> missingMandatoryFields = requestValidations.checkExistsAndNotEmpty(payload, FIELD_USERNAME, FIELD_EMAIL, FIELD_TELEPHONE_NUMBER, FIELD_ROLE_NAME);
         if (missingMandatoryFields.isPresent()) {
             return Optional.of(Errors.from(missingMandatoryFields.get()));
         }
@@ -61,7 +61,7 @@ public class UserRequestValidator {
     }
 
     public Optional<Errors> validate2FAAuthRequest(JsonNode payload) {
-        Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExistsOrEmpty(payload, "code");
+        Optional<List<String>> missingMandatoryFields = requestValidations.checkExistsAndNotEmpty(payload, "code");
         if (missingMandatoryFields.isPresent()) {
             return Optional.of(Errors.from(missingMandatoryFields.get()));
         }
@@ -70,7 +70,7 @@ public class UserRequestValidator {
     }
 
     public Optional<Errors> validate2faActivateRequest(JsonNode payload) {
-        Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExistsOrEmpty(payload, "code", "second_factor");
+        Optional<List<String>> missingMandatoryFields = requestValidations.checkExistsAndNotEmpty(payload, "code", "second_factor");
         if (missingMandatoryFields.isPresent()) {
             return Optional.of(Errors.from(missingMandatoryFields.get()));
         }
@@ -88,17 +88,17 @@ public class UserRequestValidator {
     }
 
     public Optional<Errors> validateServiceRole(JsonNode payload) {
-        Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExistsOrEmpty(payload, "role_name");
+        Optional<List<String>> missingMandatoryFields = requestValidations.checkExistsAndNotEmpty(payload, "role_name");
         return missingMandatoryFields.map(Errors::from);
     }
 
     public Optional<Errors> validateAssignServiceRequest(JsonNode payload) {
-        Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExistsOrEmpty(payload, FIELD_SERVICE_EXTERNAL_ID, FIELD_ROLE_NAME);
+        Optional<List<String>> missingMandatoryFields = requestValidations.checkExistsAndNotEmpty(payload, FIELD_SERVICE_EXTERNAL_ID, FIELD_ROLE_NAME);
         return missingMandatoryFields.map(Errors::from);
     }
 
     public Optional<Errors> validatePatchRequest(JsonNode payload) {
-        Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExistsOrEmpty(payload, "op", "path", "value");
+        Optional<List<String>> missingMandatoryFields = requestValidations.checkExistsAndNotEmpty(payload, "op", "path", "value");
         if (missingMandatoryFields.isPresent()) {
             return Optional.of(Errors.from(missingMandatoryFields.get()));
         }
@@ -123,7 +123,7 @@ public class UserRequestValidator {
     }
 
     public Optional<Errors> validateFindRequest(JsonNode payload) {
-        Optional<List<String>> missingMandatoryFields = requestValidations.checkIfExistsOrEmpty(payload, FIELD_USERNAME);
+        Optional<List<String>> missingMandatoryFields = requestValidations.checkExistsAndNotEmpty(payload, FIELD_USERNAME);
         if (missingMandatoryFields.isPresent()) {
             return Optional.of(Errors.from(missingMandatoryFields.get()));
         }

--- a/src/main/java/uk/gov/pay/adminusers/validations/RequestValidations.java
+++ b/src/main/java/uk/gov/pay/adminusers/validations/RequestValidations.java
@@ -29,6 +29,10 @@ public class RequestValidations {
         return applyCheck(payload, notExistOrEmpty(), fieldNames, "Field [%s] is required");
     }
 
+    public Optional<List<String>> checkExists(JsonNode payload, String... fieldNames) {
+        return applyCheck(payload, notExists(), fieldNames, "Field [%s] is required");
+    }
+
     public Optional<List<String>> checkMaxLength(JsonNode payload, int maxLength, String... fieldNames) {
         return applyCheck(payload, exceedsMaxLength(maxLength), fieldNames, "Field [%s] must have a maximum length of " + maxLength + " characters");
     }
@@ -57,6 +61,10 @@ public class RequestValidations {
                 return notExistOrBlankText().apply(jsonElement);
             }
         };
+    }
+    
+    private Function<JsonNode, Boolean> notExists() {
+        return (JsonNode jsonElement) -> isNullValue().apply(jsonElement);
     }
 
     private Function<JsonNode, Boolean> notExistOrEmptyArray() {

--- a/src/main/java/uk/gov/pay/adminusers/validations/RequestValidations.java
+++ b/src/main/java/uk/gov/pay/adminusers/validations/RequestValidations.java
@@ -25,8 +25,8 @@ public class RequestValidations {
         return applyCheck(payload, isNotBoolean(), fieldNames, "Field [%s] must be a boolean");
     }
 
-    public Optional<List<String>> checkIfExistsOrEmpty(JsonNode payload, String... fieldNames) {
-        return applyCheck(payload, notExistOrEmpty(), fieldNames, "Field [%s] is required");
+    public Optional<List<String>> checkExistsAndNotEmpty(JsonNode payload, String... fieldNames) {
+        return applyCheck(payload, notExistsOrIsEmpty(), fieldNames, "Field [%s] is required");
     }
 
     public Optional<List<String>> checkExists(JsonNode payload, String... fieldNames) {
@@ -51,7 +51,7 @@ public class RequestValidations {
         return errors.isEmpty() ? Optional.empty() : Optional.of(errors);
     }
 
-    private Function<JsonNode, Boolean> notExistOrEmpty() {
+    private Function<JsonNode, Boolean> notExistsOrIsEmpty() {
         return (JsonNode jsonElement) -> {
             if (jsonElement instanceof NullNode) {
                 return isNullValue().apply(jsonElement);

--- a/src/test/java/uk/gov/pay/adminusers/resources/RequestValidationsTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/RequestValidationsTest.java
@@ -24,7 +24,7 @@ public class RequestValidationsTest {
         payload.put(FIELD_1, "value1");
         payload.put(FIELD_2, "value2");
 
-        Optional<List<String>> errors = requestValidations.checkIfExistsOrEmpty(payload, FIELD_1, FIELD_2);
+        Optional<List<String>> errors = requestValidations.checkExistsAndNotEmpty(payload, FIELD_1, FIELD_2);
 
         assertThat(errors.isPresent(), is(false));
     }
@@ -35,7 +35,7 @@ public class RequestValidationsTest {
         payload.put(FIELD_1, "");
         payload.put(FIELD_2, "");
 
-        Optional<List<String>> errors = requestValidations.checkIfExistsOrEmpty(payload, FIELD_1, FIELD_2);
+        Optional<List<String>> errors = requestValidations.checkExistsAndNotEmpty(payload, FIELD_1, FIELD_2);
 
         assertThat(errors.isPresent(), is(true));
     }
@@ -46,7 +46,7 @@ public class RequestValidationsTest {
         payload.set(FIELD_1, null);
         payload.set(FIELD_2, null);
 
-        Optional<List<String>> errors = requestValidations.checkIfExistsOrEmpty(payload, FIELD_1, FIELD_2);
+        Optional<List<String>> errors = requestValidations.checkExistsAndNotEmpty(payload, FIELD_1, FIELD_2);
 
         assertThat(errors.isPresent(), is(true));
     }

--- a/src/test/java/uk/gov/pay/adminusers/resources/RequestValidationsTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/RequestValidationsTest.java
@@ -19,7 +19,7 @@ public class RequestValidationsTest {
     private static final String FIELD_2 = "field2";
 
     @Test
-    public void checkIfExists_shouldSuccess_whenFieldsAreProvidedWithValues() throws Exception {
+    public void checkIfExistsOrEmpty_shouldSucceed_whenFieldsAreProvidedWithValues() {
         ObjectNode payload = JsonNodeFactory.instance.objectNode();
         payload.put(FIELD_1, "value1");
         payload.put(FIELD_2, "value2");
@@ -30,7 +30,7 @@ public class RequestValidationsTest {
     }
 
     @Test
-    public void checkIfExists_shouldFail_whenFieldsAreProvidedWithEmptyValues() throws Exception {
+    public void checkIfExistsOrEmpty_shouldFail_whenFieldsAreProvidedWithEmptyValues() {
         ObjectNode payload = JsonNodeFactory.instance.objectNode();
         payload.put(FIELD_1, "");
         payload.put(FIELD_2, "");
@@ -41,11 +41,10 @@ public class RequestValidationsTest {
     }
 
     @Test
-    public void checkIfExists_shouldFail_whenFieldsAreProvidedWithNullValues() throws Exception {
+    public void checkIfExistsOrEmpty_shouldFail_whenFieldsAreProvidedWithNullValues() {
         ObjectNode payload = JsonNodeFactory.instance.objectNode();
         payload.set(FIELD_1, null);
         payload.set(FIELD_2, null);
-        System.out.println(payload);
 
         Optional<List<String>> errors = requestValidations.checkIfExistsOrEmpty(payload, FIELD_1, FIELD_2);
 
@@ -53,7 +52,40 @@ public class RequestValidationsTest {
     }
 
     @Test
-    public void checkNotBoolean_shouldSuccess_whenFieldsAreTrueOrFalse() {
+    public void checkIfExists_shouldSucceed_whenFieldsAreProvidedWithValues() {
+        ObjectNode payload = JsonNodeFactory.instance.objectNode();
+        payload.put(FIELD_1, "value1");
+        payload.put(FIELD_2, "value2");
+
+        Optional<List<String>> errors = requestValidations.checkExists(payload, FIELD_1, FIELD_2);
+
+        assertThat(errors.isPresent(), is(false));
+    }
+
+    @Test
+    public void checkIfExists_shouldSucceed_whenFieldsAreProvidedWithEmptyValues() {
+        ObjectNode payload = JsonNodeFactory.instance.objectNode();
+        payload.put(FIELD_1, "");
+        payload.put(FIELD_2, " ");
+
+        Optional<List<String>> errors = requestValidations.checkExists(payload, FIELD_1, FIELD_2);
+
+        assertThat(errors.isPresent(), is(false));
+    }
+
+    @Test
+    public void checkIfExists_shouldFail_whenFieldsAreProvidedWithNullValues() {
+        ObjectNode payload = JsonNodeFactory.instance.objectNode();
+        payload.set(FIELD_1, null);
+        payload.set(FIELD_2, null);
+
+        Optional<List<String>> errors = requestValidations.checkExists(payload, FIELD_1, FIELD_2);
+
+        assertThat(errors.isPresent(), is(true));
+    }
+
+    @Test
+    public void checkNotBoolean_shouldSucceed_whenFieldsAreTrueOrFalse() {
         ObjectNode payload = JsonNodeFactory.instance.objectNode();
         payload.put(FIELD_1, "true");
         payload.put(FIELD_2, "false");

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
@@ -25,7 +25,7 @@ public class ServiceUpdateOperationValidatorTest {
         
         assertThat(errors.isEmpty(), is(true));
     }
-
+    
     @Test
     public void shouldFail_whenUpdateName_whenNameFieldPresentAndItIsTooLong() {
         ImmutableMap<String, String> payload = ImmutableMap.of("path", "name", "op", "replace",
@@ -126,6 +126,25 @@ public class ServiceUpdateOperationValidatorTest {
         assertThat(errors.isEmpty(), is(true));
     }
 
+    @Test
+    public void shouldSuccess_whenUpdateServiceName_withAllFieldsPresentAndWelshServiceNameBlank() {
+        ImmutableMap<String, String> payload = ImmutableMap.of("path", "service_name/cy", "op", "replace", "value", " ");
+
+        List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
+
+        assertThat(errors.isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldFail_whenUpdateServiceName_withAllFieldsPresentAndEnglishServiceNameBlank() {
+        ImmutableMap<String, String> payload = ImmutableMap.of("path", "service_name/en", "op", "replace", "value", "");
+
+        List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
+
+        assertThat(errors.size(), is(1));
+        assertThat(errors, hasItem("Field [value] is required"));
+    }
+    
     @Test
     public void shouldFail_whenUpdateServiceName_whenServiceNameFieldPresentAndItIsTooLong() {
         ImmutableMap<String, String> payload = ImmutableMap.of("path", "service_name/en", "op", "replace",

--- a/src/test/resources/fixtures/resource/service/patch/array-replace-service-name-cy-blank.json
+++ b/src/test/resources/fixtures/resource/service/patch/array-replace-service-name-cy-blank.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "replace",
+    "path": "service_name/cy",
+    "value": " "
+  }
+]


### PR DESCRIPTION
When receiving a request to replace one of a service’s multilingual service names, allow empty or all-whitespace strings because — in combination with the feature that means we won’t ever return a
blank service name when someone retrieves a service — this is the best way we have for users to remove a multilingual service name right now.

However, don’t allow an English service name (JSON path `service_name/en`) to be blank because that is mandatory.

with @danworth