### PR TITLE
PP-4378: Use --no-cache with apk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM govukpay/openjdk:alpine-3.8.1-jre-8.181.13
 
-RUN apk update
-RUN apk upgrade
+RUN apk --no-cache upgrade
 
 RUN apk add --no-cache bash
 


### PR DESCRIPTION
When building our images, using the --no-cache argument to Alpine's package
manager, apk, avoids saving package listings to disk. This reduces the size of
our docker images slightly.

This shaves about 1MB off the image