### PR TITLE
bau: fix pact publishing issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
         <dependency>
             <groupId>au.com.dius</groupId>
             <artifactId>pact-jvm-provider-junit_2.12</artifactId>
-            <version>3.5.24</version>
+            <version>3.6.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/uk/gov/pay/adminusers/pact/ProviderContractTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/pact/ProviderContractTest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.adminusers.pact;
 
+import au.com.dius.pact.provider.junit.PactRunner;
 import au.com.dius.pact.provider.junit.Provider;
 import au.com.dius.pact.provider.junit.State;
 import au.com.dius.pact.provider.junit.loader.PactBroker;
@@ -23,7 +24,6 @@ import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.service.PasswordHasher;
 import uk.gov.pay.adminusers.utils.DatabaseTestHelper;
-import uk.gov.pay.commons.testing.pact.providers.PayPactRunner;
 
 import java.util.Arrays;
 import java.util.List;
@@ -35,7 +35,7 @@ import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.RoleDbFixture.roleDbFixture;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 
-@RunWith(PayPactRunner.class)
+@RunWith(PactRunner.class)
 @Provider("adminusers")
 @PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test", "staging", "production"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"))


### PR DESCRIPTION
Deprecate our custom PayPactRunner, and upgrade the pact library to version
3.6.1.

This commit is in conjunction with alphagov/pay-jenkins-library@2ca9dc2.

@oswaldquek