### PR TITLE
BAU: fix DatabaseTestHelper

### DIFF
--- a/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
@@ -402,5 +402,6 @@ public class DatabaseTestHelper {
 
     public void truncateAllData() {
         jdbi.withHandle(handle -> handle.createStatement("TRUNCATE TABLE users CASCADE").execute());
+        jdbi.withHandle(handle -> handle.createStatement("TRUNCATE TABLE services CASCADE").execute());
     }
 }


### PR DESCRIPTION
- fix failing tests by truncating 'services' table at the end of each
  tests

with @stephencdaly