### PR TITLE
PP-4204 Add redirect to service immediately flag to service PATCH operation

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/model/ServiceUpdateRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/ServiceUpdateRequest.java
@@ -63,6 +63,10 @@ public class ServiceUpdateRequest {
         return null;
     }
 
+    public boolean valueAsBoolean() {
+        return value != null && Boolean.parseBoolean(value.asText());
+    }
+
 
     private ServiceUpdateRequest(String op, String path, JsonNode value) {
         this.op = op;

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
@@ -20,6 +20,7 @@ import static uk.gov.pay.adminusers.model.ServiceUpdateRequest.FIELD_VALUE;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_CUSTOM_BRANDING;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_GATEWAY_ACCOUNT_IDS;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_NAME;
+import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_REDIRECT_NAME;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_SERVICE_NAME_PREFIX;
 
 public class ServiceUpdateOperationValidator {
@@ -39,6 +40,7 @@ public class ServiceUpdateOperationValidator {
         validAttributeUpdateOperations.put(FIELD_NAME, singletonList(REPLACE));
         validAttributeUpdateOperations.put(FIELD_GATEWAY_ACCOUNT_IDS, singletonList(ADD));
         validAttributeUpdateOperations.put(FIELD_CUSTOM_BRANDING, singletonList(REPLACE));
+        validAttributeUpdateOperations.put(FIELD_REDIRECT_NAME, singletonList(REPLACE));
         Arrays.stream(SupportedLanguage.values()).forEach(lang ->
                 validAttributeUpdateOperations.put(FIELD_SERVICE_NAME_PREFIX + '/' + lang.toString(), singletonList(REPLACE)));
         this.validAttributeUpdateOperations = validAttributeUpdateOperations.build();
@@ -85,8 +87,12 @@ public class ServiceUpdateOperationValidator {
             if (errors.isEmpty()) {
                 requestValidations.checkMaxLength(operation, SERVICE_NAME_MAX_LENGTH, FIELD_VALUE).ifPresent(errors::addAll);
             }
+        } else if (FIELD_REDIRECT_NAME.equals(path)) {
+            requestValidations.checkExists(operation, FIELD_VALUE).ifPresent(errors::addAll);
+            if (errors.isEmpty()) {
+                requestValidations.checkIsStrictBoolean(operation, FIELD_VALUE).ifPresent(errors::addAll);
+            }
         }
-
         return errors;
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
@@ -28,6 +28,7 @@ public class ServiceUpdater {
     public static final String FIELD_GATEWAY_ACCOUNT_IDS = "gateway_account_ids";
     public static final String FIELD_CUSTOM_BRANDING = "custom_branding";
     public static final String FIELD_SERVICE_NAME_PREFIX = "service_name";
+    public static final String FIELD_REDIRECT_NAME = "redirect_to_service_immediately_on_terminal_state";
 
     private final ServiceDao serviceDao;
 
@@ -39,6 +40,7 @@ public class ServiceUpdater {
         attributeUpdaters.put(FIELD_NAME, updateServiceName());
         attributeUpdaters.put(FIELD_GATEWAY_ACCOUNT_IDS, assignGatewayAccounts());
         attributeUpdaters.put(FIELD_CUSTOM_BRANDING, updateCustomBranding());
+        attributeUpdaters.put(FIELD_REDIRECT_NAME, updateRedirectImmediately());
         Arrays.stream(SupportedLanguage.values())
                 .forEach(language -> attributeUpdaters.put(FIELD_SERVICE_NAME_PREFIX + '/' + language.toString(), updateMultilingualServiceName()));
         this.attributeUpdaters = attributeUpdaters.build();
@@ -101,5 +103,10 @@ public class ServiceUpdater {
             ServiceNameEntity serviceNameEntity = ServiceNameEntity.from(language, serviceUpdateRequest.valueAsString());
             serviceEntity.addOrUpdateServiceName(serviceNameEntity);
         };
+    }
+
+    private BiConsumer<ServiceUpdateRequest, ServiceEntity> updateRedirectImmediately() {
+        return ((serviceUpdateRequest, serviceEntity) -> 
+                serviceEntity.setRedirectToServiceImmediatelyOnTerminalState(serviceUpdateRequest.valueAsBoolean()));
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/validations/RequestValidations.java
+++ b/src/main/java/uk/gov/pay/adminusers/validations/RequestValidations.java
@@ -25,6 +25,10 @@ public class RequestValidations {
         return applyCheck(payload, isNotBoolean(), fieldNames, "Field [%s] must be a boolean");
     }
 
+    public Optional<List<String>> checkIsStrictBoolean(JsonNode payload, String... fieldNames) {
+        return applyCheck(payload, isNotStrictBoolean(), fieldNames, "Field [%s] must be a boolean");
+    }
+
     public Optional<List<String>> checkExistsAndNotEmpty(JsonNode payload, String... fieldNames) {
         return applyCheck(payload, notExistsOrIsEmpty(), fieldNames, "Field [%s] is required");
     }
@@ -93,6 +97,10 @@ public class RequestValidations {
 
     static Function<JsonNode, Boolean> isNotBoolean() {
         return jsonNode -> !ImmutableList.of("true", "false").contains(jsonNode.asText().toLowerCase());
+    }
+
+    static Function<JsonNode, Boolean> isNotStrictBoolean() {
+        return jsonNode -> !jsonNode.isBoolean();
     }
 
     public Optional<List<String>> isValidEmail(JsonNode payload, String... fieldNames) {

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Test;
@@ -166,4 +167,65 @@ public class ServiceUpdateOperationValidatorTest {
         assertThat(errors, hasItem("Path [service_name/xx] is invalid"));
     }
 
+    @Test
+    public void shouldSucceed_whenUpdateRedirectToService() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("path", "redirect_to_service_immediately_on_terminal_state");
+        payload.put("op", "replace");
+        payload.put("value", true);
+
+        List<String> errors = serviceUpdateOperationValidator.validate(payload);
+
+        assertThat(errors.size(), is(0));
+    }
+
+    @Test
+    public void shouldFail_whenUpdateRedirectToService_whenOpIsNotReplace() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("path", "redirect_to_service_immediately_on_terminal_state");
+        payload.put("op", "not_replace");
+        payload.put("value", true);
+
+        List<String> errors = serviceUpdateOperationValidator.validate(payload);
+
+        assertThat(errors.size(), is(1));
+        assertThat(errors, hasItem("Operation [not_replace] is invalid for path [redirect_to_service_immediately_on_terminal_state]"));
+    }
+
+    @Test
+    public void shouldFail_whenUpdateRedirectToService_whenOpIsNotPresent() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("path", "redirect_to_service_immediately_on_terminal_state");
+        payload.put("value", true);
+
+        List<String> errors = serviceUpdateOperationValidator.validate(payload);
+
+        assertThat(errors.size(), is(1));
+        assertThat(errors, hasItem("Field [op] is required"));
+    }
+
+    @Test
+    public void shouldFail_whenUpdateRedirectToService_whenValueIsNotBoolean() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("path", "redirect_to_service_immediately_on_terminal_state");
+        payload.put("op", "replace");
+        payload.put("value", "not a boolean");
+
+        List<String> errors = serviceUpdateOperationValidator.validate(payload);
+
+        assertThat(errors.size(), is(1));
+        assertThat(errors, hasItem("Field [value] must be a boolean"));
+    }
+
+    @Test
+    public void shouldFail_whenUpdateRedirectToService_whenMissingValue() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("path", "redirect_to_service_immediately_on_terminal_state");
+        payload.put("op", "replace");
+
+        List<String> errors = serviceUpdateOperationValidator.validate(payload);
+
+        assertThat(errors.size(), is(1));
+        assertThat(errors, hasItem("Field [value] is required"));
+    }
 }

--- a/src/test/resources/fixtures/resource/service/patch/replace_redirect_immediately_invalid_value.json
+++ b/src/test/resources/fixtures/resource/service/patch/replace_redirect_immediately_invalid_value.json
@@ -1,0 +1,5 @@
+{
+  "op": "replace",
+  "path": "redirect_to_service_immediately_on_terminal_state",
+  "value": "not a boolean"
+}

--- a/src/test/resources/fixtures/resource/service/patch/replace_redirect_immediately_to_true.json
+++ b/src/test/resources/fixtures/resource/service/patch/replace_redirect_immediately_to_true.json
@@ -1,0 +1,5 @@
+{
+  "op": "replace",
+  "path": "redirect_to_service_immediately_on_terminal_state",
+  "value": true
+}


### PR DESCRIPTION
## WHAT

- add validation for service Patch operation to replace `redirect_to_service_immediately_on_terminal_state`.
- add operation to replace value.
- updated unit and resource tests.

with @sandorarpa