### PR TITLE
PP-4204 add redirect to service immediately on terminal state flag

### DIFF
--- a/src/main/resources/migrations/00043_add_redirect_to_service_immedidately_flag.sql
+++ b/src/main/resources/migrations/00043_add_redirect_to_service_immedidately_flag.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_redirect_to_service_immediately_flag
+ALTER TABLE services ADD COLUMN redirect_to_service_immediately_on_terminal_state boolean NULL;
+ALTER TABLE services ALTER COLUMN redirect_to_service_immediately_on_terminal_state SET DEFAULT false;
+UPDATE services SET redirect_to_service_immediately_on_terminal_state = false WHERE redirect_to_service_immediately_on_terminal_state IS NULL;
+
+--rollback ALTER TABLE services DROP COLUMN redirect_to_service_immediately_on_terminal_state;


### PR DESCRIPTION
- add `redirect_to_service_immediately_on_terminal_state` boolean to `services`
table.
- add default value of `false`.
- update existing entries to default value of `false`.