### PR TITLE
PP-4521 Updating name with a non string value should not return 500

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
@@ -87,6 +87,9 @@ public class ServiceUpdateOperationValidator {
                 requestValidations.checkExists(operation, FIELD_VALUE).ifPresent(errors::addAll);
             }
             if (errors.isEmpty()) {
+                requestValidations.checkIsString(operation, FIELD_VALUE).ifPresent(errors::addAll);
+            }
+            if (errors.isEmpty()) {
                 requestValidations.checkMaxLength(operation, SERVICE_NAME_MAX_LENGTH, FIELD_VALUE).ifPresent(errors::addAll);
             }
         } else if (FIELD_REDIRECT_NAME.equals(path)) {

--- a/src/main/java/uk/gov/pay/adminusers/validations/RequestValidations.java
+++ b/src/main/java/uk/gov/pay/adminusers/validations/RequestValidations.java
@@ -40,6 +40,10 @@ public class RequestValidations {
     public Optional<List<String>> checkMaxLength(JsonNode payload, int maxLength, String... fieldNames) {
         return applyCheck(payload, exceedsMaxLength(maxLength), fieldNames, "Field [%s] must have a maximum length of " + maxLength + " characters");
     }
+    
+    public Optional<List<String>> checkIsString(JsonNode payload, String... fieldNames) {
+        return applyCheck(payload, isNotString(), fieldNames, "Field [%s] must be a string");
+    }
 
     private Function<JsonNode, Boolean> exceedsMaxLength(int maxLength) {
         return jsonNode -> jsonNode.asText().length() > maxLength;
@@ -101,6 +105,10 @@ public class RequestValidations {
 
     static Function<JsonNode, Boolean> isNotStrictBoolean() {
         return jsonNode -> !jsonNode.isBoolean();
+    }
+    
+    static Function<JsonNode, Boolean> isNotString() {
+        return jsonNode -> !jsonNode.isTextual();
     }
 
     public Optional<List<String>> isValidEmail(JsonNode payload, String... fieldNames) {

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
@@ -290,4 +290,26 @@ public class ServiceUpdateOperationValidatorTest {
         assertThat(errors.size(), is(1));
         assertThat(errors, hasItem("Field [value] is required"));
     }
+
+    @Test
+    public void shouldFail_updatingServiceName_whenValueIsNumeric() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("path", "name");
+        payload.put("op", "replace");
+        payload.put("value", 42);
+        List<String> errors = serviceUpdateOperationValidator.validate(payload);
+        assertThat(errors.size(), is(1));
+        assertThat(errors, hasItem("Field [value] must be a string"));
+    }
+
+    @Test
+    public void shouldFail_updatingServiceName_whenValueIsBoolean() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("path", "service_name/en");
+        payload.put("op", "replace");
+        payload.put("value", false);
+        List<String> errors = serviceUpdateOperationValidator.validate(payload);
+        assertThat(errors.size(), is(1));
+        assertThat(errors, hasItem("Field [value] must be a string"));
+    }
 }


### PR DESCRIPTION
##WHAT
- fix validation for ServiceUpdateOperationValidator that it checks whether the value for 'name' and 'service_name/xx' is string
- add relevant tests