### PR TITLE
Use runAppE2E to run end to end tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
     stage('Tests') {
       failFast true
       parallel {
-        stage('Card Payment End-to-End Tests') {
+        stage('End-to-End Tests') {
             when {
                 anyOf {
                   branch 'master'
@@ -65,7 +65,7 @@ pipeline {
                 }
             }
             steps {
-                runCardPaymentsE2E("adminusers")
+                runAppE2E("adminusers", "card")
             }
         }
       }


### PR DESCRIPTION
Let's deprecate the run{test}E2E groovy routines and use runAppE2E everywhere