### PR TITLE
PP-4159 Get tests running locally with docker for mac

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,21 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-guava</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-base</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>

--- a/src/test/java/uk/gov/pay/adminusers/infra/PostgresContainer.java
+++ b/src/test/java/uk/gov/pay/adminusers/infra/PostgresContainer.java
@@ -34,11 +34,10 @@ public class PostgresContainer {
     private static final int DB_TIMEOUT_SEC = 15;
     private static final String INTERNAL_PORT = "5432";
 
-    public  PostgresContainer(DockerClient docker, String host) throws InterruptedException, IOException, ClassNotFoundException, DockerException {
+    public  PostgresContainer(DockerClient docker) throws InterruptedException, IOException, ClassNotFoundException, DockerException {
         Class.forName("org.postgresql.Driver");
 
         this.docker = docker;
-        this.host = host;
 
         failsafeDockerPull(docker, GOVUK_POSTGRES_IMAGE);
         docker.listImages(DockerClient.ListImagesParam.create("name", GOVUK_POSTGRES_IMAGE));
@@ -65,11 +64,12 @@ public class PostgresContainer {
     }
 
     public String getConnectionUrl() {
-        return "jdbc:postgresql://" + host + ":" + port + "/";
+        return "jdbc:postgresql://" + docker.getHost() + ":" + port + "/";
     }
 
     private void failsafeDockerPull(DockerClient docker, String image) {
         try {
+            docker.pull(image);
             docker.pull(image);
         } catch (Exception e) {
             logger.error("Docker image " + image + " could not be pulled from DockerHub", e);

--- a/src/test/java/uk/gov/pay/adminusers/infra/PostgresDockerRule.java
+++ b/src/test/java/uk/gov/pay/adminusers/infra/PostgresDockerRule.java
@@ -9,33 +9,10 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Optional;
-
-import static org.junit.Assert.assertNotNull;
 
 public class PostgresDockerRule implements TestRule {
-
-    private static final String DOCKER_HOST = "DOCKER_HOST";
-    private static final String DOCKER_CERT_PATH = "DOCKER_CERT_PATH";
-    private static String host;
+    
     private static PostgresContainer container;
-
-    static {
-        try {
-            String dockerHost = Optional.ofNullable(System.getenv(DOCKER_HOST)).
-                    orElseThrow(() -> new RuntimeException(DOCKER_HOST + " environment variable not set. It has to be set to the docker daemon location."));
-            URI dockerHostURI = new URI(dockerHost);
-            boolean isDockerDaemonLocal = "unix".equals(dockerHostURI.getScheme());
-            if (!isDockerDaemonLocal) {
-                assertNotNull(DOCKER_CERT_PATH + " environment variable not set.", System.getenv(DOCKER_CERT_PATH));
-            }
-            host = isDockerDaemonLocal ? "localhost" : dockerHostURI.getHost();
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
-    }
 
     public PostgresDockerRule() {
         startPostgresIfNecessary();
@@ -54,7 +31,7 @@ public class PostgresDockerRule implements TestRule {
         try {
             if (container == null) {
                 DockerClient docker = DefaultDockerClient.fromEnv().build();
-                container = new PostgresContainer(docker, host);
+                container = new PostgresContainer(docker);
             }
         } catch (DockerCertificateException | InterruptedException | DockerException | IOException | ClassNotFoundException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
- Mirror change made in pay-connector to remove the need for the
  DOCKER_HOST and DOCKER_CERT_PATH which were not required.
- Upgrade version of jackson-jaxrs-base dependency (2.5.4 -> 2.9.6)
  which was causing tests to fail.
- Upgrade version of jackson-datatype-guava (2.88 -> 2.9.6) and 
  jackson-jaxrs-json-provider (2.88 -> 2.9.6) which were not causing
  failures but were also an older version

Related pay-connector changes:
https://github.com/alphagov/pay-connector/commit/1f5ad7b6ec1dd8ae27b3c9dd3a7fd98556264693