### PR TITLE
PP-4160 Set "collect billing address" and "redirect to service immediately on terminal state" flags correctly

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
@@ -44,10 +44,10 @@ public class ServiceEntity {
     private String name = Service.DEFAULT_NAME_VALUE;
 
     @Column(name = "redirect_to_service_immediately_on_terminal_state")
-    private boolean redirectToServiceImmediatelyOnTerminalState;
+    private boolean redirectToServiceImmediatelyOnTerminalState = false;
 
     @Column(name = "collect_billing_address")
-    private boolean collectBillingAddress;
+    private boolean collectBillingAddress = true;
 
     @Embedded
     private MerchantDetailsEntity merchantDetailsEntity;
@@ -71,6 +71,8 @@ public class ServiceEntity {
     public ServiceEntity(List<String> gatewayAccountIds) {
         this.gatewayAccountIds.clear();
         this.externalId = randomUuid();
+        this.redirectToServiceImmediatelyOnTerminalState = false;
+        this.collectBillingAddress = true;
         populateGatewayAccountIds(gatewayAccountIds);
     }
 
@@ -177,6 +179,8 @@ public class ServiceEntity {
         ServiceEntity serviceEntity = new ServiceEntity();
         serviceEntity.setName(service.getName());
         serviceEntity.setExternalId(service.getExternalId());
+        serviceEntity.setRedirectToServiceImmediatelyOnTerminalState(service.isRedirectToServiceImmediatelyOnTerminalState());
+        serviceEntity.setCollectBillingAddress(service.isCollectBillingAddress());
         return serviceEntity;
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceCreator.java
@@ -34,8 +34,6 @@ public class ServiceCreator {
                 .orElseGet(Service::from);
 
         ServiceEntity serviceEntity = ServiceEntity.from(service);
-        serviceEntity.setRedirectToServiceImmediatelyOnTerminalState(false);
-        serviceEntity.setCollectBillingAddress(true);
         serviceEntity.addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.ENGLISH, service.getName()));
         serviceNameVariants.forEach((language, name) -> serviceEntity.addOrUpdateServiceName(ServiceNameEntity.from(language, name)));
 

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCompleterTest.java
@@ -11,10 +11,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.adminusers.model.InviteCompleteRequest;
 import uk.gov.pay.adminusers.model.InviteCompleteResponse;
 import uk.gov.pay.adminusers.model.InviteType;
+import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.dao.RoleDao;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
+import uk.gov.pay.adminusers.persistence.entity.GatewayAccountIdEntity;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
 import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
@@ -94,7 +96,14 @@ public class ServiceInviteCompleterTest {
         verify(mockUserDao).merge(expectedInvitedUser.capture());
         verify(mockInviteDao).merge(expectedInvite.capture());
 
-        assertThat(expectedService.getValue().getGatewayAccountIds().stream().map(gaie -> gaie.getGatewayAccountId()).collect(toList()), hasItems("2", "1"));
+        ServiceEntity serviceEntity = expectedService.getValue();
+        assertThat(serviceEntity.getGatewayAccountIds().stream()
+                .map(GatewayAccountIdEntity::getGatewayAccountId)
+                .collect(toList()), hasItems("2", "1"));
+        assertThat(serviceEntity.getName(), is(Service.DEFAULT_NAME_VALUE));
+        assertThat(serviceEntity.isRedirectToServiceImmediatelyOnTerminalState(), is(false));
+        assertThat(serviceEntity.isCollectBillingAddress(), is(true));
+
         assertThat(inviteResponse.getInvite().isDisabled(), is(true));
         assertThat(inviteResponse.getInvite().getLinks().size(), is(1));
         assertThat(inviteResponse.getInvite().getLinks().get(0).getRel().toString(), is("user"));
@@ -118,6 +127,12 @@ public class ServiceInviteCompleterTest {
         verify(mockInviteDao).merge(expectedInvite.capture());
 
         assertThat(expectedService.getValue().getGatewayAccountIds().isEmpty(), is(true));
+
+        ServiceEntity serviceEntity = expectedService.getValue();
+        assertThat(serviceEntity.getGatewayAccountIds().isEmpty(), is(true));
+        assertThat(serviceEntity.getName(), is(Service.DEFAULT_NAME_VALUE));
+        assertThat(serviceEntity.isRedirectToServiceImmediatelyOnTerminalState(), is(false));
+        assertThat(serviceEntity.isCollectBillingAddress(), is(true));
 
         assertThat(inviteResponse.getInvite().isDisabled(), is(true));
         assertThat(inviteResponse.getInvite().getLinks().size(), is(1));

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceCreateTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceCreateTest.java
@@ -61,7 +61,7 @@ public class ServiceResourceCreateTest extends ServiceResourceBaseTest {
 
     private static RequestValidations requestValidations = new RequestValidations();
     private static ServiceRequestValidator serviceRequestValidator = new ServiceRequestValidator(requestValidations, new ServiceUpdateOperationValidator(requestValidations));
-    
+
     @ClassRule
     public static final ResourceTestRule resources = ResourceTestRule.builder()
             .addResource(new ServiceResource(mockedUserDao, mockedServiceDao, linksBuilder, serviceRequestValidator, mockedServicesFactory))
@@ -219,8 +219,6 @@ public class ServiceResourceCreateTest extends ServiceResourceBaseTest {
         Service service = maybeName.map(Service::from)
                 .orElseGet(Service::from);
         ServiceEntity serviceEntity = ServiceEntity.from(service);
-        serviceEntity.setRedirectToServiceImmediatelyOnTerminalState(false);
-        serviceEntity.setCollectBillingAddress(true);
         serviceEntity.addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.ENGLISH, service.getName()));
         serviceNameVariants.forEach((k, v) -> serviceEntity.addOrUpdateServiceName(ServiceNameEntity.from(k, v)));
         if (maybeAccountIds.isPresent()) {


### PR DESCRIPTION
## WHAT

Set "collect billing address" and "redirect to service immediately on terminal state" flags correctly

## HOW

- "collect billing address" and "redirect to service immediately on terminal state" flags were not set when used in `uk.gov.pay.adminusers.service.ServiceInviteCompleter.complete` consequently they were initialised to `false`
- make sure we initialise them in central place like `uk.gov.pay.adminusers.persistence.entity.ServiceEntity.from` and initialise `ServiceEntity` with default values as in database
- added missing tests

with @alexbishop1