### PR TITLE
PP-4602 - change structure of adminusers loglines

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -13,7 +13,7 @@ logging:
         threshold: ALL
         timeZone: UTC
         target: stdout
-        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] [%-5level] [%logger{15}] %msg %n"
+        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] %msg%n"
 
 database:
   driverClass: org.postgresql.Driver

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -13,7 +13,7 @@ logging:
         threshold: ALL
         timeZone: UTC
         target: stdout
-        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] [%-5level] [%logger{15}] - %msg %n"
+        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] %msg%n"
 
 database:
   driverClass: org.postgresql.Driver


### PR DESCRIPTION
 - Making the log lines look more like connector's by adding additional info as to what is reported. 

This helps in two way: searches are going to return  more uniform results, and we will have less noise when looking for errors. For example,`level=error` will help isolating the `logger.error` lines rather than lower  level ones which simply have the word error in the message