### PR TITLE
PP-4946 Added `groovy-json` library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,12 @@
             <version>2.4.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-json</artifactId>
+            <version>2.5.5</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
## WHAT YOU DID

Added `groovy-json` library - Prep for Java 11

`groovy-json`(version 2.4.4) is a transitive dependency for  `rest-assured` library (via `json-path`) and results in following error when tests are run using Java 11.

`java.lang.ClassCastException: class [B cannot be cast to class [C ([B and [C are in module java.base of loader 'bootstrap')`

This is due to bug (https://bugs.openjdk.java.net/browse/JDK-8218540?focusedCommentId=14244740&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14244740) in `groovy-json` version and is fixed in latest version of the library.

## How to test

- CI should pass
- Tests should run on Java11