### PR TITLE
PP-4520 Updating a service's name should also update English language service name as well

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
@@ -79,7 +79,8 @@ public class ServiceUpdater {
     }
 
     private BiConsumer<ServiceUpdateRequest, ServiceEntity> updateServiceName() {
-        return (serviceUpdateRequest, serviceEntity) -> serviceEntity.setName(serviceUpdateRequest.valueAsString());
+        return (serviceUpdateRequest, serviceEntity) -> serviceEntity
+                .addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.ENGLISH, serviceUpdateRequest.valueAsString()));
     }
 
     private BiConsumer<ServiceUpdateRequest, ServiceEntity> assignGatewayAccounts() {

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/ServiceDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/ServiceDbFixture.java
@@ -51,6 +51,7 @@ public class ServiceDbFixture {
         Service service = Service.from(serviceId, extId, name);
         service.setMerchantDetails(merchantDetails);
         service.setCollectBillingAddress(collectBillingAddress);
+        service.getServiceNames().put("en", service.getName());
         databaseHelper.addService(service, gatewayAccountIds);
 
         return service;

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateNameTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateNameTest.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.adminusers.resources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.adminusers.model.Service;
+
+import static com.jayway.restassured.http.ContentType.JSON;
+import static java.lang.String.format;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
+
+public class ServiceResourceUpdateNameTest extends IntegrationTest {
+    
+    private String serviceExternalId;
+
+    @Before
+    public void setup() {
+        Service service = serviceDbFixture(databaseHelper).insertService();
+        serviceExternalId = service.getExternalId();
+    }
+    @Test
+    public void shouldUpdateBothNameAndEnglishServiceName_whenUpdatingName() {
+        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace", "path", "name", "value", "New Service Name"));
+        givenSetup()
+                .when()
+                .accept(JSON)
+                .body(payload)
+                .patch(format("/v1/api/services/%s", serviceExternalId))
+                .then()
+                .statusCode(200)
+                .body("name", is("New Service Name"))
+                .body("service_name.en", is("New Service Name"));
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceUpdaterTest.java
@@ -19,6 +19,7 @@ import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
 import javax.ws.rs.WebApplicationException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -55,16 +56,16 @@ public class ServiceUpdaterTest {
                 "path", new TextNode("name"),
                 "value", new TextNode(nameToUpdate),
                 "op", new TextNode("replace"))));
-        ServiceEntity serviceEntity = mock(ServiceEntity.class);
+        ServiceEntity serviceEntity = new ServiceEntity();
 
         when(serviceDao.findByExternalId(serviceId)).thenReturn(Optional.of(serviceEntity));
-        when(serviceEntity.toService()).thenReturn(Service.from());
 
         Optional<Service> maybeService = updater.doUpdate(serviceId, request);
 
         assertThat(maybeService.isPresent(), is(true));
-        verify(serviceEntity, times(1)).setName(nameToUpdate);
-        verify(serviceDao, times(1)).merge(serviceEntity);
+        assertThat(maybeService.get().getServiceNames().size(), is(1));
+        assertThat(maybeService.get().getServiceNames().get("en"), is(nameToUpdate));
+        verify(serviceDao).merge(serviceEntity);
     }
 
     @Test


### PR DESCRIPTION
  ## WHAT
- refactor ServiceUpdater to automagically update English language service name when updating the 'name' field
- add relevant tests