### PR TITLE
PP-4575 Fix email validator domain name ordering

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
@@ -9,14 +9,14 @@ import java.util.regex.Pattern;
 public class EmailValidator {
 
     /**
-     * {@link #PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERNS} is based on:<br>
+     * {@link #PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERNS_IN_ASCENDING_ORDER} is based on:<br>
      * - <a href="https://en.wikipedia.org/wiki/.uk">en.wikipedia.org/wiki/.uk</a><br>
      * - <a href="https://github.com/alphagov/notifications-admin/blob/9391181b2c7d077ea8fe0a72c718ab8f7fdbcd0c/app/config.py#L67">alphagov/notifications-admin</a><br>
      */
-    private static final List<String> PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERNS;
+    private static final List<String> PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERNS_IN_ASCENDING_ORDER;
     private static final org.apache.commons.validator.routines.EmailValidator commonsEmailValidator = org.apache.commons.validator.routines.EmailValidator.getInstance();
     static {
-        PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERNS = Collections.unmodifiableList(Arrays.asList(
+        PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERNS_IN_ASCENDING_ORDER = Collections.unmodifiableList(Arrays.asList(
                 "acas\\.org\\.uk",
                 "assembly\\.wales",
                 "careinspectorate\\.com",
@@ -44,7 +44,7 @@ public class EmailValidator {
     }
     private static final Pattern PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERN;
     static {
-        String domainRegExPatternString = Joiner.on("|").join(PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERNS);
+        String domainRegExPatternString = Joiner.on("|").join(PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERNS_IN_ASCENDING_ORDER);
 
         // We are splitting the logic into two parts for whitelisted domains and subdomains
         String regExDomainsOnlyPart = "(" + domainRegExPatternString + ")";

--- a/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
@@ -38,8 +38,8 @@ public class EmailValidator {
                 "police\\.uk",
                 "scotent\\.co\\.uk",
                 "slc\\.co\\.uk",
-                "ucds\\.email",
-                "socialworkengland\\.org\\.uk"
+                "socialworkengland\\.org\\.uk",
+                "ucds\\.email"
                 ));
     }
     private static final Pattern PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERN;

--- a/src/test/java/uk/gov/pay/adminusers/utils/email/EmailValidatorIsPublicSectorEmailTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/email/EmailValidatorIsPublicSectorEmailTest.java
@@ -79,8 +79,8 @@ public class EmailValidatorIsPublicSectorEmailTest {
                 {"valid@police.uk", true},
                 {"valid@scotent.co.uk", true},
                 {"valid@slc.co.uk", true},
-                {"valid@ucds.email", true},
                 {"valid@socialworkengland.org.uk", true},
+                {"valid@ucds.email", true},
 
 
                 // all valid emails with subdomains
@@ -105,8 +105,8 @@ public class EmailValidatorIsPublicSectorEmailTest {
                 {"valid@subdomain.police.uk", true},
                 {"valid@subdomain.scotent.co.uk", true},
                 {"valid@subdomain.slc.co.uk", true},
-                {"valid@subdomain.ucds.email", true},
-                {"valid@subdomain.socialworkengland.org.uk", true}
+                {"valid@subdomain.socialworkengland.org.uk", true},
+                {"valid@subdomain.ucds.email", true}
 
         });
     }


### PR DESCRIPTION
## WHAT

Sort the domain names in ascending order

## HOW

- Rename `PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERNS` to `PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERNS_IN_ASCENDING_ORDER` to explicitly document the order of domain names
- Sort domain names by ascending order

Related PR: https://github.com/alphagov/pay-adminusers/pull/326