### PR TITLE
PP-4615 Add service to send live account created email

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/app/AdminUsersApp.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/AdminUsersApp.java
@@ -21,6 +21,7 @@ import uk.gov.pay.adminusers.app.healthchecks.DependentResourceWaitCommand;
 import uk.gov.pay.adminusers.app.healthchecks.MigrateToInitialDbState;
 import uk.gov.pay.adminusers.app.healthchecks.Ping;
 import uk.gov.pay.adminusers.app.util.TrustingSSLSocketFactory;
+import uk.gov.pay.adminusers.exception.ConflictExceptionMapper;
 import uk.gov.pay.adminusers.exception.ServiceNotFoundExceptionMapper;
 import uk.gov.pay.adminusers.exception.ValidationExceptionMapper;
 import uk.gov.pay.adminusers.resources.EmailResource;
@@ -91,6 +92,7 @@ public class AdminUsersApp extends Application<AdminUsersConfig> {
         environment.jersey().register(new ServiceNotFoundExceptionMapper());
         environment.jersey().register(new InvalidEmailRequestExceptionMapper());
         environment.jersey().register(new InvalidMerchantDetailsExceptionMapper());
+        environment.jersey().register(new ConflictExceptionMapper());
 
         HttpsURLConnection.setDefaultSSLSocketFactory(new TrustingSSLSocketFactory());
         

--- a/src/main/java/uk/gov/pay/adminusers/exception/ConflictException.java
+++ b/src/main/java/uk/gov/pay/adminusers/exception/ConflictException.java
@@ -1,0 +1,8 @@
+package uk.gov.pay.adminusers.exception;
+
+public class ConflictException extends RuntimeException {
+
+    public ConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/exception/ConflictExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/adminusers/exception/ConflictExceptionMapper.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.adminusers.exception;
+
+import com.google.common.collect.ImmutableMap;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+
+public class ConflictExceptionMapper implements ExceptionMapper<ConflictException> {
+
+    @Override
+    public Response toResponse(ConflictException exception) {
+        ImmutableMap<String, String> entity = ImmutableMap.of("message", exception.getMessage());
+        return Response
+                .status(Response.Status.CONFLICT)
+                .entity(entity)
+                .type(APPLICATION_JSON_TYPE)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/exception/GovUkPayAgreementNotSignedException.java
+++ b/src/main/java/uk/gov/pay/adminusers/exception/GovUkPayAgreementNotSignedException.java
@@ -1,0 +1,7 @@
+package uk.gov.pay.adminusers.exception;
+
+public class GovUkPayAgreementNotSignedException extends ConflictException {
+    public GovUkPayAgreementNotSignedException() {
+        super("Nobody from this service is on record as having agreed to the legal terms");
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/service/SendLiveAccountCreatedEmailService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/SendLiveAccountCreatedEmailService.java
@@ -1,0 +1,48 @@
+package uk.gov.pay.adminusers.service;
+
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import uk.gov.pay.adminusers.app.config.AdminUsersConfig;
+import uk.gov.pay.adminusers.exception.GovUkPayAgreementNotSignedException;
+import uk.gov.pay.adminusers.logger.PayLoggerFactory;
+import uk.gov.pay.adminusers.persistence.dao.GovUkPayAgreementDao;
+import uk.gov.pay.adminusers.persistence.entity.GovUkPayAgreementEntity;
+
+import static javax.ws.rs.core.UriBuilder.fromUri;
+
+public class SendLiveAccountCreatedEmailService {
+
+    private static final Logger LOGGER = PayLoggerFactory.getLogger(SendLiveAccountCreatedEmailService.class);
+    private static final String SELFSERVICE_LIVE_ACCOUNT_PATH = "live-account";
+    
+    private final GovUkPayAgreementDao govUkPayAgreementDao;
+    private final NotificationService notificationService;
+    private final String selfserviceServicesUrl;
+    
+    @Inject
+    public SendLiveAccountCreatedEmailService(GovUkPayAgreementDao govUkPayAgreementDao,
+                                              NotificationService notificationService,
+                                              AdminUsersConfig config) {
+        this.govUkPayAgreementDao = govUkPayAgreementDao;
+        this.notificationService = notificationService;
+        this.selfserviceServicesUrl = config.getLinks().getSelfserviceServicesUrl();
+    }
+
+    public void sendEmail(String serviceExternalId) {
+        GovUkPayAgreementEntity agreement = govUkPayAgreementDao.findByExternalServiceId(serviceExternalId)
+                .orElseThrow(GovUkPayAgreementNotSignedException::new);
+
+        String serviceLiveAccountUrl = fromUri(selfserviceServicesUrl)
+                .path(serviceExternalId)
+                .path(SELFSERVICE_LIVE_ACCOUNT_PATH)
+                .build()
+                .toString();
+
+        notificationService.sendLiveAccountCreatedEmail(agreement.getEmail(), serviceLiveAccountUrl)
+                .thenAcceptAsync(notificationId -> LOGGER.info("Sent service is live email successfully, notification id [{}]", notificationId))
+                .exceptionally(exception -> {
+                    LOGGER.error("Error sending service is live email", exception);
+                    return null;
+                });
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/service/SendLiveAccountCreatedEmailServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/SendLiveAccountCreatedEmailServiceTest.java
@@ -1,0 +1,82 @@
+package uk.gov.pay.adminusers.service;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.adminusers.app.config.AdminUsersConfig;
+import uk.gov.pay.adminusers.app.config.LinksConfig;
+import uk.gov.pay.adminusers.exception.GovUkPayAgreementNotSignedException;
+import uk.gov.pay.adminusers.persistence.dao.GovUkPayAgreementDao;
+import uk.gov.pay.adminusers.persistence.entity.GovUkPayAgreementEntity;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SendLiveAccountCreatedEmailServiceTest {
+    
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    
+    @Mock
+    private GovUkPayAgreementDao mockGovUkPayAgreementDao;
+    @Mock
+    private AdminUsersConfig mockConfig;
+    @Mock
+    private NotificationService mockNotificationService;
+
+    private static final String SELFSERVICE_SERVICES_URL = "http://selfservice/services";
+    
+    private SendLiveAccountCreatedEmailService sendLiveAccountCreatedEmailService;
+
+    @Before
+    public void setUp() {
+        LinksConfig mockLinks = mock(LinksConfig.class);
+        when(mockLinks.getSelfserviceServicesUrl()).thenReturn(SELFSERVICE_SERVICES_URL);
+        when(mockConfig.getLinks()).thenReturn(mockLinks);
+        sendLiveAccountCreatedEmailService = new SendLiveAccountCreatedEmailService(mockGovUkPayAgreementDao, mockNotificationService, mockConfig);
+    }
+
+    @Test
+    public void shouldSendServiceIsLiveEmail_whenAgreementIsSigned() {
+        String serviceExternalId = "abc123";
+        String email = "some-user@example.com";
+        
+        GovUkPayAgreementEntity mockAgreement = mock(GovUkPayAgreementEntity.class);
+        when(mockAgreement.getEmail()).thenReturn(email);
+        when(mockGovUkPayAgreementDao.findByExternalServiceId(serviceExternalId)).thenReturn(Optional.of(mockAgreement));
+
+        CompletableFuture<String> notifyPromise = CompletableFuture.completedFuture("random-notify-id");
+        ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+        when(mockNotificationService.sendLiveAccountCreatedEmail(eq(email), urlCaptor.capture()))
+                .thenReturn(notifyPromise);
+        
+        sendLiveAccountCreatedEmailService.sendEmail(serviceExternalId);
+
+        assertThat(urlCaptor.getValue(), is(SELFSERVICE_SERVICES_URL + '/' + serviceExternalId + "/live-account"));
+        assertThat(notifyPromise.isDone(), is(true));
+    }
+
+    @Test
+    public void shouldThrowException_whenAgreementNotSigned() {
+        String serviceExternalId = "abc123";
+        
+        when(mockGovUkPayAgreementDao.findByExternalServiceId(serviceExternalId)).thenReturn(Optional.empty());
+
+        expectedException.expect(GovUkPayAgreementNotSignedException.class);
+        expectedException.expectMessage(is("Nobody from this service is on record as having agreed to the legal terms"));
+        
+        sendLiveAccountCreatedEmailService.sendEmail(serviceExternalId);
+    }
+}


### PR DESCRIPTION
- Add service to send email with tests
- Add GovUkPayAgreementNotSignedException which extends ConflictException which DropWizard will map to a CONFLICT error response. This follows how we throw and map exceptions in direct-debit-connector and avoids throwing WebApplicationExceptions from the service layer.