### PR TITLE
PP-5061 Migration SQL to backfill English-language service names

### DIFF
--- a/src/main/resources/migrations/00055_backfill_english_service_names.sql
+++ b/src/main/resources/migrations/00055_backfill_english_service_names.sql
@@ -1,0 +1,11 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:backfill_english_service_names
+INSERT INTO service_names (service_id, language, name)
+SELECT id, 'en', name
+FROM services
+WHERE NOT EXISTS (
+    SELECT *
+    FROM service_names
+    WHERE service_id = services.id AND language = 'en'
+);


### PR DESCRIPTION
Database migration to insert a row with the English-language service name into the `service_names` table if there is not already one present for the service.

This should ensure that every English-language service name is duplicated in the `service_names` table.

This won’t lock the table so it’s possible that other service name changes made while this is running may result in inconsistencies and there’s a tiny chance a service trying to update their service
name while this is running may encounter an error. However, the chances are very small (service names are not changed very often) and we can easily check for inconsistencies afterwards and fix any
that are found (which at the very worst may just mean old service names continue to be used for longer than anticipated).