### PR TITLE
PP-5061 Ignore "name" property of service creation requests

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -503,7 +503,6 @@ Content-Type: application/json
 
 | Field                    | required | Description                                                      | Supported Values     |
 | ------------------------ |:--------:| ---------------------------------------------------------------- |----------------------|
-| `name`       |         | a name for the service          |  |
 | `gateway_account_ids`            |          | valid gateway account IDs from connector | |
 | `service_name` | | object where keys are supported ISO-639-1 language codes and values are translated service names | key must be `"en"` or `"cy"` |
 

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
@@ -146,30 +146,20 @@ public class ServiceResource {
     @Consumes(APPLICATION_JSON)
     public Response createService(JsonNode payload) {
         LOGGER.info("Create Service POST request - [ {} ]", payload);
-        Optional<String> serviceName = extractServiceName(payload);
-        Optional<List<String>> gatewayAccountIds = extractGatewayAccountIds(payload);
+        List<String> gatewayAccountIds = extractGatewayAccountIds(payload);
         Map<SupportedLanguage, String> serviceNameVariants = getServiceNameVariants(payload);
 
-        Service service = serviceServicesFactory.serviceCreator().doCreate(serviceName, gatewayAccountIds, serviceNameVariants);
+        Service service = serviceServicesFactory.serviceCreator().doCreate(gatewayAccountIds, serviceNameVariants);
         return Response.status(CREATED).entity(service).build();
 
     }
 
-    private Optional<List<String>> extractGatewayAccountIds(JsonNode payload) {
+    private List<String> extractGatewayAccountIds(JsonNode payload) {
         if (payload == null || payload.get(FIELD_GATEWAY_ACCOUNT_IDS) == null) {
-            return Optional.empty();
+            return Collections.emptyList();
         }
         List<JsonNode> gatewayAccountIds = newArrayList(payload.get(FIELD_GATEWAY_ACCOUNT_IDS).elements());
-        return Optional.of(gatewayAccountIds.stream()
-                .map(JsonNode::textValue)
-                .collect(Collectors.toList()));
-    }
-
-    private Optional<String> extractServiceName(JsonNode payload) {
-        if (payload == null || payload.get(FIELD_NAME) == null || isBlank(payload.get(FIELD_NAME).textValue())) {
-            return Optional.empty();
-        }
-        return Optional.of(payload.get(FIELD_NAME).textValue());
+        return gatewayAccountIds.stream().map(JsonNode::textValue).collect(Collectors.toUnmodifiableList());
     }
 
     @Path("/{serviceExternalId}")

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceCreatorTest.java
@@ -20,9 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
-import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -61,7 +59,7 @@ public class ServiceCreatorTest {
 
     @Test
     public void shouldSuccess_whenProvidedWith_noParameters() {
-        Service service = serviceCreator.doCreate(Optional.empty(), Optional.empty(), Collections.emptyMap());
+        Service service = serviceCreator.doCreate(Collections.emptyList(), Collections.emptyMap());
 
         verify(mockedServiceDao, never()).checkIfGatewayAccountsUsed(anyList());
         verify(mockedServiceDao, times(1)).persist(persistedServiceEntity.capture());
@@ -76,7 +74,7 @@ public class ServiceCreatorTest {
 
     @Test
     public void shouldSuccess_whenProvidedWith_onlyAValidName() {
-        Service service = serviceCreator.doCreate(Optional.of(EN_SERVICE_NAME), Optional.empty(), Collections.emptyMap());
+        Service service = serviceCreator.doCreate(Collections.emptyList(), Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME));
 
         verify(mockedServiceDao, never()).checkIfGatewayAccountsUsed(anyList());
         verify(mockedServiceDao, times(1)).persist(persistedServiceEntity.capture());
@@ -90,9 +88,10 @@ public class ServiceCreatorTest {
 
     @Test
     public void shouldSuccess_whenProvidedWith_multipleValidNames_andNoGatewayAccountIds() {
-        Map<SupportedLanguage, String> serviceNameVariants = new HashMap<>();
-        serviceNameVariants.put(SupportedLanguage.WELSH, CY_SERVICE_NAME);
-        Service service = serviceCreator.doCreate(Optional.of(EN_SERVICE_NAME), Optional.empty(), serviceNameVariants);
+        Map<SupportedLanguage, String> serviceNames = new HashMap<>();
+        serviceNames.put(SupportedLanguage.ENGLISH, EN_SERVICE_NAME);
+        serviceNames.put(SupportedLanguage.WELSH, CY_SERVICE_NAME);
+        Service service = serviceCreator.doCreate(Collections.emptyList(), serviceNames);
 
         verify(mockedServiceDao, never()).checkIfGatewayAccountsUsed(anyList());
         verify(mockedServiceDao, times(1)).persist(persistedServiceEntity.capture());
@@ -110,7 +109,7 @@ public class ServiceCreatorTest {
     public void shouldSuccess_whenProvidedWith_unassignedGatewayId() {
         String gatewayAccountId_2 = "gatewayAccountId_2";
         String gatewayAccountId_1 = "gatewayAccountId_1";
-        Service service = serviceCreator.doCreate(Optional.empty(), Optional.of(asList(gatewayAccountId_1, gatewayAccountId_2)), Collections.emptyMap());
+        Service service = serviceCreator.doCreate(List.of(gatewayAccountId_1, gatewayAccountId_2), Collections.emptyMap());
 
         verify(mockedServiceDao, times(1)).checkIfGatewayAccountsUsed(anyList());
         verify(mockedServiceDao, times(1)).persist(persistedServiceEntity.capture());
@@ -135,7 +134,7 @@ public class ServiceCreatorTest {
     public void shouldSuccess_whenProvidedWith_validName_AndUnassignedGatewayId() {
         String gatewayAccountId_2 = "gatewayAccountId_2";
         String gatewayAccountId_1 = "gatewayAccountId_1";
-        Service service = serviceCreator.doCreate(Optional.of(EN_SERVICE_NAME), Optional.of(asList(gatewayAccountId_1, gatewayAccountId_2)), Collections.emptyMap());
+        Service service = serviceCreator.doCreate(List.of(gatewayAccountId_1, gatewayAccountId_2), Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME));
 
         verify(mockedServiceDao, times(1)).checkIfGatewayAccountsUsed(anyList());
         verify(mockedServiceDao, times(1)).persist(persistedServiceEntity.capture());
@@ -153,9 +152,9 @@ public class ServiceCreatorTest {
 
     @Test(expected = WebApplicationException.class)
     public void shouldFail_whenProvidedAConflictingGatewayID() {
-        List<String> gatewayAccountsIds = Collections.singletonList("3");
+        List<String> gatewayAccountsIds = List.of("3");
         when(mockedServiceDao.checkIfGatewayAccountsUsed(gatewayAccountsIds)).thenReturn(true);
-        serviceCreator.doCreate(Optional.of(EN_SERVICE_NAME), Optional.of(gatewayAccountsIds), Collections.emptyMap());
+        serviceCreator.doCreate(gatewayAccountsIds, Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME));
     }
 
     private void assertEnServiceNameMap(Service service, String serviceName) {

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceCreateTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceCreateTest.java
@@ -12,7 +12,6 @@ import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.adminusers.model.Service;
-import uk.gov.pay.adminusers.model.ServiceName;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
@@ -36,7 +35,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -102,8 +100,8 @@ public class ServiceResourceCreateTest extends ServiceResourceBaseTest {
 
     @Test
     public void shouldSuccess_whenCreateAServiceWithoutParameters() {
-        Service service = buildService(Optional.empty(), Optional.empty(), Collections.emptyMap());
-        given(mockedServiceCreator.doCreate(Optional.empty(), Optional.empty(), Collections.emptyMap()))
+        Service service = buildService(Collections.emptyList(), Collections.emptyMap());
+        given(mockedServiceCreator.doCreate(Collections.emptyList(), Collections.emptyMap()))
                 .willReturn(service);
         Response response = resources.target(SERVICES_RESOURCE)
                 .request(MediaType.APPLICATION_JSON)
@@ -125,11 +123,10 @@ public class ServiceResourceCreateTest extends ServiceResourceBaseTest {
 
     @Test
     public void shouldSuccess_whenCreateAServiceWithNameOnly() {
+        PAYLOAD_MAP.put("service_name", Map.of(SupportedLanguage.ENGLISH.toString(), EN_SERVICE_NAME));
 
-        PAYLOAD_MAP.put(FIELD_NAME, EN_SERVICE_NAME);
-
-        Service service = buildService(Optional.of(EN_SERVICE_NAME), Optional.empty(), Collections.emptyMap());
-        given(mockedServiceCreator.doCreate(Optional.of(EN_SERVICE_NAME), Optional.empty(), Collections.emptyMap()))
+        Service service = buildService(Collections.emptyList(), Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME));
+        given(mockedServiceCreator.doCreate(Collections.emptyList(), Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME)))
                 .willReturn(service);
         Response response = resources.target(SERVICES_RESOURCE)
                 .request(MediaType.APPLICATION_JSON)
@@ -151,8 +148,8 @@ public class ServiceResourceCreateTest extends ServiceResourceBaseTest {
     public void shouldSuccess_whenCreateAServiceWithEnglishNameOnly() {
         PAYLOAD_MAP.put("service_name", Map.of(SupportedLanguage.ENGLISH.toString(), EN_SERVICE_NAME));
 
-        Service service = buildService(Optional.empty(), Optional.empty(), Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME));
-        given(mockedServiceCreator.doCreate(Optional.empty(), Optional.empty(), Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME)))
+        Service service = buildService(Collections.emptyList(), Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME));
+        given(mockedServiceCreator.doCreate(Collections.emptyList(), Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME)))
                 .willReturn(service);
         Response response = resources.target(SERVICES_RESOURCE)
                 .request(MediaType.APPLICATION_JSON)
@@ -172,13 +169,13 @@ public class ServiceResourceCreateTest extends ServiceResourceBaseTest {
 
     @Test
     public void shouldSuccess_whenCreateAServiceWithName_andGatewayAccountIds() {
-        PAYLOAD_MAP.put(FIELD_NAME, EN_SERVICE_NAME);
+        PAYLOAD_MAP.put("service_name", Map.of(SupportedLanguage.ENGLISH.toString(), EN_SERVICE_NAME));
         String anotherGatewayAccountId = "another-gateway-account-id";
         List<String> gatewayAccounts = Arrays.asList(GATEWAY_ACCOUNT_ID, anotherGatewayAccountId);
         PAYLOAD_MAP.put(FIELD_GATEWAY_ACCOUNT_IDS, gatewayAccounts);
 
-        Service service = buildService(Optional.of(EN_SERVICE_NAME), Optional.of(gatewayAccounts), Collections.emptyMap());
-        given(mockedServiceCreator.doCreate(Optional.of(EN_SERVICE_NAME), Optional.of(gatewayAccounts), Collections.emptyMap()))
+        Service service = buildService(gatewayAccounts, Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME));
+        given(mockedServiceCreator.doCreate(gatewayAccounts, Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME)))
                 .willReturn(service);
 
         Response response = resources.target(SERVICES_RESOURCE)
@@ -200,11 +197,11 @@ public class ServiceResourceCreateTest extends ServiceResourceBaseTest {
     public void shouldSuccess_whenCreateAServiceWithEnglishName_andGatewayAccountIds() {
         PAYLOAD_MAP.put("service_name", Map.of(SupportedLanguage.ENGLISH.toString(), EN_SERVICE_NAME));
         String anotherGatewayAccountId = "another-gateway-account-id";
-        List<String> gatewayAccounts = Arrays.asList(GATEWAY_ACCOUNT_ID, anotherGatewayAccountId);
+        List<String> gatewayAccounts = List.of(GATEWAY_ACCOUNT_ID, anotherGatewayAccountId);
         PAYLOAD_MAP.put(FIELD_GATEWAY_ACCOUNT_IDS, gatewayAccounts);
 
-        Service service = buildService(Optional.empty(), Optional.of(gatewayAccounts), Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME));
-        given(mockedServiceCreator.doCreate(Optional.empty(), Optional.of(gatewayAccounts), Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME)))
+        Service service = buildService(gatewayAccounts, Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME));
+        given(mockedServiceCreator.doCreate(gatewayAccounts, Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME)))
                 .willReturn(service);
 
         Response response = resources.target(SERVICES_RESOURCE)
@@ -226,15 +223,15 @@ public class ServiceResourceCreateTest extends ServiceResourceBaseTest {
     public void shouldSuccess_whenCreateAServiceWithName_andGatewayAccountIds_andServiceNameVariants_englishAndCymru() {
         PAYLOAD_MAP.put(FIELD_NAME, EN_SERVICE_NAME);
         String anotherGatewayAccountId = "another-gateway-account-id";
-        List<String> gatewayAccounts = Arrays.asList(GATEWAY_ACCOUNT_ID, anotherGatewayAccountId);
+        List<String> gatewayAccounts = List.of(GATEWAY_ACCOUNT_ID, anotherGatewayAccountId);
         PAYLOAD_MAP.put(FIELD_GATEWAY_ACCOUNT_IDS, gatewayAccounts);
         PAYLOAD_MAP.put("service_name",
                 Map.of(SupportedLanguage.ENGLISH.toString(), EN_SERVICE_NAME, SupportedLanguage.WELSH.toString(), CY_SERVICE_NAME));
 
         Map<SupportedLanguage, String> serviceName = Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME, SupportedLanguage.WELSH, CY_SERVICE_NAME);
 
-        Service service = buildService(Optional.of(EN_SERVICE_NAME), Optional.of(gatewayAccounts), serviceName);
-        given(mockedServiceCreator.doCreate(Optional.of(EN_SERVICE_NAME), Optional.of(gatewayAccounts), serviceName))
+        Service service = buildService(gatewayAccounts, serviceName);
+        given(mockedServiceCreator.doCreate(gatewayAccounts, serviceName))
                 .willReturn(service);
 
         Response response = resources.target(SERVICES_RESOURCE)
@@ -274,18 +271,10 @@ public class ServiceResourceCreateTest extends ServiceResourceBaseTest {
         Mockito.verify(mockedServiceDao, never()).persist(serviceEntityArgumentCaptor.capture());
     }
 
-    private Service buildService(Optional<String> maybeName,
-                                 Optional<List<String>> maybeAccountIds,
-                                 Map<SupportedLanguage, String> serviceNameVariants) {
-        Service service = maybeName.map(ServiceName::new).map(name -> Service.from(name))
-                .orElseGet(Service::from);
-        ServiceEntity serviceEntity = ServiceEntity.from(service);
-        serviceEntity.addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.ENGLISH, service.getName()));
-        serviceNameVariants.forEach((k, v) -> serviceEntity.addOrUpdateServiceName(ServiceNameEntity.from(k, v)));
-        if (maybeAccountIds.isPresent()) {
-            List<String> gatewayAccountsIds = maybeAccountIds.get();
-            serviceEntity.addGatewayAccountIds(gatewayAccountsIds.toArray(new String[0]));
-        }
+    private Service buildService(List<String> gatewayAccountIds, Map<SupportedLanguage, String> serviceNames) {
+        ServiceEntity serviceEntity = ServiceEntity.from(Service.from());
+        serviceNames.forEach((language, name) -> serviceEntity.addOrUpdateServiceName(ServiceNameEntity.from(language, name)));
+        serviceEntity.addGatewayAccountIds(gatewayAccountIds.toArray(new String[0]));
         return linksBuilder.decorate(serviceEntity.toService());
     }
 }


### PR DESCRIPTION
When processing a request to create a new service, ignore the `"name"` property and only use the names from the `"service_name"` property.

Only selfservice creates services and it no longer sends the `"name"` property (but it does always include `"service_name"` with at least an `"en"` property).

Since this involves changes to the `ServiceResource` and `ServiceCreator`, make them not use an `Optional<List<String>>` for the gateway account IDs because optionals of lists are cursed.