### PR TITLE
PP-5061 Always set English service name when creating service

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceInviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceInviteCompleter.java
@@ -11,6 +11,8 @@ import uk.gov.pay.adminusers.persistence.dao.UserDao;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
+import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
+import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.util.Optional;
 
@@ -55,6 +57,7 @@ public class ServiceInviteCompleter extends InviteCompleter {
                     if (inviteEntity.isServiceType()) {
                         UserEntity userEntity = inviteEntity.mapToUserEntity();
                         ServiceEntity serviceEntity = ServiceEntity.from(Service.from());
+                        serviceEntity.addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.ENGLISH, serviceEntity.getName()));
                         if (!data.getGatewayAccountIds().isEmpty()) {
                             serviceEntity.addGatewayAccountIds(data.getGatewayAccountIds().toArray(new String[0]));
                         }

--- a/src/main/java/uk/gov/pay/adminusers/service/UserCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserCreator.java
@@ -13,6 +13,8 @@ import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
+import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
+import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.util.List;
 import java.util.Optional;
@@ -79,6 +81,7 @@ public class UserCreator {
                 .map(serviceEntity -> new ServiceRoleEntity(serviceEntity, role))
                 .orElseGet(() -> {
                     ServiceEntity service = new ServiceEntity(gatewayAccountIds);
+                    service.addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.ENGLISH, service.getName()));
                     serviceDao.persist(service);
                     return new ServiceRoleEntity(service, role);
                 });

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCompleterTest.java
@@ -22,6 +22,7 @@ import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
+import uk.gov.pay.commons.model.SupportedLanguage;
 
 import javax.ws.rs.WebApplicationException;
 import java.time.ZonedDateTime;
@@ -101,6 +102,7 @@ public class ServiceInviteCompleterTest {
                 .map(GatewayAccountIdEntity::getGatewayAccountId)
                 .collect(toList()), hasItems("2", "1"));
         assertThat(serviceEntity.getName(), is(Service.DEFAULT_NAME_VALUE));
+        assertThat(serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName(), is(Service.DEFAULT_NAME_VALUE));
         assertThat(serviceEntity.isRedirectToServiceImmediatelyOnTerminalState(), is(false));
         assertThat(serviceEntity.isCollectBillingAddress(), is(true));
 
@@ -131,6 +133,7 @@ public class ServiceInviteCompleterTest {
         ServiceEntity serviceEntity = expectedService.getValue();
         assertThat(serviceEntity.getGatewayAccountIds().isEmpty(), is(true));
         assertThat(serviceEntity.getName(), is(Service.DEFAULT_NAME_VALUE));
+        assertThat(serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName(), is(Service.DEFAULT_NAME_VALUE));
         assertThat(serviceEntity.isRedirectToServiceImmediatelyOnTerminalState(), is(false));
         assertThat(serviceEntity.isCollectBillingAddress(), is(true));
 

--- a/src/test/java/uk/gov/pay/adminusers/service/UserCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserCreatorTest.java
@@ -18,6 +18,7 @@ import uk.gov.pay.adminusers.persistence.dao.UserDao;
 import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
+import uk.gov.pay.commons.model.SupportedLanguage;
 
 import javax.ws.rs.WebApplicationException;
 import java.util.Optional;
@@ -80,9 +81,18 @@ public class UserCreatorTest {
         assertThat(user.getEmail(), is("email@example.com"));
         assertThat(user.getSecondFactor(), is(SecondFactorMethod.SMS));
         assertThat(user.getServiceRoles().size(), is(1));
-        
+
+        ArgumentCaptor<ServiceEntity> serviceEntityArgumentCaptor = ArgumentCaptor.forClass(ServiceEntity.class);
+        verify(mockServiceDao).persist(serviceEntityArgumentCaptor.capture());
+        ServiceEntity serviceEntity = serviceEntityArgumentCaptor.getValue();
+        assertThat(serviceEntity.getName(), is(Service.DEFAULT_NAME_VALUE));
+        assertThat(serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName(), is(Service.DEFAULT_NAME_VALUE));
+        assertThat(serviceEntity.getGatewayAccountIds().get(0).getGatewayAccountId(), is("1"));
+        assertThat(serviceEntity.getGatewayAccountIds().get(1).getGatewayAccountId(), is("2"));
+
         Service service = user.getServiceRoles().get(0).getService();
         assertThat(service.getName(), is (Service.DEFAULT_NAME_VALUE));
+        assertThat(service.getServiceNames().get(SupportedLanguage.ENGLISH.toString()), is (Service.DEFAULT_NAME_VALUE));
         assertThat(service.getGatewayAccountIds(), is(asList("1", "2")));
         assertThat(service.isRedirectToServiceImmediatelyOnTerminalState(), is(false));
         assertThat(service.isCollectBillingAddress(), is(true));


### PR DESCRIPTION
Two separate commits:

- When creating a service using the `ServiceInviteCompleter`, set the English service name as well as the default service name.
- When creating a service via the `UserCreator` with a user with a list of gateway account IDs, set the English service name as well as the default service name.