### PR TITLE
PP-5061 Copy across names when creating ServiceEntity from Service

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
@@ -200,6 +200,8 @@ public class ServiceEntity {
     public static ServiceEntity from(Service service) {
         ServiceEntity serviceEntity = new ServiceEntity();
         serviceEntity.setName(service.getName());
+        service.getServiceNames().forEach((languageCode, serviceName) ->
+                serviceEntity.addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.fromIso639AlphaTwoCode(languageCode), serviceName)));
         serviceEntity.setExternalId(service.getExternalId());
         serviceEntity.setRedirectToServiceImmediatelyOnTerminalState(service.isRedirectToServiceImmediatelyOnTerminalState());
         serviceEntity.setCollectBillingAddress(service.isCollectBillingAddress());

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceCreator.java
@@ -34,7 +34,6 @@ public class ServiceCreator {
                 .orElseGet(Service::from);
 
         ServiceEntity serviceEntity = ServiceEntity.from(service);
-        serviceEntity.addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.ENGLISH, service.getName()));
         serviceNameVariants.forEach((language, name) -> serviceEntity.addOrUpdateServiceName(ServiceNameEntity.from(language, name)));
 
         if (gatewayAccountIdsOptional.isPresent()) {

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceInviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceInviteCompleter.java
@@ -11,8 +11,6 @@ import uk.gov.pay.adminusers.persistence.dao.UserDao;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
-import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
-import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.util.Optional;
 
@@ -59,7 +57,6 @@ public class ServiceInviteCompleter extends InviteCompleter {
                     if (inviteEntity.isServiceType()) {
                         UserEntity userEntity = inviteEntity.mapToUserEntity();
                         ServiceEntity serviceEntity = ServiceEntity.from(Service.from());
-                        serviceEntity.addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.ENGLISH, Service.DEFAULT_NAME_VALUE));
                         if (!data.getGatewayAccountIds().isEmpty()) {
                             serviceEntity.addGatewayAccountIds(data.getGatewayAccountIds().toArray(new String[0]));
                         }


### PR DESCRIPTION
When creating a `ServiceEntity` from a `Service` with `ServiceEntity.from(Service)`, use `ServiceEntity.addOrUpdateServiceName(ServiceNameEntity)` to add all the service names provided by `Service.getServiceNames()`.

Two pieces of code create `ServiceEntity`s with `ServiceEntity.from(Service)`: `ServiceCreator` and
`ServiceInviteCompleter`. Both use Service objects they’ve just created and which only have English-language service names. Both `ServiceCreator` and `ServiceInviteCompleter` used to call `ServiceEntity.addOrUpdateServiceName(ServiceNameEntity)` to add their English service names to the `ServiceEntity`. These two calls have been removed and `ServiceEntity.from(Service)` now does the job itself by calling `ServiceEntity.addOrUpdateServiceName(ServiceNameEntity)` with every
name provided by `Service.getServiceNames()` (which due to the smoke and mirrors we already have in place will always include the English-language service name).

Therefore there is no behaviour change for the production code. Some tests use `ServiceEntity.from(Service)` and so may find their `ServiceEntity`s are more thoroughly populated but this is a good thing (either they’re matching the behaviour for newly-created services or they’re trying to simulate loading a `ServiceEntity` from the database, which should now always include at least an English-language `ServiceNameEntity`).