### PR TITLE
PP-4539 Make StripeAgreementDao search by service external id

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/model/StripeAgreement.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/StripeAgreement.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.adminusers.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
@@ -11,23 +10,15 @@ public class StripeAgreement {
     
     public static final String FIELD_IP_ADDRESS = "ip_address";
     
-    @JsonIgnore
-    private int serviceId;
-    
     @JsonProperty(FIELD_IP_ADDRESS)
     private InetAddress ipAddress;
     
     @JsonProperty("agreement_time")
     private ZonedDateTime agreementTime;
 
-    public StripeAgreement(int serviceId, InetAddress ipAddress, ZonedDateTime agreementTime) {
-        this.serviceId = serviceId;
+    public StripeAgreement(InetAddress ipAddress, ZonedDateTime agreementTime) {
         this.ipAddress = ipAddress;
         this.agreementTime = agreementTime;
-    }
-    
-    public int getServiceId() {
-        return serviceId;
     }
 
     public InetAddress getIpAddress() {

--- a/src/main/java/uk/gov/pay/adminusers/persistence/dao/StripeAgreementDao.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/dao/StripeAgreementDao.java
@@ -17,14 +17,14 @@ public class StripeAgreementDao extends JpaDao<StripeAgreementEntity> {
     }
 
 
-    public Optional<StripeAgreementEntity> findByServiceId(int serviceId) {
+    public Optional<StripeAgreementEntity> findByServiceExternalId(String serviceExternalId) {
 
         String query = "SELECT s FROM StripeAgreementEntity s " +
-                "WHERE s.serviceId = :serviceId";
+                "WHERE s.service.externalId = :serviceExternalId";
 
         return entityManager.get()
                 .createQuery(query, StripeAgreementEntity.class)
-                .setParameter("serviceId", serviceId)
+                .setParameter("serviceExternalId", serviceExternalId)
                 .getResultStream()
                 .findFirst();
     }

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/StripeAgreementEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/StripeAgreementEntity.java
@@ -8,6 +8,10 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MapsId;
+import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import java.net.InetAddress;
@@ -23,9 +27,10 @@ public class StripeAgreementEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "stripe_agreements_id_seq_gen")
     private int id;
-
-    @Column(name = "service_id")
-    private int serviceId;
+    
+    @OneToOne
+    @JoinColumn(name = "service_id", referencedColumnName = "id")
+    private ServiceEntity service;
 
     @Column(name = "ip_address")
     private String ipAddress;
@@ -38,23 +43,15 @@ public class StripeAgreementEntity {
         // for jpa
     }
 
-    public StripeAgreementEntity(int serviceId, String ipAddress, ZonedDateTime agreementTime) {
-        this.serviceId = serviceId;
+    public StripeAgreementEntity(ServiceEntity service, String ipAddress, ZonedDateTime agreementTime) {
+        this.service = service;
         this.ipAddress = ipAddress;
         this.agreementTime = agreementTime;
     }
     
-    public static StripeAgreementEntity from(StripeAgreement stripeAgreement) {
-        return new StripeAgreementEntity(
-                stripeAgreement.getServiceId(),
-                stripeAgreement.getIpAddress().getHostAddress(),
-                stripeAgreement.getAgreementTime()
-        );
-    }
-    
     public StripeAgreement toStripeAgreement() {
         try {
-            return new StripeAgreement(serviceId, InetAddress.getByName(ipAddress), agreementTime);
+            return new StripeAgreement(InetAddress.getByName(ipAddress), agreementTime);
         } catch (UnknownHostException e) {
             // Ip addresses are validated before storing them in the table so its very unlikely this will happen.
             throw new RuntimeException(String.format("%s is not a valid InetAddress.", ipAddress));
@@ -65,8 +62,8 @@ public class StripeAgreementEntity {
         return id;
     }
 
-    public int getServiceId() {
-        return serviceId;
+    public ServiceEntity getService() {
+        return service;
     }
 
     public String getIpAddress() {

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
@@ -36,8 +36,6 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -234,17 +232,8 @@ public class ServiceResource {
                                           @NotNull @Valid StripeAgreementRequest stripeAgreementRequest) throws UnknownHostException {
         LOGGER.info("Create stripe agreement POST request - [ {} ]", stripeAgreementRequest.toString());
 
-        ServiceEntity service = serviceDao.findByExternalId(serviceExternalId)
-                .orElseThrow( () -> new WebApplicationException(Status.NOT_FOUND));
-        
-        if (stripeAgreementService.findStripeAgreementByServiceId(service.getId()).isPresent()) {
-            throw new WebApplicationException("Stripe agreement information is already stored for this service",
-                    Status.CONFLICT);
-        }
-
-        stripeAgreementService.doCreate(service.getId(),
-                InetAddress.getByName(stripeAgreementRequest.getIpAddress()),
-                ZonedDateTime.now(ZoneId.of("UTC")));
+        stripeAgreementService.doCreate(serviceExternalId,
+                InetAddress.getByName(stripeAgreementRequest.getIpAddress()));
 
         return Response.status(OK).build();
     }
@@ -254,8 +243,7 @@ public class ServiceResource {
     @Produces(APPLICATION_JSON)
     public StripeAgreement getStripeAgreement(@PathParam("serviceExternalId") String serviceExternalId) {
 
-        return serviceDao.findByExternalId(serviceExternalId)
-                .flatMap(serviceEntity -> stripeAgreementService.findStripeAgreementByServiceId(serviceEntity.getId()))
+        return stripeAgreementService.findStripeAgreementByServiceId(serviceExternalId)
                 .orElseThrow(() -> new WebApplicationException(Status.NOT_FOUND));
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/service/StripeAgreementService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/StripeAgreementService.java
@@ -4,10 +4,15 @@ import com.google.inject.Inject;
 import org.slf4j.Logger;
 import uk.gov.pay.adminusers.logger.PayLoggerFactory;
 import uk.gov.pay.adminusers.model.StripeAgreement;
+import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
 import uk.gov.pay.adminusers.persistence.dao.StripeAgreementDao;
+import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.StripeAgreementEntity;
 
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
 import java.net.InetAddress;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
@@ -18,19 +23,31 @@ public class StripeAgreementService {
     private static Logger logger = PayLoggerFactory.getLogger(StripeAgreementService.class);
 
     private final StripeAgreementDao stripeAgreementDao;
+    private ServiceDao serviceDao;
 
     @Inject
-    public StripeAgreementService(StripeAgreementDao stripeAgreementDao) {
+    public StripeAgreementService(StripeAgreementDao stripeAgreementDao,
+                                  ServiceDao serviceDao) {
         this.stripeAgreementDao = stripeAgreementDao;
+        this.serviceDao = serviceDao;
     }
 
-    public Optional<StripeAgreement> findStripeAgreementByServiceId(int serviceId) {
-        return stripeAgreementDao.findByServiceId(serviceId)
+    public Optional<StripeAgreement> findStripeAgreementByServiceId(String serviceExternalId) {
+        return stripeAgreementDao.findByServiceExternalId(serviceExternalId)
                 .map((StripeAgreementEntity::toStripeAgreement));
     }
     
-    public void doCreate(int serviceId, InetAddress ipAddress, ZonedDateTime agreementTime) {
-        logger.info(format("Creating stripe agreement for service %s", serviceId));
-        stripeAgreementDao.persist(new StripeAgreementEntity(serviceId, ipAddress.getHostAddress(), agreementTime));
+    public void doCreate(String serviceExternalId, InetAddress ipAddress) {
+        ServiceEntity serviceEntity = serviceDao.findByExternalId(serviceExternalId)
+                .orElseThrow( () -> new WebApplicationException(Response.Status.NOT_FOUND));
+        
+        if (stripeAgreementDao.findByServiceExternalId(serviceExternalId).isPresent()) {
+            throw new WebApplicationException("Stripe agreement information is already stored for this service",
+                    Response.Status.CONFLICT);
+        }
+
+        logger.info(format("Creating stripe agreement for service %s", serviceExternalId));
+        ZonedDateTime agreementTime = ZonedDateTime.now(ZoneId.of("UTC"));
+        stripeAgreementDao.persist(new StripeAgreementEntity(serviceEntity, ipAddress.getHostAddress(), agreementTime));
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/StripeAgreementDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/StripeAgreementDbFixture.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.adminusers.fixtures;
 
-import uk.gov.pay.adminusers.persistence.entity.StripeAgreementEntity;
 import uk.gov.pay.adminusers.utils.DatabaseTestHelper;
 
 import java.time.ZoneId;
@@ -21,10 +20,8 @@ public class StripeAgreementDbFixture {
         return new StripeAgreementDbFixture(databaseTestHelper);
     }
 
-    public StripeAgreementEntity insert() {
-        StripeAgreementEntity stripeAgreementEntity = new StripeAgreementEntity(serviceId, ipAddress, agreementTime);
-        databaseTestHelper.insertStripeAgreementEntity(stripeAgreementEntity);
-        return stripeAgreementEntity;
+    public void insert() {
+        databaseTestHelper.insertStripeAgreementEntity(serviceId, agreementTime, ipAddress);
     }
 
     public StripeAgreementDbFixture withIpAddress(String ipAddress) {

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceStripeAgreementTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceStripeAgreementTest.java
@@ -7,8 +7,10 @@ import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.adminusers.fixtures.StripeAgreementDbFixture;
 import uk.gov.pay.adminusers.model.Service;
-import uk.gov.pay.adminusers.persistence.entity.StripeAgreementEntity;
 import uk.gov.pay.adminusers.utils.DateTimeUtils;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
@@ -52,7 +54,7 @@ public class ServiceResourceStripeAgreementTest extends IntegrationTest {
 
     @Test
     public void shouldReturn_409_whenStripeAgreementAlreadyExists() {
-        StripeAgreementEntity stripeAgreement = StripeAgreementDbFixture.stripeAgreementDbFixture(databaseHelper)
+        StripeAgreementDbFixture.stripeAgreementDbFixture(databaseHelper)
                 .withServiceId(service.getId())
                 .insert();
         
@@ -97,8 +99,13 @@ public class ServiceResourceStripeAgreementTest extends IntegrationTest {
 
     @Test
     public void shouldGetStripeAgreementDetails() {
-        StripeAgreementEntity stripeAgreement = StripeAgreementDbFixture.stripeAgreementDbFixture(databaseHelper)
+        ZonedDateTime agreementTime = ZonedDateTime.now(ZoneId.of("UTC"));
+        String ipAddress = "192.0.2.0";
+        
+        StripeAgreementDbFixture.stripeAgreementDbFixture(databaseHelper)
                 .withServiceId(service.getId())
+                .withIpAddress(ipAddress)
+                .withAgreementTime(agreementTime)
                 .insert();
         
         givenSetup()
@@ -106,8 +113,8 @@ public class ServiceResourceStripeAgreementTest extends IntegrationTest {
                 .get(format("/v1/api/services/%s/stripe-agreement", service.getExternalId()))
                 .then()
                 .statusCode(200)
-                .body("ip_address", is(stripeAgreement.getIpAddress()))
-                .body("agreement_time", is(DateTimeUtils.toUTCDateString(stripeAgreement.getAgreementTime())));
+                .body("ip_address", is(ipAddress))
+                .body("agreement_time", is(DateTimeUtils.toUTCDateString(agreementTime)));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
@@ -369,12 +369,12 @@ public class DatabaseTestHelper {
         return this;
     }
 
-    public DatabaseTestHelper insertStripeAgreementEntity(StripeAgreementEntity stripeAgreementEntity) {
+    public DatabaseTestHelper insertStripeAgreementEntity(int serviceId, ZonedDateTime agreementTime, String ipAddress) {
         jdbi.withHandle(handle -> handle
                 .createStatement("INSERT INTO stripe_agreements(service_id, agreement_time, ip_address) VALUES (:serviceId, :agreementTime, :ipAddress)")
-                .bind("serviceId", stripeAgreementEntity.getServiceId())
-                .bind("agreementTime", from(stripeAgreementEntity.getAgreementTime().toInstant()))
-                .bind("ipAddress", stripeAgreementEntity.getIpAddress())
+                .bind("serviceId", serviceId)
+                .bind("agreementTime", from(agreementTime.toInstant()))
+                .bind("ipAddress", ipAddress)
                 .execute());
         return this;
     }


### PR DESCRIPTION
- Previously was searching by service ID which required first looking
  up the service in a separate query
- Refactored code to move more logic into the service from the resource