### PR TITLE
Add PMD 5.8.1 ruleset configuration for use with Codacy

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,0 +1,10 @@
+<ruleset name="Custom Rules"
+        xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+
+    <description>PMD (Legacy) Ruleset</description>
+
+    <rule ref="rulesets/java/strictexception.xml/AvoidThrowingRawExceptionTypes"/>
+
+</ruleset>


### PR DESCRIPTION
Only one rule (`AvoidThrowingRawExceptionTypes`) for now so we can check if it works.

If it does, the rules in this file will override the default ones Codacy uses (i.e. it will give us fewer warnings). We can add more rules later, probably using the default Codacy rules as a starting point.

This file is intended for use with PMD 5.8.1 even though it’s legacy because that’s what Codacy has enabled by default. We may choose to move to PMD 6.0.0 as we get more comfortable with the tool.