### PR TITLE
Be more functional in HealthCheckResource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,12 @@
             <version>${pay-java-commons.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path-assert</artifactId>
+            <version>2.4.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/uk/gov/pay/adminusers/resources/HealthCheckResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/HealthCheckResource.java
@@ -9,21 +9,19 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
-import java.util.HashMap;
+import java.util.Collection;
 import java.util.Map;
 import java.util.SortedMap;
+import java.util.stream.Collectors;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.Response.status;
-import static org.apache.commons.lang3.StringUtils.isBlank;
+import static javax.ws.rs.core.Response.Status.OK;
+import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
+import static org.apache.commons.lang3.StringUtils.defaultString;
 
 @Path("/")
 public class HealthCheckResource {
-    public static final String HEALTHCHECK = "healthcheck";
-    public static final String HEALTHY = "healthy";
-    public static final String MESSAGE = "message";
-
-    private Environment environment;
+    private final Environment environment;
 
     @Inject
     public HealthCheckResource(Environment environment) {
@@ -31,31 +29,26 @@ public class HealthCheckResource {
     }
 
     @GET
-    @Path(HEALTHCHECK)
+    @Path("healthcheck")
     @Produces(APPLICATION_JSON)
     public Response healthCheck() {
         SortedMap<String, HealthCheck.Result> results = environment.healthChecks().runHealthChecks();
 
-        Map<String, Map<String, Object>> response = getResponse(results);
-
-        boolean healthy = results.size() == results.values()
+        Map<String, Map<String, Object>> response = results.entrySet()
                 .stream()
-                .filter(HealthCheck.Result::isHealthy)
-                .count();
+                .collect(Collectors.toMap(Map.Entry::getKey,
+                        healthcheckResult -> ImmutableMap.of(
+                                "healthy", healthcheckResult.getValue().isHealthy(),
+                                "message", defaultString(healthcheckResult.getValue().getMessage(), "Healthy")
+                        )
+                ));
 
-        if(healthy) {
-            return Response.ok().entity(response).build();
-        }
-        return status(503).entity(response).build();
+        Response.Status status = allHealthy(results.values()) ? OK : SERVICE_UNAVAILABLE;
+
+        return Response.status(status).entity(response).build();
     }
 
-    private Map<String, Map<String, Object>> getResponse(SortedMap<String, HealthCheck.Result> results) {
-        Map<String, Map<String, Object>> response = new HashMap<>();
-        for (SortedMap.Entry<String, HealthCheck.Result> entry : results.entrySet() ) {
-            response.put(entry.getKey(), ImmutableMap.of(
-                    HEALTHY, entry.getValue().isHealthy(),
-                    MESSAGE, isBlank(entry.getValue().getMessage()) ? "Healthy" : entry.getValue().getMessage()));
-        }
-        return response;
+    private boolean allHealthy(Collection<HealthCheck.Result> results) {
+        return results.stream().allMatch(HealthCheck.Result::isHealthy);
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/resources/HealthCheckResourceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/HealthCheckResourceTest.java
@@ -1,0 +1,93 @@
+package uk.gov.pay.adminusers.resources;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.jayway.jsonassert.JsonAssert;
+import io.dropwizard.setup.Environment;
+import org.hamcrest.core.Is;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.ws.rs.core.Response;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HealthCheckResourceTest {
+    @Mock
+    private Environment environment;
+
+    @Mock
+    private HealthCheckRegistry healthCheckRegistry;
+
+    private HealthCheckResource resource;
+
+    @Before
+    public void setup() {
+        when(environment.healthChecks()).thenReturn(healthCheckRegistry);
+        resource = new HealthCheckResource(environment);
+    }
+
+    @Test
+    public void checkHealthCheck_isUnHealthy() throws JsonProcessingException {
+        SortedMap<String,HealthCheck.Result> map = new TreeMap<>();
+        map.put("ping", HealthCheck.Result.unhealthy("application is unavailable"));
+        map.put("deadlocks", HealthCheck.Result.unhealthy("no new threads available"));
+        when(healthCheckRegistry.runHealthChecks()).thenReturn(map);
+        Response response = resource.healthCheck();
+        assertThat(response.getStatus(), is(503));
+        ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+        String body = ow.writeValueAsString(response.getEntity());
+
+        JsonAssert.with(body)
+                .assertThat("$.*", hasSize(2))
+                .assertThat("$.ping.healthy", Is.is(false))
+                .assertThat("$.deadlocks.healthy", Is.is(false));
+    }
+
+    @Test
+    public void checkHealthCheck_isHealthy() throws JsonProcessingException {
+        SortedMap<String,HealthCheck.Result> map = new TreeMap<>();
+        map.put("ping", HealthCheck.Result.healthy());
+        map.put("deadlocks", HealthCheck.Result.healthy());
+        when(healthCheckRegistry.runHealthChecks()).thenReturn(map);
+        Response response = resource.healthCheck();
+        assertThat(response.getStatus(), is(200));
+        ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+        String body = ow.writeValueAsString(response.getEntity());
+
+        JsonAssert.with(body)
+                .assertThat("$.*", hasSize(2))
+                .assertThat("$.ping.healthy", Is.is(true))
+                .assertThat("$.deadlocks.healthy", Is.is(true));
+    }
+
+    @Test
+    public void checkHealthCheck_pingIsHealthy_deadlocksIsUnhealthy() throws JsonProcessingException {
+        SortedMap<String,HealthCheck.Result> map = new TreeMap<>();
+        map.put("ping", HealthCheck.Result.healthy());
+        map.put("deadlocks", HealthCheck.Result.unhealthy("no new threads available"));
+        when(healthCheckRegistry.runHealthChecks()).thenReturn(map);
+        Response response = resource.healthCheck();
+        assertThat(response.getStatus(), is(503));
+        ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+        String body = ow.writeValueAsString(response.getEntity());
+
+        JsonAssert.with(body)
+                .assertThat("$.*", hasSize(2))
+                .assertThat("$.ping.healthy", Is.is(true))
+                .assertThat("$.deadlocks.healthy", Is.is(false));
+    }
+
+}


### PR DESCRIPTION
Apply the same change made in pay-direct-debit-connector to adminusers'
healthcheck resource, making it simpler and with a more functional style.

Bring the unit test over from pay-publicapi