### PR TITLE
PP-4575 Allow domain socialworkengland.org.uk

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
@@ -38,7 +38,8 @@ public class EmailValidator {
                 "police\\.uk",
                 "scotent\\.co\\.uk",
                 "slc\\.co\\.uk",
-                "ucds\\.email"
+                "ucds\\.email",
+                "socialworkengland\\.org\\.uk"
                 ));
     }
     private static final Pattern PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERN;

--- a/src/test/java/uk/gov/pay/adminusers/utils/email/EmailValidatorIsPublicSectorEmailTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/email/EmailValidatorIsPublicSectorEmailTest.java
@@ -80,6 +80,7 @@ public class EmailValidatorIsPublicSectorEmailTest {
                 {"valid@scotent.co.uk", true},
                 {"valid@slc.co.uk", true},
                 {"valid@ucds.email", true},
+                {"valid@socialworkengland.org.uk", true},
 
 
                 // all valid emails with subdomains
@@ -104,7 +105,8 @@ public class EmailValidatorIsPublicSectorEmailTest {
                 {"valid@subdomain.police.uk", true},
                 {"valid@subdomain.scotent.co.uk", true},
                 {"valid@subdomain.slc.co.uk", true},
-                {"valid@subdomain.ucds.email", true}
+                {"valid@subdomain.ucds.email", true},
+                {"valid@subdomain.socialworkengland.org.uk", true}
 
         });
     }


### PR DESCRIPTION
### WHAT

Allow new domain socialworkengland.org.uk ( see Zendesk #3544527)