### PR TITLE
BAU: Stop needlessly wrapping Optionals in Optionals

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceInviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceInviteCompleter.java
@@ -72,11 +72,11 @@ public class ServiceInviteCompleter extends InviteCompleter {
                         InviteCompleteResponse response = new InviteCompleteResponse(invite);
                         response.setServiceExternalId(serviceEntity.getExternalId());
                         response.setUserExternalId(userEntity.getExternalId());
-                        return Optional.of(response);
+                        return response;
                     } else {
                         throw internalServerError(format("Attempting to complete a service invite for a non service invite of type. invite-code = %s", inviteEntity.getCode()));
                     }
-                }).orElseGet(Optional::empty);
+                });
     }
 
 }


### PR DESCRIPTION
We have some code like this (simplified):

```java
return inviteDao.findByCode(inviteCode).map(inviteEntity -> {
    // Do some stuff to create an InviteCompleteResponse
    return Optional.of(response);
}).orElseGet(Optional::empty);
```

This is silly. The `Optional.map(…)` method wraps what’s returned in an `Optional`, so when `Optional<InviteCompleteResponse>` is returned, it becomes `Optional<Optional<InviteCompleteResponse>>` . Then `.orElseGet(Optional::empty)` unwraps the outer `Optional` so we just have `Optional<InviteCompleteResponse>`, which is returned.

We can avoid this muppetry by changing the code to be like this:

```java
return inviteDao.findByCode(inviteCode).map(inviteEntity -> {
    // Do some stuff to create an InviteCompleteResponse
    return response;
});
```

(If for some reason we absolutely had to return `Optional.of(response)` from the lambda expression, we could have used `Optional.flatMap(…)` instead of `Optional.map(…)` to avoid it being wrapped in an another `Optional`, allowing us to remove the `.orElseGet(Optional::empty)` bit.)