### PR TITLE
Intellij tidyups for DaoTestBase

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/model/CreateUserRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/CreateUserRequest.java
@@ -32,8 +32,8 @@ public class CreateUserRequest {
     private String username;
     private String password;
     private String email;
-    private List<String> gatewayAccountIds = new ArrayList<>();
-    private List<String> serviceExternalIds = new ArrayList<>();
+    private List<String> gatewayAccountIds;
+    private List<String> serviceExternalIds;
     private String telephoneNumber;
     private String otpKey;
     private String features;

--- a/src/main/java/uk/gov/pay/adminusers/model/User.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/User.java
@@ -30,7 +30,7 @@ public class User {
     private Boolean disabled = Boolean.FALSE;
     private Integer loginCounter = 0;
     private String features;
-    private List<ServiceRole> serviceRoles = new ArrayList<>();
+    private List<ServiceRole> serviceRoles;
     private SecondFactorMethod secondFactor;
     private String provisionalOtpKey;
     private ZonedDateTime provisionalOtpKeyCreatedAt;

--- a/src/main/java/uk/gov/pay/adminusers/resources/GovUkPayAgreementRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/GovUkPayAgreementRequestValidator.java
@@ -5,7 +5,6 @@ import com.google.inject.Inject;
 import uk.gov.pay.adminusers.utils.Errors;
 import uk.gov.pay.adminusers.validations.RequestValidations;
 
-import java.util.List;
 import java.util.Optional;
 
 public class GovUkPayAgreementRequestValidator {
@@ -19,14 +18,9 @@ public class GovUkPayAgreementRequestValidator {
     }
     
     public Optional<Errors> validateCreateRequest(JsonNode payload) {
-        Optional<List<String>> missingMandatoryFields = requestValidations.checkExistsAndNotEmpty(payload, FIELD_USER_ID);
-        if (missingMandatoryFields.isPresent()) {
-            return Optional.of(Errors.from(missingMandatoryFields.get()));
-        }
-        Optional<List<String>> invalidType = requestValidations.checkIsString("Field [%s] must be a valid user ID", payload, FIELD_USER_ID);
-        if (invalidType.isPresent()) {
-            return Optional.of(Errors.from(invalidType.get()));
-        }
-        return Optional.empty();
+        return requestValidations.checkExistsAndNotEmpty(payload, FIELD_USER_ID)
+                .map(strings -> Optional.of(Errors.from(strings)))
+                .orElseGet(() -> requestValidations.checkIsString("Field [%s] must be a valid user ID", payload, FIELD_USER_ID)
+                .map(Errors::from));
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/utils/Errors.java
+++ b/src/main/java/uk/gov/pay/adminusers/utils/Errors.java
@@ -6,11 +6,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Collections;
 import java.util.List;
 
-import static com.google.common.collect.Lists.newArrayList;
-
 public class Errors {
 
-    private List<String> errors = newArrayList();
+    private List<String> errors;
 
     private Errors(@JsonProperty("errors") List<String> errors) {
         this.errors = errors;

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/DaoTestBase.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/DaoTestBase.java
@@ -12,7 +12,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.adminusers.infra.GuicedTestEnvironment;
 import uk.gov.pay.adminusers.model.Permission;
-import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.utils.DatabaseTestHelper;
 import uk.gov.pay.commons.testing.db.PostgresDockerRule;
 
@@ -23,7 +22,6 @@ import java.util.Properties;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.model.Permission.permission;
-import static uk.gov.pay.adminusers.model.Role.role;
 
 public class DaoTestBase {
 
@@ -74,14 +72,6 @@ public class DaoTestBase {
             logger.error("Error stopping docker", e);
         }
         env.stop();
-    }
-
-    protected Role aRole() {
-        return aRole("role-name-" + randomUuid());
-    }
-
-    protected Role aRole(String name) {
-        return role(randomInt(), name, "role-description" + randomUuid());
     }
 
     protected Permission aPermission() {

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/DaoTestBase.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/DaoTestBase.java
@@ -31,8 +31,7 @@ public class DaoTestBase {
     public static PostgresDockerRule postgres = new PostgresDockerRule();
 
     protected static DatabaseTestHelper databaseHelper;
-    private static JpaPersistModule jpaModule;
-    protected static GuicedTestEnvironment env;
+    static GuicedTestEnvironment env;
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -42,8 +41,7 @@ public class DaoTestBase {
         properties.put("javax.persistence.jdbc.user", postgres.getUsername());
         properties.put("javax.persistence.jdbc.password", postgres.getPassword());
 
-        jpaModule = new JpaPersistModule("AdminUsersUnit");
-        jpaModule.properties(properties);
+        JpaPersistModule jpaModule = new JpaPersistModule("AdminUsersUnit").properties(properties);
 
         databaseHelper = new DatabaseTestHelper(new DBI(postgres.getConnectionUrl(), postgres.getUsername(), postgres.getPassword()));
 
@@ -74,7 +72,7 @@ public class DaoTestBase {
         env.stop();
     }
 
-    protected Permission aPermission() {
+    Permission aPermission() {
         return permission(randomInt(), "permission-name-" + randomUuid(), "permission-description" + randomUuid());
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/DaoTestBase.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/DaoTestBase.java
@@ -62,14 +62,14 @@ public class DaoTestBase {
 
     @AfterClass
     public static void tearDown() {
-        Connection connection = null;
-        try {
-            connection = DriverManager.getConnection(postgres.getConnectionUrl(), postgres.getUsername(), postgres.getPassword());
+        try (Connection connection = DriverManager.getConnection(
+                postgres.getConnectionUrl(),
+                postgres.getUsername(),
+                postgres.getPassword())) {
             Liquibase migrator = new Liquibase("config/initial-db-state.xml", new ClassLoaderResourceAccessor(), new JdbcConnection(connection));
             Liquibase migrator2 = new Liquibase("migrations.xml", new ClassLoaderResourceAccessor(), new JdbcConnection(connection));
             migrator2.dropAll();
             migrator.dropAll();
-            connection.close();
         } catch (Exception e) {
             logger.error("Error stopping docker", e);
         }


### PR DESCRIPTION
Tidy some things IntelliJ didn't like

- Use try-with-resources to avoid a possible JDBC `Connection` leak
- Make some things package-private
- Turn a field into a local variable
- Remove unused methods
- Remove redundant initialisers
- Make `GovUkPayAgreementRequestValidator` more functional