### PR TITLE
PP-4539 Create components to persist stripe agreement information

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/persistence/dao/StripeAgreementDao.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/dao/StripeAgreementDao.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.adminusers.persistence.dao;
+
+import com.google.inject.Provider;
+import com.google.inject.persist.Transactional;
+import uk.gov.pay.adminusers.persistence.entity.StripeAgreementEntity;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import java.util.Optional;
+
+@Transactional
+public class StripeAgreementDao extends JpaDao<StripeAgreementEntity> {
+
+    @Inject
+    public StripeAgreementDao(Provider<EntityManager> entityManager) {
+        super(entityManager, StripeAgreementEntity.class);
+    }
+
+
+    public Optional<StripeAgreementEntity> findByServiceId(int serviceId) {
+
+        String query = "SELECT s FROM StripeAgreementEntity s " +
+                "WHERE s.serviceId = :serviceId";
+
+        return entityManager.get()
+                .createQuery(query, StripeAgreementEntity.class)
+                .setParameter("serviceId", serviceId)
+                .getResultStream()
+                .findFirst();
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/StripeAgreementEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/StripeAgreementEntity.java
@@ -1,0 +1,56 @@
+package uk.gov.pay.adminusers.persistence.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "stripe_agreements")
+@SequenceGenerator(name = "stripe_agreements_id_seq_gen", sequenceName = "stripe_agreements_id_seq", allocationSize = 1)
+
+public class StripeAgreementEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "stripe_agreements_id_seq_gen")
+    private int id;
+
+    @Column(name = "service_id")
+    private int serviceId;
+
+    @Column(name = "ip_address")
+    private String ipAddress;
+
+    @Column(name = "agreement_time", columnDefinition = "TIMESTAMP WITHOUT TIME ZONE NOT NULL")
+    private LocalDateTime agreementTime;
+
+    public StripeAgreementEntity() {
+        // for jpa
+    }
+
+    public StripeAgreementEntity(int serviceId, String ipAddress, LocalDateTime agreementTime) {
+        this.serviceId = serviceId;
+        this.ipAddress = ipAddress;
+        this.agreementTime = agreementTime;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public int getServiceId() {
+        return serviceId;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public LocalDateTime getAgreementTime() {
+        return agreementTime;
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/StripeAgreementDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/StripeAgreementDbFixture.java
@@ -1,0 +1,43 @@
+package uk.gov.pay.adminusers.fixtures;
+
+import uk.gov.pay.adminusers.persistence.entity.StripeAgreementEntity;
+import uk.gov.pay.adminusers.utils.DatabaseTestHelper;
+
+import java.time.LocalDateTime;
+
+public class StripeAgreementDbFixture {
+
+    private final DatabaseTestHelper databaseTestHelper;
+    private String ipAddress = "192.0.2.0";
+    private int serviceId;
+    private LocalDateTime agreementTime = LocalDateTime.now();
+
+    private StripeAgreementDbFixture(DatabaseTestHelper databaseTestHelper) {
+        this.databaseTestHelper = databaseTestHelper;
+    }
+
+    public static StripeAgreementDbFixture stripeAgreementDbFixture(DatabaseTestHelper databaseTestHelper) {
+        return new StripeAgreementDbFixture(databaseTestHelper);
+    }
+
+    public StripeAgreementEntity insert() {
+        StripeAgreementEntity stripeAgreementEntity = new StripeAgreementEntity(serviceId, ipAddress, agreementTime);
+        databaseTestHelper.insertStripeAgreementEntity(stripeAgreementEntity);
+        return stripeAgreementEntity;
+    }
+
+    public StripeAgreementDbFixture withIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+        return this;
+    }
+
+    public StripeAgreementDbFixture withServiceId(int serviceId) {
+        this.serviceId = serviceId;
+        return this;
+    }
+
+    public StripeAgreementDbFixture withAgreementTime(LocalDateTime agreementTime) {
+        this.agreementTime = agreementTime;
+        return this;
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/StripeAgreementDaoTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/StripeAgreementDaoTest.java
@@ -1,0 +1,101 @@
+package uk.gov.pay.adminusers.persistence.dao;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.adminusers.model.Service;
+import uk.gov.pay.adminusers.persistence.entity.StripeAgreementEntity;
+
+import javax.persistence.RollbackException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.commons.lang3.RandomUtils.nextInt;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
+import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
+import static uk.gov.pay.adminusers.fixtures.StripeAgreementDbFixture.stripeAgreementDbFixture;
+
+public class StripeAgreementDaoTest extends DaoTestBase {
+
+    private StripeAgreementDao stripeAgreementDao;
+
+    @Before
+    public void before() throws Exception {
+        stripeAgreementDao = env.getInstance(StripeAgreementDao.class);
+    }
+
+    @Test
+    public void shouldPersistStripeAgreementEntity() {
+        int serviceId = serviceDbFixture(databaseHelper)
+                .withGatewayAccountIds(randomInt().toString())
+                .insertService()
+                .getId();
+
+        StripeAgreementEntity stripeAgreementEntity = new StripeAgreementEntity(serviceId, "192.0.2.0", LocalDateTime.now());
+        stripeAgreementDao.persist(stripeAgreementEntity);
+
+        assertThat(stripeAgreementEntity.getId(), is(notNullValue()));
+        List<Map<String, Object>> searchResults = databaseHelper.findStripeAgreementById(stripeAgreementEntity.getId());
+        assertThat(searchResults.size(), is(1));
+        assertThat(searchResults.get(0).get("service_id"), is(stripeAgreementEntity.getServiceId()));
+        assertThat(searchResults.get(0).get("ip_address"), is(stripeAgreementEntity.getIpAddress()));
+        assertThat(searchResults.get(0).get("id"), is(stripeAgreementEntity.getId()));
+        assertThat(((Timestamp) searchResults.get(0).get("agreement_time")).toLocalDateTime(), is(stripeAgreementEntity.getAgreementTime()));
+    }
+
+    @Test
+    public void shouldNotPersistStripeAgreementEntityWhenOneAlreadyExistsForService() {
+        int serviceId = serviceDbFixture(databaseHelper)
+                .withGatewayAccountIds(randomInt().toString())
+                .insertService()
+                .getId();
+
+        StripeAgreementEntity stripeAgreementEntity = new StripeAgreementEntity(serviceId, "192.0.2.0", LocalDateTime.now());
+        stripeAgreementDao.persist(stripeAgreementEntity);
+
+        StripeAgreementEntity anotherStripeAgreementEntity = new StripeAgreementEntity(serviceId, "192.0.2.1", LocalDateTime.now());
+        try {
+            stripeAgreementDao.persist(anotherStripeAgreementEntity);
+            fail();
+        } catch (RollbackException e) {
+            assertTrue(e.getMessage().contains("Key (service_id)=(" + serviceId + ") already exists."));
+        }
+    }
+
+    @Test
+    public void shouldFindStripeAgreementEntityByServiceId() {
+        Service service = serviceDbFixture(databaseHelper)
+                .insertService();
+
+        StripeAgreementEntity stripeAgreementEntity = stripeAgreementDbFixture(databaseHelper)
+                .withServiceId(service.getId())
+                .insert();
+
+        Optional<StripeAgreementEntity> maybeStripeAgreementEntity = stripeAgreementDao.findByServiceId(stripeAgreementEntity.getServiceId());
+        assertTrue(maybeStripeAgreementEntity.isPresent());
+        assertThat(maybeStripeAgreementEntity.get().getIpAddress(), is(stripeAgreementEntity.getIpAddress()));
+        assertThat(maybeStripeAgreementEntity.get().getServiceId(), is(stripeAgreementEntity.getServiceId()));
+        assertThat(maybeStripeAgreementEntity.get().getAgreementTime(), is(stripeAgreementEntity.getAgreementTime()));
+    }
+
+    @Test
+    public void shouldNotFindStripeAgreementEntityWhenNoneExistForServiceId() {
+        Service service = serviceDbFixture(databaseHelper)
+                .insertService();
+
+        stripeAgreementDbFixture(databaseHelper)
+                .withServiceId(service.getId())
+                .insert();
+
+        Optional<StripeAgreementEntity> maybeStripeAgreementEntity = stripeAgreementDao.findByServiceId(nextInt());
+        assertFalse(maybeStripeAgreementEntity.isPresent());
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
@@ -11,6 +11,7 @@ import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.persistence.entity.CustomBrandingConverter;
 import uk.gov.pay.adminusers.persistence.entity.MerchantDetailsEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
+import uk.gov.pay.adminusers.persistence.entity.StripeAgreementEntity;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
 
 import java.sql.Timestamp;
@@ -348,6 +349,23 @@ public class DatabaseTestHelper {
                 h.createQuery("SELECT * FROM service_names WHERE service_id = :serviceId")
                         .bind("serviceId", serviceId)
                         .list());
+    }
+
+    public List<Map<String, Object>> findStripeAgreementById(int id) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("SELECT * FROM stripe_agreements WHERE id = :id")
+                        .bind("id", id)
+                        .list());
+    }
+
+    public DatabaseTestHelper insertStripeAgreementEntity(StripeAgreementEntity stripeAgreementEntity) {
+        jdbi.withHandle(handle -> handle
+                .createStatement("INSERT INTO stripe_agreements(service_id, agreement_time, ip_address) VALUES (:serviceId, :agreementTime, :ipAddress)")
+                .bind("serviceId", stripeAgreementEntity.getServiceId())
+                .bind("agreementTime", stripeAgreementEntity.getAgreementTime())
+                .bind("ipAddress", stripeAgreementEntity.getIpAddress())
+                .execute());
+        return this;
     }
 
     public DatabaseTestHelper addServiceName(ServiceNameEntity entity, Integer serviceId) {


### PR DESCRIPTION
- Add `StripeAgreementDao` to manage persistence of stripe agreements.
- Add `StripeAgreementEntity`.
- Add tests for `StripeAgreementDao` including necessary fixtures and methods to
`DatabaseTestHelper` class.