### PR TITLE
PP-4389: Switch to using our openjdk-jre-base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM govukpay/openjdk:alpine-3.8.1-jre-8.181.13
+FROM govukpay/openjdk:alpine-3.8.1-jre-base-8.181.13
 
 RUN apk --no-cache upgrade
 


### PR DESCRIPTION
Switch to using Alpine's openjdk base JRE, which doesn't include image and
audio decoders.

This shrinks our containers slightly and reduces the potential for false
security alerts.