### PR TITLE
PP-4539 Map exceptions thrown by StripeAgreementService

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/app/AdminUsersApp.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/AdminUsersApp.java
@@ -21,7 +21,8 @@ import uk.gov.pay.adminusers.app.healthchecks.DependentResourceWaitCommand;
 import uk.gov.pay.adminusers.app.healthchecks.MigrateToInitialDbState;
 import uk.gov.pay.adminusers.app.healthchecks.Ping;
 import uk.gov.pay.adminusers.app.util.TrustingSSLSocketFactory;
-import uk.gov.pay.adminusers.exception.ServiceNotFoundExceptionMapper;
+import uk.gov.pay.adminusers.exception.ConflictExceptionMapper;
+import uk.gov.pay.adminusers.exception.NotFoundExceptionMapper;
 import uk.gov.pay.adminusers.exception.ValidationExceptionMapper;
 import uk.gov.pay.adminusers.resources.EmailResource;
 import uk.gov.pay.adminusers.resources.ForgottenPasswordResource;
@@ -88,7 +89,8 @@ public class AdminUsersApp extends Application<AdminUsersConfig> {
 
         // Register the custom ExceptionMapper(s)
         environment.jersey().register(new ValidationExceptionMapper());
-        environment.jersey().register(new ServiceNotFoundExceptionMapper());
+        environment.jersey().register(new NotFoundExceptionMapper());
+        environment.jersey().register(new ConflictExceptionMapper());
         environment.jersey().register(new InvalidEmailRequestExceptionMapper());
         environment.jersey().register(new InvalidMerchantDetailsExceptionMapper());
 

--- a/src/main/java/uk/gov/pay/adminusers/exception/ConflictException.java
+++ b/src/main/java/uk/gov/pay/adminusers/exception/ConflictException.java
@@ -1,0 +1,8 @@
+package uk.gov.pay.adminusers.exception;
+
+public class ConflictException extends RuntimeException {
+    
+    public ConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/exception/ConflictExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/adminusers/exception/ConflictExceptionMapper.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.adminusers.exception;
+
+import com.google.common.collect.ImmutableMap;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+
+public class ConflictExceptionMapper implements ExceptionMapper<ConflictException> {
+
+    @Override
+    public Response toResponse(ConflictException exception) {
+        ImmutableMap<String, String> entity = ImmutableMap.of("message", exception.getMessage());
+        return Response
+                .status(Response.Status.CONFLICT)
+                .entity(entity)
+                .type(APPLICATION_JSON_TYPE)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/exception/NotFoundException.java
+++ b/src/main/java/uk/gov/pay/adminusers/exception/NotFoundException.java
@@ -1,0 +1,8 @@
+package uk.gov.pay.adminusers.exception;
+
+public class NotFoundException extends RuntimeException {
+
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/exception/NotFoundExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/adminusers/exception/NotFoundExceptionMapper.java
@@ -5,10 +5,10 @@ import javax.ws.rs.ext.ExceptionMapper;
 
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 
-public class ServiceNotFoundExceptionMapper implements ExceptionMapper<ServiceNotFoundException> {
+public class NotFoundExceptionMapper implements ExceptionMapper<NotFoundException> {
 
     @Override
-    public Response toResponse(ServiceNotFoundException exception) {
+    public Response toResponse(NotFoundException exception) {
         return Response.status(NOT_FOUND).build();
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/exception/ServiceNotFoundException.java
+++ b/src/main/java/uk/gov/pay/adminusers/exception/ServiceNotFoundException.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.adminusers.exception;
 
-public class ServiceNotFoundException extends Throwable {
+public class ServiceNotFoundException extends NotFoundException {
 
     public ServiceNotFoundException(String serviceExternalId) {
         super("Service with serviceExternalId = \"" + serviceExternalId + "\" NOT FOUND");

--- a/src/main/java/uk/gov/pay/adminusers/exception/StripeAgreementAlreadyExistsException.java
+++ b/src/main/java/uk/gov/pay/adminusers/exception/StripeAgreementAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package uk.gov.pay.adminusers.exception;
+
+public class StripeAgreementAlreadyExistsException extends ConflictException {
+    
+    public StripeAgreementAlreadyExistsException() {
+        super("Stripe agreement information is already stored for this service");
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/service/StripeAgreementService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/StripeAgreementService.java
@@ -2,6 +2,8 @@ package uk.gov.pay.adminusers.service;
 
 import com.google.inject.Inject;
 import org.slf4j.Logger;
+import uk.gov.pay.adminusers.exception.ServiceNotFoundException;
+import uk.gov.pay.adminusers.exception.StripeAgreementAlreadyExistsException;
 import uk.gov.pay.adminusers.logger.PayLoggerFactory;
 import uk.gov.pay.adminusers.model.StripeAgreement;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
@@ -39,11 +41,10 @@ public class StripeAgreementService {
     
     public void doCreate(String serviceExternalId, InetAddress ipAddress) {
         ServiceEntity serviceEntity = serviceDao.findByExternalId(serviceExternalId)
-                .orElseThrow( () -> new WebApplicationException(Response.Status.NOT_FOUND));
+                .orElseThrow( () -> new ServiceNotFoundException(serviceExternalId));
         
         if (stripeAgreementDao.findByServiceExternalId(serviceExternalId).isPresent()) {
-            throw new WebApplicationException("Stripe agreement information is already stored for this service",
-                    Response.Status.CONFLICT);
+            throw new StripeAgreementAlreadyExistsException();
         }
 
         logger.info(format("Creating stripe agreement for service %s", serviceExternalId));

--- a/src/test/java/uk/gov/pay/adminusers/service/StripeAgreementServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/StripeAgreementServiceTest.java
@@ -10,6 +10,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.adminusers.exception.ServiceNotFoundException;
+import uk.gov.pay.adminusers.exception.StripeAgreementAlreadyExistsException;
 import uk.gov.pay.adminusers.model.StripeAgreement;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
 import uk.gov.pay.adminusers.persistence.dao.StripeAgreementDao;
@@ -97,8 +99,7 @@ public class StripeAgreementServiceTest {
         String serviceExternalId = "abc123";
         when(mockedServiceDao.findByExternalId(serviceExternalId)).thenReturn(Optional.empty());
         
-        expectedException.expect(WebApplicationException.class);
-        expectedException.expectMessage("HTTP 404 Not Found");
+        expectedException.expect(ServiceNotFoundException.class);
         
         stripeAgreementService.doCreate(serviceExternalId, InetAddress.getByName("192.0.2.0"));
     }
@@ -113,8 +114,7 @@ public class StripeAgreementServiceTest {
         StripeAgreementEntity mockStripeAgreementEntity = mock(StripeAgreementEntity.class);
         when(mockedStripeAgreementDao.findByServiceExternalId(serviceExternalId)).thenReturn(Optional.of(mockStripeAgreementEntity));
 
-        expectedException.expect(WebApplicationException.class);
-        expectedException.expectMessage("Stripe agreement information is already stored for this service");
+        expectedException.expect(StripeAgreementAlreadyExistsException.class);
 
         stripeAgreementService.doCreate(serviceExternalId, InetAddress.getByName("192.0.2.0"));
     }


### PR DESCRIPTION
- Rather than throwing WebApplicationExceptions in the service layer, instead throw more specific exceptions which are mapped by the dropwizard app into HTTP responses

This is aimed to replicated how we deal with exceptions in direct-debit-connector