### PR TITLE
PP-4952 Upgrade `REST Assured` library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,9 +214,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.jayway.restassured</groupId>
+            <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
-            <version>2.9.0</version>
+            <version>3.3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/uk/gov/pay/adminusers/resources/EmailResourceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/EmailResourceTest.java
@@ -8,7 +8,7 @@ import uk.gov.pay.adminusers.model.MerchantDetails;
 
 import java.util.Map;
 
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 
 public class EmailResourceTest extends IntegrationTest {
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/ForgottenPasswordResourceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ForgottenPasswordResourceTest.java
@@ -3,7 +3,7 @@ package uk.gov.pay.adminusers.resources;
 import org.junit.Test;
 
 import static com.google.common.collect.ImmutableMap.of;
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;

--- a/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
@@ -1,14 +1,14 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.jayway.restassured.specification.RequestSpecification;
+import io.restassured.specification.RequestSpecification;
 import org.junit.Before;
 import org.junit.ClassRule;
 import uk.gov.pay.adminusers.infra.DropwizardAppWithPostgresRule;
 import uk.gov.pay.adminusers.utils.DatabaseTestHelper;
 
-import static com.jayway.restassured.RestAssured.given;
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
 
 public class IntegrationTest {
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateServiceTest.java
@@ -2,7 +2,7 @@ package uk.gov.pay.adminusers.resources;
 
 
 import com.google.common.collect.ImmutableMap;
-import com.jayway.restassured.http.ContentType;
+import io.restassured.http.ContentType;
 import org.junit.Test;
 import uk.gov.pay.adminusers.fixtures.UserDbFixture;
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateUserTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateUserTest.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.google.common.collect.ImmutableMap;
-import com.jayway.restassured.http.ContentType;
+import io.restassured.http.ContentType;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.Service;

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGenerateOtpTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGenerateOtpTest.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.google.common.collect.ImmutableMap;
-import com.jayway.restassured.http.ContentType;
+import io.restassured.http.ContentType;
 import org.junit.Test;
 import uk.gov.pay.adminusers.fixtures.InviteDbFixture;
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGetTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGetTest.java
@@ -2,7 +2,7 @@ package uk.gov.pay.adminusers.resources;
 
 import org.junit.Test;
 
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.Response.Status.*;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpTest.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.google.common.collect.ImmutableMap;
-import com.jayway.restassured.http.ContentType;
-import com.jayway.restassured.response.ValidatableResponse;
 import com.warrenstrange.googleauth.GoogleAuthenticator;
+import io.restassured.http.ContentType;
+import io.restassured.response.ValidatableResponse;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.adminusers.fixtures.InviteDbFixture;
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.io.BaseEncoding.base32;
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.Response.Status.*;
 import static org.apache.commons.lang3.RandomStringUtils.random;
 import static org.hamcrest.Matchers.hasSize;
@@ -110,7 +110,7 @@ public class InviteResourceOtpTest extends IntegrationTest {
         givenSetup()
                 .when()
                 .body(mapper.writeValueAsString(invitationOtpRequest))
-                .contentType(ContentType.JSON)
+                .contentType(JSON)
                 .post(INVITES_VALIDATE_OTP_RESOURCE_URL)
                 .then()
                 .statusCode(NOT_FOUND.getStatusCode());
@@ -136,7 +136,7 @@ public class InviteResourceOtpTest extends IntegrationTest {
         givenSetup()
                 .when()
                 .body(mapper.writeValueAsString(invitationOtpRequest))
-                .contentType(ContentType.JSON)
+                .contentType(JSON)
                 .post(INVITES_VALIDATE_OTP_RESOURCE_URL)
                 .then()
                 .statusCode(UNAUTHORIZED.getStatusCode());
@@ -163,7 +163,7 @@ public class InviteResourceOtpTest extends IntegrationTest {
         givenSetup()
                 .when()
                 .body(mapper.writeValueAsString(invitationOtpRequest))
-                .contentType(ContentType.JSON)
+                .contentType(JSON)
                 .post(INVITES_VALIDATE_OTP_RESOURCE_URL)
                 .then()
                 .statusCode(GONE.getStatusCode());
@@ -185,7 +185,7 @@ public class InviteResourceOtpTest extends IntegrationTest {
         givenSetup()
                 .when()
                 .body(mapper.writeValueAsString(invitationRequest))
-                .contentType(ContentType.JSON)
+                .contentType(JSON)
                 .post(INVITES_VALIDATE_OTP_RESOURCE_URL)
                 .then()
                 .statusCode(BAD_REQUEST.getStatusCode());
@@ -214,7 +214,7 @@ public class InviteResourceOtpTest extends IntegrationTest {
         givenSetup()
                 .when()
                 .body(mapper.writeValueAsString(resendRequest))
-                .contentType(ContentType.JSON)
+                .contentType(JSON)
                 .post(INVITES_RESEND_OTP_RESOURCE_URL)
                 .then()
                 .statusCode(OK.getStatusCode());
@@ -235,7 +235,7 @@ public class InviteResourceOtpTest extends IntegrationTest {
         givenSetup()
                 .when()
                 .body(mapper.writeValueAsString(invitationRequest))
-                .contentType(ContentType.JSON)
+                .contentType(JSON)
                 .post(INVITES_RESEND_OTP_RESOURCE_URL)
                 .then()
                 .statusCode(BAD_REQUEST.getStatusCode());
@@ -256,7 +256,7 @@ public class InviteResourceOtpTest extends IntegrationTest {
         givenSetup()
                 .when()
                 .body(mapper.writeValueAsString(sendRequest))
-                .contentType(ContentType.JSON)
+                .contentType(JSON)
                 .post(SERVICE_INVITES_VALIDATE_OTP_RESOURCE_URL)
                 .then()
                 .statusCode(OK.getStatusCode());
@@ -279,7 +279,7 @@ public class InviteResourceOtpTest extends IntegrationTest {
         givenSetup()
                 .when()
                 .body(mapper.writeValueAsString(sendRequest))
-                .contentType(ContentType.JSON)
+                .contentType(JSON)
                 .post(SERVICE_INVITES_VALIDATE_OTP_RESOURCE_URL)
                 .then()
                 .statusCode(UNAUTHORIZED.getStatusCode());

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceServiceCompleteTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceServiceCompleteTest.java
@@ -1,13 +1,13 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.google.common.collect.ImmutableMap;
-import com.jayway.restassured.response.ValidatableResponse;
+import io.restassured.response.ValidatableResponse;
 import org.junit.Test;
 
 import java.util.List;
 import java.util.Map;
 
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static javax.ws.rs.core.Response.Status.CONFLICT;

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceUserCompleteTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceUserCompleteTest.java
@@ -2,7 +2,7 @@ package uk.gov.pay.adminusers.resources;
 
 import org.junit.Test;
 
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static javax.ws.rs.core.Response.Status.GONE;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;

--- a/src/test/java/uk/gov/pay/adminusers/resources/ResetPasswordResourceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ResetPasswordResourceTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 import java.util.Map;
 
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.hasSize;

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceGovUkPayAgreementResourceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceGovUkPayAgreementResourceTest.java
@@ -12,7 +12,7 @@ import uk.gov.pay.adminusers.model.User;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceStripeAgreementTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceStripeAgreementTest.java
@@ -11,7 +11,7 @@ import uk.gov.pay.adminusers.model.Service;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceTest.java
@@ -9,7 +9,7 @@ import uk.gov.pay.adminusers.model.User;
 import java.util.List;
 import java.util.Map;
 
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.isEmptyString;

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateCustomBrandingTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateCustomBrandingTest.java
@@ -6,7 +6,7 @@ import uk.gov.pay.adminusers.model.Service;
 
 import java.util.Map;
 
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateGoLiveStageTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateGoLiveStageTest.java
@@ -6,7 +6,7 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.GoLiveStage;
 
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static java.lang.String.valueOf;
 import static org.hamcrest.core.Is.is;

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateMerchantDetailsTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateMerchantDetailsTest.java
@@ -8,7 +8,7 @@ import uk.gov.pay.adminusers.model.Service;
 
 import java.util.Map;
 
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.hasItems;

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateNameTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateNameTest.java
@@ -7,7 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.Service;
 
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationTest.java
@@ -9,7 +9,7 @@ import uk.gov.pay.adminusers.service.PasswordHasher;
 
 import java.util.UUID;
 
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateServiceRoleTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateServiceRoleTest.java
@@ -9,7 +9,7 @@ import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.User;
 
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateTest.java
@@ -1,14 +1,14 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.google.common.collect.ImmutableMap;
-import com.jayway.restassured.response.ValidatableResponse;
+import io.restassured.response.ValidatableResponse;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.Service;
 
 import java.util.List;
 import java.util.Map;
 
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static java.lang.String.valueOf;
 import static org.apache.commons.lang3.RandomUtils.nextInt;

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceFindTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceFindTest.java
@@ -7,7 +7,7 @@ import uk.gov.pay.adminusers.model.User;
 
 import java.util.Map;
 
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceGetMultipleTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceGetMultipleTest.java
@@ -5,7 +5,7 @@ import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.User;
 
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.valueOf;
 import static org.apache.commons.lang3.RandomUtils.nextInt;
 import static org.hamcrest.Matchers.hasSize;

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceGetTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceGetTest.java
@@ -6,7 +6,7 @@ import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.User;
 
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static java.lang.String.valueOf;
 import static org.apache.commons.lang3.RandomUtils.nextInt;

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourcePatchTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourcePatchTest.java
@@ -7,7 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.User;
 
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceSecondFactorAuthenticationTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceSecondFactorAuthenticationTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import uk.gov.pay.adminusers.model.User;
 
 import static com.google.common.io.BaseEncoding.base32;
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceSecondFactorProvisioningTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceSecondFactorProvisioningTest.java
@@ -7,7 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.User;
 
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceUpdateServiceRoleTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceUpdateServiceRoleTest.java
@@ -8,7 +8,7 @@ import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.User;
 
-import static com.jayway.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceBaseTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceBaseTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.adminusers.unit.service;
 
-import com.jayway.restassured.path.json.JsonPath;
+import io.restassured.path.json.JsonPath;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
 import uk.gov.pay.adminusers.service.LinksBuilder;
 import uk.gov.pay.commons.model.SupportedLanguage;

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceCreateTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceCreateTest.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.adminusers.unit.service;
 
-import com.jayway.restassured.path.json.JsonPath;
 import io.dropwizard.testing.junit.ResourceTestRule;
+import io.restassured.path.json.JsonPath;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceFindTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceFindTest.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.adminusers.unit.service;
 
-import com.jayway.restassured.path.json.JsonPath;
 import io.dropwizard.testing.junit.ResourceTestRule;
+import io.restassured.path.json.JsonPath;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceUpdateTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceUpdateTest.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.adminusers.unit.service;
 
-import com.jayway.restassured.path.json.JsonPath;
 import io.dropwizard.testing.junit.ResourceTestRule;
+import io.restassured.path.json.JsonPath;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;


### PR DESCRIPTION
## WHAT YOU DID

Prep for Java11:

- Upgraded `rest-assured` library which also uses transitive dependency `groovy-json` (version 2.4.15) instead of 2.4.4 which fails on tests for Java 11 (See PR https://github.com/alphagov/pay-adminusers/pull/434 for details)

## How to test
- CI should pass
- Tests should run on Java11
