### PR TITLE
PP-4864: Stop deduplicating certs when adding to truststore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM govukpay/openjdk:adoptopenjdk-jre-11.0.2.9-alpine
 
 RUN apk --no-cache upgrade
 
-# openssl is only here temporarily whilst docker-startup.sh needs it
-RUN apk add --no-cache bash openssl
+RUN apk add --no-cache bash
 
 ENV JAVA_HOME /opt/java/openjdk
 ENV PORT 8080

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -8,15 +8,10 @@ if [ -n "${CERTS_PATH:-}" ]; then
   i=0
   truststore=$JAVA_HOME/lib/security/cacerts
   truststore_pass=changeit
-  existing_fingerprints=$(keytool -list -keystore "$truststore" -storepass "$truststore_pass"| sed -ne 's/^Certificate fingerprint (SHA1): //p')
   for cert in "$CERTS_PATH"/*; do
     [ -f "$cert" ] || continue
-    if grep -qFx "$(openssl x509 -in "$cert" -fingerprint -noout | sed -ne 's/^SHA1 Fingerprint=//p')" <<<"$existing_fingerprints"; then
-      echo "$cert already in truststore $truststore"
-    else
-      echo "Adding $cert to $truststore"
-      keytool -importcert -noprompt -keystore "$truststore" -storepass "$truststore_pass" -file "$cert" -alias custom$((i++))
-    fi
+    echo "Adding $cert to $truststore"
+    keytool -importcert -noprompt -keystore "$truststore" -storepass "$truststore_pass" -file "$cert" -alias custom$((i++))
   done
 fi
 


### PR DESCRIPTION
We had code to avoid adding duplicate certificates to the default Java
truststore from $CERTS_PATH. This was only needed because adding a certificate
takes 0.5s and we mounted all the Ubuntu trusted CAs into the container in ECS
environments. This is no longer the case - we no longer set CERTS_PATH in ECS
environments, so we don't need this extra complexity.