### PR TITLE
PP-5061 Don’t use ServiceEntity.getName() in production code

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
@@ -99,6 +99,21 @@ public class ServiceEntity {
         this.id = id;
     }
 
+    /**
+     * @deprecated Replaced by {@link #getServiceNames()}:
+     * 
+     * <pre>
+     * {@code
+     * serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName();
+     * }
+     * </pre>
+     * 
+     * This should be equivalent to <code>getName()</code> as long as the ServiceEntity is loaded
+     * from the database and {@link #addOrUpdateServiceName(ServiceNameEntity)} is always used to
+     * update the name
+     * 
+     */
+    @Deprecated
     public String getName() {
         return name;
     }

--- a/src/main/java/uk/gov/pay/adminusers/service/EmailService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/EmailService.java
@@ -12,6 +12,7 @@ import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.resources.EmailTemplate;
 import uk.gov.pay.adminusers.resources.InvalidMerchantDetailsException;
 import uk.gov.pay.adminusers.utils.CountryConverter;
+import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -81,14 +82,14 @@ public class EmailService {
         }
 
         ImmutableMap<String, String> personalisation = ImmutableMap.of(
-                SERVICE_NAME_KEY, service.getName(),
+                SERVICE_NAME_KEY, service.getServiceNames().get(SupportedLanguage.ENGLISH).getName(),
                 ORGANISATION_NAME_KEY, merchantDetails.getName(),
                 ORGANISATION_ADDRESS_KEY, formatMerchantAddress(merchantDetails),
                 ORGANISATION_PHONE_NUMBER_KEY, merchantDetails.getTelephoneNumber(),
                 ORGANISATION_EMAIL_ADDRESS_KEY, merchantDetails.getEmail()
         );
 
-        return new HashMap<EmailTemplate, StaticEmailContent>() {
+        return new HashMap<>() {
             {
                 put(EmailTemplate.ONE_OFF_PAYMENT_CONFIRMED, new StaticEmailContent(
                         notificationService.getNotifyDirectDebitConfiguration().getOneOffMandateAndPaymentCreatedEmailTemplateId(),

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceInviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceInviteCompleter.java
@@ -17,7 +17,9 @@ import uk.gov.pay.commons.model.SupportedLanguage;
 import java.util.Optional;
 
 import static java.lang.String.format;
-import static uk.gov.pay.adminusers.service.AdminUsersExceptions.*;
+import static uk.gov.pay.adminusers.service.AdminUsersExceptions.conflictingEmail;
+import static uk.gov.pay.adminusers.service.AdminUsersExceptions.internalServerError;
+import static uk.gov.pay.adminusers.service.AdminUsersExceptions.inviteLockedException;
 
 public class ServiceInviteCompleter extends InviteCompleter {
 
@@ -57,7 +59,7 @@ public class ServiceInviteCompleter extends InviteCompleter {
                     if (inviteEntity.isServiceType()) {
                         UserEntity userEntity = inviteEntity.mapToUserEntity();
                         ServiceEntity serviceEntity = ServiceEntity.from(Service.from());
-                        serviceEntity.addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.ENGLISH, serviceEntity.getName()));
+                        serviceEntity.addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.ENGLISH, Service.DEFAULT_NAME_VALUE));
                         if (!data.getGatewayAccountIds().isEmpty()) {
                             serviceEntity.addGatewayAccountIds(data.getGatewayAccountIds().toArray(new String[0]));
                         }

--- a/src/main/java/uk/gov/pay/adminusers/service/UserCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserCreator.java
@@ -5,6 +5,7 @@ import com.google.inject.persist.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.adminusers.model.CreateUserRequest;
+import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.persistence.dao.RoleDao;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
@@ -81,7 +82,7 @@ public class UserCreator {
                 .map(serviceEntity -> new ServiceRoleEntity(serviceEntity, role))
                 .orElseGet(() -> {
                     ServiceEntity service = new ServiceEntity(gatewayAccountIds);
-                    service.addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.ENGLISH, service.getName()));
+                    service.addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.ENGLISH, Service.DEFAULT_NAME_VALUE));
                     serviceDao.persist(service);
                     return new ServiceRoleEntity(service, role);
                 });

--- a/src/test/java/uk/gov/pay/adminusers/service/EmailServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/EmailServiceTest.java
@@ -9,12 +9,12 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.adminusers.app.config.NotifyConfiguration;
 import uk.gov.pay.adminusers.app.config.NotifyDirectDebitConfiguration;
 import uk.gov.pay.adminusers.model.PaymentType;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
 import uk.gov.pay.adminusers.persistence.entity.MerchantDetailsEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
+import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
 import uk.gov.pay.adminusers.resources.EmailTemplate;
 import uk.gov.pay.adminusers.resources.InvalidMerchantDetailsException;
 import uk.gov.pay.adminusers.utils.CountryConverter;
@@ -28,6 +28,7 @@ import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static uk.gov.pay.commons.model.SupportedLanguage.ENGLISH;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EmailServiceTest {
@@ -72,7 +73,7 @@ public class EmailServiceTest {
         given(mockNotifyDirectDebitConfiguration.getOnDemandMandateCreatedEmailTemplateId()).willReturn("NOTIFY_ON_DEMAND_MANDATE_CREATED_EMAIL_TEMPLATE_ID_VALUE");
         given(mockNotifyDirectDebitConfiguration.getOnDemandPaymentConfirmedEmailTemplateId()).willReturn("NOTIFY_ON_DEMAND_PAYMENT_CONFIRMED_EMAIL_TEMPLATE_ID_VALUE");
         given(mockServiceDao.findByGatewayAccountId(GATEWAY_ACCOUNT_ID)).willReturn(Optional.of(mockServiceEntity));
-        given(mockServiceEntity.getName()).willReturn("a service");
+        given(mockServiceEntity.getServiceNames()).willReturn(Map.of(ENGLISH, ServiceNameEntity.from(ENGLISH, "a service")));
         given(mockCountryConverter.getCountryNameFrom(ADDRESS_COUNTRY_CODE)).willReturn(Optional.of("Cake Land"));
         emailService = new EmailService(mockNotificationService, mockCountryConverter, mockServiceDao);
     }

--- a/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
@@ -25,6 +25,8 @@ import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
+import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
+import uk.gov.pay.commons.model.SupportedLanguage;
 
 import javax.ws.rs.WebApplicationException;
 import java.time.ZonedDateTime;
@@ -281,7 +283,9 @@ public class UserInviteCreatorTest {
         emptyServiceInvite.setExpiryDate(ZonedDateTime.now().plusDays(1));
 
         InviteEntity nonMatchingServiceInvite = new InviteEntity();
-        nonMatchingServiceInvite.setService(ServiceEntity.from(Service.from("another-service")));
+        ServiceEntity serviceEntity = ServiceEntity.from(Service.from("another-service"));
+        serviceEntity.addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.ENGLISH, serviceEntity.getName()));
+        nonMatchingServiceInvite.setService(serviceEntity);
         nonMatchingServiceInvite.setExpiryDate(ZonedDateTime.now().plusDays(1));
 
         when(mockInviteDao.findByEmail(email)).thenReturn(newArrayList(expiredInvite, disabledInvite, emptyServiceInvite, nonMatchingServiceInvite, validInvite));
@@ -302,6 +306,7 @@ public class UserInviteCreatorTest {
 
     private InviteEntity mockInviteSuccess_existingInvite() {
         ServiceEntity service = new ServiceEntity();
+        service.addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.ENGLISH, service.getName()));
         service.setId(serviceId);
         service.setExternalId(serviceExternalId);
 

--- a/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
@@ -12,6 +12,7 @@ import uk.gov.pay.adminusers.persistence.entity.CustomBrandingConverter;
 import uk.gov.pay.adminusers.persistence.entity.MerchantDetailsEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
+import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.sql.Timestamp;
 import java.time.ZoneId;
@@ -226,6 +227,8 @@ public class DatabaseTestHelper {
                     .execute();
         });
 
+        addServiceName(ServiceNameEntity.from(SupportedLanguage.ENGLISH, service.getName()), service.getId());
+        
         for (String gatewayAccountId : gatewayAccountIds) {
             jdbi.withHandle(handle ->
                     handle.createStatement("INSERT INTO service_gateway_accounts(service_id, gateway_account_id) VALUES (:serviceId, :gatewayAccountId)")
@@ -361,8 +364,7 @@ public class DatabaseTestHelper {
 
     private DatabaseTestHelper addServiceName(ServiceNameEntity entity, Integer serviceId) {
         jdbi.withHandle(handle -> handle
-                .createStatement("INSERT INTO service_names(id, service_id, language, name) VALUES (:id, :serviceId, :language, :name)")
-                .bind("id", entity.getId())
+                .createStatement("INSERT INTO service_names(service_id, language, name) VALUES (:serviceId, :language, :name)")
                 .bind("serviceId", serviceId)
                 .bind("language", entity.getLanguage().toString())
                 .bind("name", entity.getName())


### PR DESCRIPTION
Stop using `ServiceEntity.getName()` in favour of `ServiceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName()`, which should return the same thing now that all services have an `'en'` entry in the `'service_names'` table (and updating the name on the service updates in both tables).

`ServiceEntity.getName()` is now only used in tests.