### PR TITLE
BAU: Remove Spotify docker-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,6 @@
         <eclipselink.version>2.7.3</eclipselink.version>
         <guice.version>4.2.2</guice.version>
         <guava.version>27.0.1-jre</guava.version>
-        <docker-client.version>8.14.5</docker-client.version>
         <jackson.version>2.9.7</jackson.version>
         <pay-java-commons.version>1.0.0-f6097986677849386f283bb84072198b57931b1b</pay-java-commons.version>
         <dependency-check.skip>true</dependency-check.skip>
@@ -236,12 +235,6 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>java-hamcrest</artifactId>
             <version>2.0.0.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.spotify</groupId>
-            <artifactId>docker-client</artifactId>
-            <version>${docker-client.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Since 0ecff2068702092ff1820a81fce1e3ff9ebe30ea we don't use this library
directly, instead we use it via pay-java-commons. Remove the unnecessary
dependency.