### PR TITLE
BAU: Do not run dependency-check maven plugin in verify phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <docker-client.version>8.14.5</docker-client.version>
         <jackson.version>2.9.7</jackson.version>
         <pay-java-commons.version>1.0.0-7</pay-java-commons.version>
+        <dependency-check.skip>true</dependency-check.skip>
     </properties>
     <repositories>
         <repository>
@@ -383,10 +384,23 @@
                     </arguments>
                 </configuration>
             </plugin>
+            <!--
+                https://jeremylong.github.io/DependencyCheck/dependency-check-maven/
+                By default, the dependency-check plugin is tied to the verify phase
+                (when used as a build plugin). We don’t want this; we just want to
+                run it manually when required. So we define a property called
+                dependency-check.skip, set it to true, and use this property’s value
+                to set the dependency-check plugin’s own skip property. To execute
+                the plugin manually, override the dependency-check.skip property:
+                $ mvn dependency-check:check -Ddependency-check.skip=false
+            -->
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
                 <version>4.0.0</version>
+                <configuration>
+                    <skip>${dependency-check.skip}</skip>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -277,18 +277,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.owasp</groupId>
-                <artifactId>dependency-check-maven</artifactId>
-                <version>4.0.0</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
@@ -394,6 +382,18 @@
                         <argument>src/main/resources/config/config.yaml</argument>
                     </arguments>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>4.0.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
By default, the dependency-check plugin is tied to the `verify` phase (when used as a build plugin). We don’t want this; we just want to run it manually when required. So we define a property called `dependency-check.skip`, set it to `true`, and use this property’s value to set the dependency-check plugin’s own `skip` property. To execute the plugin manually, override the dependency-check.skip property:

```
$ mvn dependency-check:check -Ddependency-check.skip=false
```