### PR TITLE
PP-5061 Stop updating the legacy service name

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
@@ -211,18 +211,14 @@ public class ServiceEntity {
     }
 
     public void addOrUpdateServiceName(ServiceNameEntity newServiceName) {
-        if (newServiceName.getLanguage().equals(SupportedLanguage.ENGLISH)) {
-            setName(newServiceName.getName());
-        }
         newServiceName.setService(this);
-        final Optional<ServiceNameEntity> existingServiceName = serviceNames.stream()
-                .filter(n -> n.getLanguage().equals(newServiceName.getLanguage()))
-                .findFirst();
-        if (existingServiceName.isPresent()) {
-            existingServiceName.get().setName(newServiceName.getName());
-        } else {
-            serviceNames.add(newServiceName);
-        }
+        serviceNames.stream()
+                .filter(serviceName -> serviceName.getLanguage().equals(newServiceName.getLanguage()))
+                .findFirst()
+                .ifPresentOrElse(
+                        existingServiceName -> existingServiceName.setName(newServiceName.getName()),
+                        () -> serviceNames.add(newServiceName)
+                );
     }
 
     public Map<SupportedLanguage, ServiceNameEntity> getServiceNames() {

--- a/src/test/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntityTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntityTest.java
@@ -13,23 +13,34 @@ import static org.junit.Assert.assertThat;
 
 public class ServiceEntityTest {
 
+    private static final String ENGLISH_SERVICE_NAME = "Apply for your licence";
+    private static final String WELSH_SERVICE_NAME = "Gwneud cais am eich trwydded";
+
     @Test
-    public void addOrUpdateServiceName_shouldUpdateNameWhenAddingEnName() {
-        ServiceNameEntity serviceNameEntity = ServiceNameEntity.from(SupportedLanguage.ENGLISH, "newest-en-name");
-        ServiceEntity serviceEntity = ServiceEntityBuilder.aServiceEntity()
-                .withName("old-en-name")
-                .withServiceName(Set.of(ServiceNameEntity.from(SupportedLanguage.ENGLISH, "old-en-name")))
-                .build();
+    public void shouldUpdateExistingServiceName() {
+        ServiceEntity serviceEntity = ServiceEntityBuilder.aServiceEntity().build();
 
-        assertThat(serviceEntity.getName(), is("old-en-name"));
         assertThat(serviceEntity.getServiceNames().size(), is(1));
-        assertThat(serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName(), is("old-en-name"));
+        assertThat(serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName(), is(Service.DEFAULT_NAME_VALUE));
 
-        serviceEntity.addOrUpdateServiceName(serviceNameEntity);
+        serviceEntity.addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.ENGLISH, ENGLISH_SERVICE_NAME));
 
-        assertThat(serviceEntity.getName(), is("newest-en-name"));
         assertThat(serviceEntity.getServiceNames().size(), is(1));
-        assertThat(serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName(), is("newest-en-name"));
+        assertThat(serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName(), is(ENGLISH_SERVICE_NAME));
+    }
+
+    @Test
+    public void shouldAddNewServiceName() {
+        ServiceEntity serviceEntity = ServiceEntityBuilder.aServiceEntity().build();
+
+        assertThat(serviceEntity.getServiceNames().size(), is(1));
+        assertThat(serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName(), is(Service.DEFAULT_NAME_VALUE));
+
+        serviceEntity.addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.WELSH, WELSH_SERVICE_NAME));
+
+        assertThat(serviceEntity.getServiceNames().size(), is(2));
+        assertThat(serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName(), is(Service.DEFAULT_NAME_VALUE));
+        assertThat(serviceEntity.getServiceNames().get(SupportedLanguage.WELSH).getName(), is(WELSH_SERVICE_NAME));
     }
 
     @Test
@@ -37,4 +48,5 @@ public class ServiceEntityTest {
         Service service = ServiceEntityBuilder.aServiceEntity().build().toService();
         assertThat(service.getGoLiveStage(), is(GoLiveStage.NOT_STARTED));
     }
+
 }


### PR DESCRIPTION
When updating the English-language service name, stop updating the legacy service name i.e. `name` on `ServiceEntity`, which maps to the `name` column in the `services` table in the database.

This is safe to do because nothing ever reads from the name property of `ServiceEntity` for non-test purpose any more.

This may lead to the name column in the `services` table in the database becoming out of sync with the `service_names` table but nothing relies on the former and we intend to remove it soon.