### PR TITLE
PP-4539 Create stripe_agreements table to hold IP address.

### DIFF
--- a/src/main/resources/migrations/00048_create_table_stripe_agreements.sql
+++ b/src/main/resources/migrations/00048_create_table_stripe_agreements.sql
@@ -1,0 +1,10 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:create_table-stripe_agreements
+CREATE TABLE stripe_agreements (
+  id SERIAL PRIMARY KEY,
+  service_id INT NOT NULL UNIQUE REFERENCES services (id),
+  ip_address VARCHAR(45) NOT NULL,
+  agreement_time TIMESTAMP WITHOUT TIME ZONE NOT NULL
+);
+--rollback drop table stripe_agreements;


### PR DESCRIPTION
- Create `stripe_agreements` table to hold `ip_address`, `service_id` and
`agreement_time`.
- Discussed the option of defaulting the `agreement_time` to `NOW()` to provide
the option of letting postgres set the value however this would be inconsistent
with existing implementations so it was discouraged.
- `service_id` is unique since there can be only one stripe agreement per service.