### PR TITLE
PP-5139 Add connected go-cardless account permission

### DIFF
--- a/src/main/resources/migrations/00057_add_link_gocardless_account_permission.sql
+++ b/src/main/resources/migrations/00057_add_link_gocardless_account_permission.sql
@@ -1,0 +1,11 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:connected_gocardless_account_update_permission
+INSERT INTO permissions(id, name, description) VALUES (45, 'connected-gocardless-account:update', 'Update Connected Go Cardless Account');
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'super-admin'), (SELECT id FROM permissions WHERE name = 'connected-gocardless-account:update'), NOW(), NOW());
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'admin'), (SELECT id FROM permissions WHERE name = 'connected-gocardless-account:update'), NOW(), NOW());
+
+--changeset uk.gov.pay:connected_gocardless_account_read_permission
+INSERT INTO  permissions(id, name, description) VALUES (46, 'connected-gocardless-account:read', 'View Connected Go Cardless Account');
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'super-admin'), (SELECT id FROM permissions WHERE name = 'connected-gocardless-account:read'), NOW(), NOW());
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'admin'), (SELECT id FROM permissions WHERE name = 'connected-gocardless-account:read'), NOW(), NOW());

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationIT.java
@@ -50,7 +50,7 @@ public class UserResourceAuthenticationIT extends IntegrationTest {
                 .body("disabled", is(false))
                 .body("_links", hasSize(1))
                 .body("service_roles[0].role.name", is("admin"))
-                .body("service_roles[0].role.permissions", hasSize(43));
+                .body("service_roles[0].role.permissions", hasSize(45));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateIT.java
@@ -111,7 +111,7 @@ public class UserResourceCreateIT extends IntegrationTest {
                 .body("disabled", is(false))
                 .body("service_roles[0].role.name", is("admin"))
                 .body("service_roles[0].role.description", is("Administrator"))
-                .body("service_roles[0].role.permissions", hasSize(43));
+                .body("service_roles[0].role.permissions", hasSize(45));
 
         response
                 .body("_links", hasSize(1))


### PR DESCRIPTION
A permission didn't exist for connecting a direct debit account to a go cardless account in selfservice
