### PR TITLE
BAU: Remove org.apache.httpcomponents httpclient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,11 +169,6 @@
             <version>1.2.0</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.6</version>
-        </dependency>
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.2.3</version>


### PR DESCRIPTION
adminusers doesn't use this dependency. Remove it.