### PR TITLE
BAU: Configure maven for UTF-8 encoded source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,7 @@
     <artifactId>pay-adminusers</artifactId>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dropwizard.version>1.3.7</dropwizard.version>
         <hamcrest.version>1.3</hamcrest.version>
         <eclipselink.version>2.7.3</eclipselink.version>


### PR DESCRIPTION
This turns

`[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!`

into

`[INFO] Using 'UTF-8' encoding to copy filtered resources.`