### PR TITLE
PP-4949 Add Stripe vat number company number permissions

### DIFF
--- a/src/main/resources/migrations/00054_add_stripe_vat_number_company_number_permissions.sql
+++ b/src/main/resources/migrations/00054_add_stripe_vat_number_company_number_permissions.sql
@@ -1,0 +1,11 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:stripe_vat_number_company_number_update_permission
+INSERT INTO permissions(id, name, description) VALUES (43, 'stripe-vat-number-company-number:update', 'Update Stripe vat number company number');
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'super-admin'), (SELECT id FROM permissions WHERE name = 'stripe-vat-number-company-number:update'), NOW(), NOW());
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'admin'), (SELECT id FROM permissions WHERE name = 'stripe-vat-number-company-number:update'), NOW(), NOW());
+
+--changeset uk.gov.pay:stripe_vat_number_company_number_read_permission
+INSERT INTO  permissions(id, name, description) VALUES (44, 'stripe-vat-number-company-number:read', 'View Stripe vat number company number');
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'super-admin'), (SELECT id FROM permissions WHERE name = 'stripe-vat-number-company-number:read'), NOW(), NOW());
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'admin'), (SELECT id FROM permissions WHERE name = 'stripe-vat-number-company-number:read'), NOW(), NOW());

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationTest.java
@@ -50,7 +50,7 @@ public class UserResourceAuthenticationTest extends IntegrationTest {
                 .body("disabled", is(false))
                 .body("_links", hasSize(1))
                 .body("service_roles[0].role.name", is("admin"))
-                .body("service_roles[0].role.permissions", hasSize(41));
+                .body("service_roles[0].role.permissions", hasSize(43));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateTest.java
@@ -111,7 +111,7 @@ public class UserResourceCreateTest extends IntegrationTest {
                 .body("disabled", is(false))
                 .body("service_roles[0].role.name", is("admin"))
                 .body("service_roles[0].role.description", is("Administrator"))
-                .body("service_roles[0].role.permissions", hasSize(41));
+                .body("service_roles[0].role.permissions", hasSize(43));
 
         response
                 .body("_links", hasSize(1))


### PR DESCRIPTION
## WHAT YOU DID

- Add `stripe-vat-number-company-number:update` and `stripe-vat-number-company-number:read` permissions which will be used in "VAT number and company number" workflow
