### PR TITLE
PP-5061 Don’t write legacy service name when creating service

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -43,9 +42,6 @@ public class ServiceEntity {
 
     @Column(name = "external_id")
     private String externalId;
-
-    @Column(name = "name")
-    private String name = Service.DEFAULT_NAME_VALUE;
 
     @Column(name = "redirect_to_service_immediately_on_terminal_state")
     private boolean redirectToServiceImmediatelyOnTerminalState = false;
@@ -98,29 +94,6 @@ public class ServiceEntity {
 
     public void setId(Integer id) {
         this.id = id;
-    }
-
-    /**
-     * @deprecated Replaced by {@link #getServiceNames()}:
-     * 
-     * <pre>
-     * {@code
-     * serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName();
-     * }
-     * </pre>
-     * 
-     * This should be equivalent to <code>getName()</code> as long as the ServiceEntity is loaded
-     * from the database and {@link #addOrUpdateServiceName(ServiceNameEntity)} is always used to
-     * update the name
-     * 
-     */
-    @Deprecated
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
     }
 
     public boolean isRedirectToServiceImmediatelyOnTerminalState() {
@@ -201,7 +174,6 @@ public class ServiceEntity {
 
     public static ServiceEntity from(Service service) {
         ServiceEntity serviceEntity = new ServiceEntity();
-        serviceEntity.setName(service.getName());
         service.getServiceNames().forEach((languageCode, serviceName) ->
                 serviceEntity.addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.fromIso639AlphaTwoCode(languageCode), serviceName)));
         serviceEntity.setExternalId(service.getExternalId());

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoTest.java
@@ -78,7 +78,6 @@ public class ServiceDaoTest extends DaoTestBase {
     public void shouldSaveAService_withMultipleServiceNames() {
         ServiceEntity thisServiceEntity = ServiceEntityBuilder.aServiceEntity()
                 .withCustomBranding(null)
-                .withName(EN_NAME)
                 .withServiceNameEntity(SupportedLanguage.WELSH, CY_NAME)
                 .withServiceNameEntity(SupportedLanguage.ENGLISH, EN_NAME)
                 .build();
@@ -105,7 +104,7 @@ public class ServiceDaoTest extends DaoTestBase {
     public void shouldSaveAService_withoutCustomisations_andServiceName() {
         ServiceEntity thisServiceEntity = ServiceEntityBuilder.aServiceEntity()
                 .withCustomBranding(null)
-                .withName(EN_NAME)
+                .withServiceNameEntity(SupportedLanguage.ENGLISH, EN_NAME)
                 .withServiceNameEntity(SupportedLanguage.WELSH, CY_NAME)
                 .build();
         serviceDao.persist(thisServiceEntity);
@@ -193,7 +192,6 @@ public class ServiceDaoTest extends DaoTestBase {
                 createServiceName(SupportedLanguage.WELSH, CY_NAME)
         ));
         ServiceEntity thisServiceEntity = ServiceEntityBuilder.aServiceEntity()
-                .withName(EN_NAME)
                 .withServiceName(serviceNames)
                 .build();
 
@@ -323,7 +321,8 @@ public class ServiceDaoTest extends DaoTestBase {
     private void assertServiceEntity(ServiceEntity thisEntity, ServiceEntity thatEntity) {
         assertThat(thisEntity.getId(), is(thatEntity.getId()));
         assertThat(thisEntity.getExternalId(), is(thatEntity.getExternalId()));
-        assertThat(thisEntity.getName(), is(thatEntity.getName()));
+        assertThat(thisEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName(),
+                is(thatEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName()));
         assertThat(thisEntity.isRedirectToServiceImmediatelyOnTerminalState(), is(thatEntity.isRedirectToServiceImmediatelyOnTerminalState()));
         assertThat(thisEntity.isCollectBillingAddress(), is(thatEntity.isCollectBillingAddress()));
     }
@@ -334,8 +333,4 @@ public class ServiceDaoTest extends DaoTestBase {
         assertThat(thisServiceEntity.getCustomBranding().values(), hasItems("image url", "css url"));
     }
 
-    private void assertNoServiceNameRecords(ServiceEntity thisServiceEntity) {
-        List<Map<String, Object>> savedServiceName = databaseHelper.findServiceNameByServiceId(thisServiceEntity.getId());
-        assertThat(savedServiceName.size(), is(0));
-    }
 }

--- a/src/test/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntityBuilder.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntityBuilder.java
@@ -43,11 +43,6 @@ public final class ServiceEntityBuilder {
         return this;
     }
 
-    public ServiceEntityBuilder withName(String name) {
-        this.name = name;
-        return this;
-    }
-
     public ServiceEntityBuilder withMerchantDetailsEntity(MerchantDetailsEntity merchantDetailsEntity) {
         this.merchantDetailsEntity = merchantDetailsEntity;
         return this;
@@ -97,7 +92,6 @@ public final class ServiceEntityBuilder {
         serviceEntity.setExternalId(externalId);
         serviceEntity.setMerchantDetailsEntity(merchantDetailsEntity);
         serviceEntity.setCustomBranding(customBranding);
-        serviceEntity.setName(name);
         serviceEntity.addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.ENGLISH, name));
         serviceName.forEach(serviceEntity::addOrUpdateServiceName);
         gatewayAccountIds.forEach(g -> serviceEntity.addGatewayAccountIds(g.getGatewayAccountId()));

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCompleterTest.java
@@ -102,7 +102,6 @@ public class ServiceInviteCompleterTest {
         assertThat(serviceEntity.getGatewayAccountIds().stream()
                 .map(GatewayAccountIdEntity::getGatewayAccountId)
                 .collect(toList()), hasItems("2", "1"));
-        assertThat(serviceEntity.getName(), is(Service.DEFAULT_NAME_VALUE));
         assertThat(serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName(), is(Service.DEFAULT_NAME_VALUE));
         assertThat(serviceEntity.isRedirectToServiceImmediatelyOnTerminalState(), is(false));
         assertThat(serviceEntity.isCollectBillingAddress(), is(true));
@@ -134,7 +133,6 @@ public class ServiceInviteCompleterTest {
 
         ServiceEntity serviceEntity = expectedService.getValue();
         assertThat(serviceEntity.getGatewayAccountIds().isEmpty(), is(true));
-        assertThat(serviceEntity.getName(), is(Service.DEFAULT_NAME_VALUE));
         assertThat(serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName(), is(Service.DEFAULT_NAME_VALUE));
         assertThat(serviceEntity.isRedirectToServiceImmediatelyOnTerminalState(), is(false));
         assertThat(serviceEntity.isCollectBillingAddress(), is(true));

--- a/src/test/java/uk/gov/pay/adminusers/service/UserCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserCreatorTest.java
@@ -85,7 +85,6 @@ public class UserCreatorTest {
         ArgumentCaptor<ServiceEntity> serviceEntityArgumentCaptor = ArgumentCaptor.forClass(ServiceEntity.class);
         verify(mockServiceDao).persist(serviceEntityArgumentCaptor.capture());
         ServiceEntity serviceEntity = serviceEntityArgumentCaptor.getValue();
-        assertThat(serviceEntity.getName(), is(Service.DEFAULT_NAME_VALUE));
         assertThat(serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName(), is(Service.DEFAULT_NAME_VALUE));
         assertThat(serviceEntity.getGatewayAccountIds().get(0).getGatewayAccountId(), is("1"));
         assertThat(serviceEntity.getGatewayAccountIds().get(1).getGatewayAccountId(), is("2"));

--- a/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
@@ -234,8 +234,8 @@ public class UserInviteCreatorTest {
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(UserEntity.from(aUser(email))));
         InviteEntity anInvite = mockInviteSuccess_existingInvite();
         CompletableFuture<String> notifyPromise = CompletableFuture.completedFuture("random-notify-id");
-        when(mockNotificationService.sendInviteExistingUserEmail(eq(senderEmail), eq(email), matches("^http://selfservice/invites/[0-9a-z]{32}$"), eq(anInvite.getService().getName())))
-                .thenReturn(notifyPromise);
+        when(mockNotificationService.sendInviteExistingUserEmail(eq(senderEmail), eq(email), matches("^http://selfservice/invites/[0-9a-z]{32}$"),
+                eq(anInvite.getService().getServiceNames().get(SupportedLanguage.ENGLISH).getName()))).thenReturn(notifyPromise);
 
         InviteUserRequest inviteUserRequest = inviteRequestFrom(senderExternalId, email, roleName);
         Optional<Invite> invite = userInviteCreator.doInvite(inviteUserRequest);
@@ -255,8 +255,8 @@ public class UserInviteCreatorTest {
         CompletableFuture<String> notifyPromise = CompletableFuture.supplyAsync(() -> {
             throw new RuntimeException("some error from notify");
         });
-        when(mockNotificationService.sendInviteExistingUserEmail(eq(senderEmail), eq(email), matches("^http://selfservice/invites/[0-9a-z]{32}$"), eq(anInvite.getService().getName())))
-                .thenReturn(notifyPromise);
+        when(mockNotificationService.sendInviteExistingUserEmail(eq(senderEmail), eq(email), matches("^http://selfservice/invites/[0-9a-z]{32}$"),
+                eq(anInvite.getService().getServiceNames().get(SupportedLanguage.ENGLISH).getName()))).thenReturn(notifyPromise);
 
         InviteUserRequest inviteUserRequest = inviteRequestFrom(senderExternalId, email, roleName);
         Optional<Invite> invite = userInviteCreator.doInvite(inviteUserRequest);
@@ -285,7 +285,6 @@ public class UserInviteCreatorTest {
 
         InviteEntity nonMatchingServiceInvite = new InviteEntity();
         ServiceEntity serviceEntity = ServiceEntity.from(Service.from(new ServiceName("another-service")));
-        serviceEntity.addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.ENGLISH, serviceEntity.getName()));
         nonMatchingServiceInvite.setService(serviceEntity);
         nonMatchingServiceInvite.setExpiryDate(ZonedDateTime.now().plusDays(1));
 
@@ -293,8 +292,8 @@ public class UserInviteCreatorTest {
 
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(UserEntity.from(aUser(email))));
         CompletableFuture<String> notifyPromise = CompletableFuture.completedFuture("random-notify-id");
-        when(mockNotificationService.sendInviteExistingUserEmail(eq(senderEmail), eq(email), matches("^http://selfservice/invites/[0-9a-z]{32}$"), eq(validInvite.getService().getName())))
-                .thenReturn(notifyPromise);
+        when(mockNotificationService.sendInviteExistingUserEmail(eq(senderEmail), eq(email), matches("^http://selfservice/invites/[0-9a-z]{32}$"),
+                eq(validInvite.getService().getServiceNames().get(SupportedLanguage.ENGLISH).getName()))).thenReturn(notifyPromise);
 
         InviteUserRequest inviteUserRequest = inviteRequestFrom(senderExternalId, email, roleName);
         Optional<Invite> invite = userInviteCreator.doInvite(inviteUserRequest);
@@ -307,7 +306,7 @@ public class UserInviteCreatorTest {
 
     private InviteEntity mockInviteSuccess_existingInvite() {
         ServiceEntity service = new ServiceEntity();
-        service.addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.ENGLISH, service.getName()));
+        service.addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.ENGLISH, Service.DEFAULT_NAME_VALUE));
         service.setId(serviceId);
         service.setExternalId(serviceExternalId);
 

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceFindTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceFindTest.java
@@ -85,8 +85,8 @@ public class ServiceResourceFindTest extends ServiceResourceBaseTest {
         String body = response.readEntity(String.class);
         JsonPath json = JsonPath.from(body);
 
-        assertThat(json.get("name"), is(serviceEntity.getName()));
-        assertEnServiceNameJson(serviceEntity.getName(), json);
+        assertThat(json.get("name"), is(serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName()));
+        assertEnServiceNameJson(serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName(), json);
         assertThat(json.getMap("service_name"), not(hasKey("cy")));
         assertMerchantDetails(serviceEntity.getMerchantDetailsEntity(), json);
         assertLinks(serviceExternalId, json);
@@ -109,8 +109,8 @@ public class ServiceResourceFindTest extends ServiceResourceBaseTest {
         String body = response.readEntity(String.class);
         JsonPath json = JsonPath.from(body);
 
-        assertThat(json.get("name"), is(serviceEntity.getName()));
-        assertEnServiceNameJson(serviceEntity.getName(), json);
+        assertThat(json.get("name"), is(serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName()));
+        assertEnServiceNameJson(serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName(), json);
         assertCyServiceNameJson(CY_SERVICE_NAME, json);
         assertMerchantDetails(serviceEntity.getMerchantDetailsEntity(), json);
         assertLinks(serviceExternalId, json);
@@ -120,7 +120,6 @@ public class ServiceResourceFindTest extends ServiceResourceBaseTest {
     public void shouldGetServiceById_withServiceNameVariantsForEn_andCy() {
         String serviceExternalId = randomUuid();
         ServiceEntity serviceEntity = ServiceEntityBuilder.aServiceEntity()
-                .withName(EN_SERVICE_NAME)
                 .withExternalId(serviceExternalId)
                 .withServiceNameEntity(SupportedLanguage.ENGLISH, EN_SERVICE_NAME)
                 .withServiceNameEntity(SupportedLanguage.WELSH, CY_SERVICE_NAME)
@@ -133,7 +132,7 @@ public class ServiceResourceFindTest extends ServiceResourceBaseTest {
         String body = response.readEntity(String.class);
         JsonPath json = JsonPath.from(body);
 
-        assertThat(json.get("name"), is(serviceEntity.getName()));
+        assertThat(json.get("name"), is(EN_SERVICE_NAME));
         assertEnServiceNameJson(EN_SERVICE_NAME, json);
         assertCyServiceNameJson(CY_SERVICE_NAME, json);
         assertMerchantDetails(serviceEntity.getMerchantDetailsEntity(), json);
@@ -161,8 +160,8 @@ public class ServiceResourceFindTest extends ServiceResourceBaseTest {
         String body = response.readEntity(String.class);
         JsonPath json = JsonPath.from(body);
 
-        assertThat(json.get("name"), is(serviceEntity.getName()));
-        assertEnServiceNameJson(serviceEntity.getName(), json);
+        assertThat(json.get("name"), is(serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName()));
+        assertEnServiceNameJson(serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName(), json);
         assertMerchantDetails(serviceEntity.getMerchantDetailsEntity(), json);
         assertLinks(serviceEntity.getExternalId(), json);
         assertThat(json.get("redirect_to_service_immediately_on_terminal_state"), is(serviceEntity.isRedirectToServiceImmediatelyOnTerminalState()));

--- a/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
@@ -380,13 +380,12 @@ public class DatabaseTestHelper {
             MerchantDetailsEntity merchantDetails = serviceEntity.getMerchantDetailsEntity();
 
             return handle.createStatement("INSERT INTO services(" +
-                    "id, name, custom_branding, " +
+                    "id, custom_branding, " +
                     "merchant_name, merchant_telephone_number, merchant_address_line1, merchant_address_line2, merchant_address_city, " +
                     "merchant_address_postcode, merchant_address_country, merchant_email, external_id, redirect_to_service_immediately_on_terminal_state, current_go_live_stage) " +
-                    "VALUES (:id, :name, :customBranding, :merchantName, :merchantTelephoneNumber, :merchantAddressLine1, :merchantAddressLine2, " +
+                    "VALUES (:id, :customBranding, :merchantName, :merchantTelephoneNumber, :merchantAddressLine1, :merchantAddressLine2, " +
                     ":merchantAddressCity, :merchantAddressPostcode, :merchantAddressCountry, :merchantEmail, :externalId, :redirectToServiceImmediatelyOnTerminalState, :currentGoLiveStage)")
                     .bind("id", serviceEntity.getId())
-                    .bind("name", serviceEntity.getName())
                     .bind("customBranding", customBranding)
                     .bind("merchantName", merchantDetails.getName())
                     .bind("merchantTelephoneNumber", merchantDetails.getTelephoneNumber())


### PR DESCRIPTION
Don’t write legacy service name (represented by the `name` property on the `ServiceEntity`, which maps to the `name` column in the `services` table in the database) when creating a new service.

Since this was the last thing that set the name property on the `ServiceEntity` (and no non-test code ever read it), remove the property and its getters and setters. Fix the tests that relied on this property (most of these should have been updated when we stopped writing the legacy service name when updating the service name in commit 54fd08789f7dab7ea776727c4d96ddfe887ff244 — in retrospect, perhaps this commit and that one should have been done in one go).