### PR TITLE
REP-137: Remove redundant environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,6 @@ The GOV.UK Pay Admin Users Module in Java (Dropwizard)
 | `PORT`                                                         | The port number to listen for requests on. Defaults to `8080`. |
 | `RUN_APP`                                                      | Set to `true` to run the application. Defaults to `true`. |
 | `RUN_MIGRATION`                                                | Set to `true` to run a database migration. Defaults to `false`. |
-| `SELFSERVICE_FORGOTTEN_PASSWORD_URL`                           | The URL to the password reset page of the admin portal. Defaults to `https://selfservice.pymnt.localdomain/reset-password`. |
-| `SELFSERVICE_INVITES_URL`                                      | The URL to the invitation page of the admin portal. Defaults to `https://selfservice.pymnt.localdomain/invites`. |
-| `SELFSERVICE_LOGIN_URL`                                        | The URL to the login page of the admin portal. Defaults to `https://selfservice.pymnt.localdomain/login`. |
-| `SELFSERVICE_SERVICES_URL`                                     | The URL to the services page of the admin portal. Defaults to `https://selfservice.pymnt.localdomain/services`. |
 | `SELFSERVICE_URL`                                              | The URL to the admin portal. Defaults to `https://selfservice.pymnt.localdomain`. |
 | `SUPPORT_URL`                                                  | The URL users can visit to get support. Defaults to `https://frontend.pymnt.localdomain/contact/`. |
  

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -83,11 +83,11 @@ graphitePort: ${METRICS_PORT:-8092}
 
 links:
   selfserviceUrl: ${SELFSERVICE_URL:-https://selfservice.pymnt.localdomain}
-  selfserviceInvitesUrl: ${SELFSERVICE_INVITES_URL:-https://selfservice.pymnt.localdomain/invites}
-  selfserviceLoginUrl: ${SELFSERVICE_LOGIN_URL:-https://selfservice.pymnt.localdomain/login}
-  selfserviceForgottenPasswordUrl: ${SELFSERVICE_FORGOTTEN_PASSWORD_URL:-https://selfservice.pymnt.localdomain/reset-password}
+  selfserviceInvitesUrl: ${SELFSERVICE_URL:-https://selfservice.pymnt.localdomain}/invites
+  selfserviceLoginUrl: ${SELFSERVICE_URL:-https://selfservice.pymnt.localdomain}/login
+  selfserviceForgottenPasswordUrl: ${SELFSERVICE_URL:-https://selfservice.pymnt.localdomain}/reset-password
+  selfserviceServicesUrl: ${SELFSERVICE_URL:-https://selfservice.pymnt.localdomain}/services
   supportUrl: ${SUPPORT_URL:-https://frontend.pymnt.localdomain/contact/}
-  selfserviceServicesUrl: ${SELFSERVICE_SERVICES_URL:-https://selfservice.pymnt.localdomain/services}
 
 baseUrl: ${BASE_URL:-http://localhost:8080}
 loginAttemptCap: ${LOGIN_ATTEMPT_CAP:-10}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -83,11 +83,11 @@ graphitePort: ${METRICS_PORT:-8092}
 
 links:
   selfserviceUrl: ${SELFSERVICE_URL:-https://selfservice.pymnt.localdomain}
-  selfserviceInvitesUrl: ${SELFSERVICE_INVITES_URL:-https://selfservice.pymnt.localdomain/invites}
-  selfserviceLoginUrl: ${SELFSERVICE_LOGIN_URL:-https://selfservice.pymnt.localdomain/login}
-  selfserviceForgottenPasswordUrl: ${SELFSERVICE_FORGOTTEN_PASSWORD_URL:-https://selfservice.pymnt.localdomain/reset-password}
+  selfserviceInvitesUrl: ${SELFSERVICE_URL:-https://selfservice.pymnt.localdomain}/invites
+  selfserviceLoginUrl: ${SELFSERVICE_URL:-https://selfservice.pymnt.localdomain}/login
+  selfserviceForgottenPasswordUrl: ${SELFSERVICE_URL:-https://selfservice.pymnt.localdomain}/reset-password
+  selfserviceServicesUrl: ${SELFSERVICE_URL:-https://selfservice.pymnt.localdomain}/services
   supportUrl: ${SUPPORT_URL:-https://frontend.pymnt.localdomain/contact/}
-  selfserviceServicesUrl: ${SELFSERVICE_SERVICES_URL:-https://selfservice.pymnt.localdomain/services}
 
 baseUrl: ${BASE_URL:-http://localhost:8080}
 loginAttemptCap: ${LOGIN_ATTEMPT_CAP:-10}


### PR DESCRIPTION
There's no need to have separate environment variables for every single
selfservice URL as there's nowhere in Pay's codebase that makes use of
this functionality. It would also help with overriding the base
selfservice URL for end-to-end tests and we could remove some extra
environment variables from our Terraform code.


## WHAT YOU DID
Removed `SELFSERVICE_*_URL` environment variables from the app's
YAML config and README.

## How to test
Functionality should be unaffected, so make sure everything works as
usual.

## Code review checklist

### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [x] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition