### PR TITLE
PP-4426 Add careinspectorate.com to public sector email account whitelist

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
@@ -17,6 +17,7 @@ public class EmailValidator {
     private static final org.apache.commons.validator.routines.EmailValidator commonsEmailValidator = org.apache.commons.validator.routines.EmailValidator.getInstance();
     static {
         PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERNS = Collections.unmodifiableList(Arrays.asList(
+                "acas\\.org\\.uk",
                 "assembly\\.wales",
                 "cynulliad\\.cymru",
                 "gov\\.scot",
@@ -28,6 +29,7 @@ public class EmailValidator {
                 "mil\\.uk",
                 "mod\\.uk",
                 "naturalengland\\.org\\.uk",
+                "nhm\\.ac\\.uk",
                 "nhs\\.net",
                 "nhs\\.uk",
                 "parliament\\.scot",
@@ -35,9 +37,7 @@ public class EmailValidator {
                 "police\\.uk",
                 "scotent\\.co\\.uk",
                 "slc\\.co\\.uk",
-                "ucds\\.email",
-                "acas\\.org\\.uk",
-                "nhm\\.ac\\.uk"
+                "ucds\\.email"
                 ));
     }
     private static final Pattern PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERN;

--- a/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
@@ -19,6 +19,7 @@ public class EmailValidator {
         PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERNS = Collections.unmodifiableList(Arrays.asList(
                 "acas\\.org\\.uk",
                 "assembly\\.wales",
+                "careinspectorate\\.com",
                 "cynulliad\\.cymru",
                 "gov\\.scot",
                 "gov\\.uk",

--- a/src/test/java/uk/gov/pay/adminusers/utils/email/EmailValidatorIsPublicSectorEmailTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/email/EmailValidatorIsPublicSectorEmailTest.java
@@ -60,6 +60,7 @@ public class EmailValidatorIsPublicSectorEmailTest {
                 // all valid emails with domains
                 {"valid@acas.org.uk", true},
                 {"valid@assembly.wales", true},
+                {"valid@careinspectorate.com", true},
                 {"valid@cynulliad.cymru", true},
                 {"valid@gov.scot", true},
                 {"valid@gov.uk", true},
@@ -84,6 +85,7 @@ public class EmailValidatorIsPublicSectorEmailTest {
                 // all valid emails with subdomains
                 {"valid@subdomain.acas.org.uk", true},
                 {"valid@subdomain.assembly.wales", true},
+                {"valid@subdomain.careinspectorate.com", true},
                 {"valid@subdomain.cynulliad.cymru", true},
                 {"valid@subdomain.gov.scot", true},
                 {"valid@subdomain.gov.uk", true},

--- a/src/test/java/uk/gov/pay/adminusers/utils/email/EmailValidatorIsPublicSectorEmailTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/email/EmailValidatorIsPublicSectorEmailTest.java
@@ -82,6 +82,7 @@ public class EmailValidatorIsPublicSectorEmailTest {
 
 
                 // all valid emails with subdomains
+                {"valid@subdomain.acas.org.uk", true},
                 {"valid@subdomain.assembly.wales", true},
                 {"valid@subdomain.cynulliad.cymru", true},
                 {"valid@subdomain.gov.scot", true},

--- a/src/test/java/uk/gov/pay/adminusers/utils/email/EmailValidatorIsPublicSectorEmailTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/email/EmailValidatorIsPublicSectorEmailTest.java
@@ -58,6 +58,7 @@ public class EmailValidatorIsPublicSectorEmailTest {
                 {"valid@sub2-2.sub2-1.sub1.naturalengland.org.uk", true},
 
                 // all valid emails with domains
+                {"valid@acas.org.uk", true},
                 {"valid@assembly.wales", true},
                 {"valid@cynulliad.cymru", true},
                 {"valid@gov.scot", true},
@@ -69,6 +70,7 @@ public class EmailValidatorIsPublicSectorEmailTest {
                 {"valid@mil.uk", true},
                 {"valid@mod.uk", true},
                 {"valid@naturalengland.org.uk", true},
+                {"valid@nhm.ac.uk", true},
                 {"valid@nhs.net", true},
                 {"valid@nhs.uk", true},
                 {"valid@parliament.scot", true},
@@ -77,8 +79,6 @@ public class EmailValidatorIsPublicSectorEmailTest {
                 {"valid@scotent.co.uk", true},
                 {"valid@slc.co.uk", true},
                 {"valid@ucds.email", true},
-                {"valid@acas.org.uk", true},
-                {"valid@nhm.ac.uk", true},
 
 
                 // all valid emails with subdomains
@@ -93,6 +93,7 @@ public class EmailValidatorIsPublicSectorEmailTest {
                 {"valid@subdomain.mil.uk", true},
                 {"valid@subdomain.mod.uk", true},
                 {"valid@subdomain.naturalengland.org.uk", true},
+                {"valid@subdomain.nhm.ac.uk", true},
                 {"valid@subdomain.nhs.net", true},
                 {"valid@subdomain.nhs.uk", true},
                 {"valid@subdomain.parliament.scot", true},
@@ -100,8 +101,8 @@ public class EmailValidatorIsPublicSectorEmailTest {
                 {"valid@subdomain.police.uk", true},
                 {"valid@subdomain.scotent.co.uk", true},
                 {"valid@subdomain.slc.co.uk", true},
-                {"valid@subdomain.ucds.email", true},
-                {"valid@subdomain.nhm.ac.uk", true}
+                {"valid@subdomain.ucds.email", true}
+
         });
     }
 


### PR DESCRIPTION
The [Care Inspectorate](http://www.careinspectorate.com/) regulates social work and social care services in Scotland.

In addition, put the public sector email domain names in alphabetical order and add a subdomain test for acas.org.uk email addresses.

It may be easier to review this by going through the three commits one by one.