### PR TITLE
Replace guava collections with standard Java mechanisms in tests

### DIFF
--- a/src/test/java/uk/gov/pay/adminusers/fixtures/RoleDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/RoleDbFixture.java
@@ -4,7 +4,8 @@ import uk.gov.pay.adminusers.model.Permission;
 import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.utils.DatabaseTestHelper;
 
-import static com.google.common.collect.Lists.newArrayList;
+import java.util.List;
+
 import static org.apache.commons.lang3.RandomStringUtils.random;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
@@ -41,7 +42,7 @@ public class RoleDbFixture {
         for (Permission permission : permissions) {
             databaseHelper.add(permission);
         }
-        role.setPermissions(newArrayList(permissions));
+        role.setPermissions(List.of(permissions));
         databaseHelper.add(role);
         return role;
     }

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/ServiceDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/ServiceDbFixture.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.adminusers.fixtures;
 
-import com.google.common.collect.ImmutableMap;
 import uk.gov.pay.adminusers.model.GoLiveStage;
 import uk.gov.pay.adminusers.model.MerchantDetails;
 import uk.gov.pay.adminusers.model.Service;
@@ -57,7 +56,7 @@ public class ServiceDbFixture {
     }
     
     public ServiceDbFixture withCustomBranding(String cssUrl, String imageUrl) {
-        this.customBranding = ImmutableMap.of(
+        this.customBranding = Map.of(
                 "css_url", cssUrl,
                 "image_url", imageUrl
         );

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
@@ -10,17 +10,17 @@ import uk.gov.pay.adminusers.model.ServiceRole;
 import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.utils.DatabaseTestHelper;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 
 public class UserDbFixture {
 
     private final DatabaseTestHelper databaseTestHelper;
-    private List<Pair<Service, Role>> serviceRolePairs = newArrayList();
+    private List<Pair<Service, Role>> serviceRolePairs = new ArrayList<>();
     private String externalId = randomUuid();
     private String username = randomUuid();
     private String otpKey = RandomStringUtils.randomAlphabetic(10);

--- a/src/test/java/uk/gov/pay/adminusers/infra/DropwizardAppWithPostgresRule.java
+++ b/src/test/java/uk/gov/pay/adminusers/infra/DropwizardAppWithPostgresRule.java
@@ -26,7 +26,6 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Properties;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 
@@ -48,10 +47,10 @@ public class DropwizardAppWithPostgresRule implements TestRule {
     public DropwizardAppWithPostgresRule(String configPath, ConfigOverride... configOverrides) {
         configFilePath = resourceFilePath(configPath);
         postgres = new PostgresDockerRule();
-        List<ConfigOverride> cfgOverrideList = newArrayList(configOverrides);
-        cfgOverrideList.add(config("database.url", postgres.getConnectionUrl()));
-        cfgOverrideList.add(config("database.user", postgres.getUsername()));
-        cfgOverrideList.add(config("database.password", postgres.getPassword()));
+        List<ConfigOverride> cfgOverrideList = List.of(
+                config("database.url", postgres.getConnectionUrl()),
+                config("database.user", postgres.getUsername()),
+                config("database.password", postgres.getPassword()));
 
         app = new DropwizardAppRule<>(
                 AdminUsersApp.class,

--- a/src/test/java/uk/gov/pay/adminusers/model/ServiceUpdateRequestTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/ServiceUpdateRequestTest.java
@@ -3,7 +3,6 @@ package uk.gov.pay.adminusers.model;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,7 +26,7 @@ public class ServiceUpdateRequestTest {
 
     @Test
     public void shouldTransformToObjectCorrectly() throws IOException {
-        Map<String, Object> payload = ImmutableMap.of("path", "custom_branding", "op", "replace", "value", ImmutableMap.of("image_url", "image url", "css_url", "css url"));
+        Map<String, Object> payload = Map.of("path", "custom_branding", "op", "replace", "value", Map.of("image_url", "image url", "css_url", "css url"));
         String content = objectMapper.writeValueAsString(payload);
         JsonNode jsonNode = objectMapper.readTree(content);
         ServiceUpdateRequest request = ServiceUpdateRequest.from(jsonNode);

--- a/src/test/java/uk/gov/pay/adminusers/model/UpdateMerchantDetailsRequestTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/UpdateMerchantDetailsRequestTest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.adminusers.model;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 
 import java.util.Map;
@@ -24,13 +23,12 @@ public class UpdateMerchantDetailsRequestTest {
 
     @Test
     public void shouldConstructMerchantDetails_fromMinimalValidJson() {
-        Map<String, Object> payload = ImmutableMap.<String, Object>builder()
-                .put("name", name)
-                .put("address_line1", addressLine1)
-                .put("address_city", addressCity)
-                .put("address_country", addressCountry)
-                .put("address_postcode", addressPostcode)
-                .build();
+        Map<String, Object> payload = Map.of(
+                "name", name,
+                "address_line1", addressLine1,
+                "address_city", addressCity,
+                "address_country", addressCountry,
+                "address_postcode", addressPostcode);
         JsonNode jsonNode = new ObjectMapper().valueToTree(payload);
         UpdateMerchantDetailsRequest updateMerchantDetailsRequest = UpdateMerchantDetailsRequest.from(jsonNode);
         assertThat(updateMerchantDetailsRequest.getName(), is(name));
@@ -43,16 +41,15 @@ public class UpdateMerchantDetailsRequestTest {
 
     @Test
     public void shouldConstructMerchantDetails_fromCompleteValidJson() {
-        Map<String, Object> payload = ImmutableMap.<String, Object>builder()
-                .put("name", name)
-                .put("telephone_number", telephoneNumber)
-                .put("address_line1", addressLine1)
-                .put("address_line2", addressLine2)
-                .put("address_city", addressCity)
-                .put("address_country", addressCountry)
-                .put("address_postcode", addressPostcode)
-                .put("email", email)
-                .build();
+        Map<String, Object> payload = Map.of(
+                "name", name,
+                "telephone_number", telephoneNumber,
+                "address_line1", addressLine1,
+                "address_line2", addressLine2,
+                "address_city", addressCity,
+                "address_country", addressCountry,
+                "address_postcode", addressPostcode,
+                "email", email);
         JsonNode jsonNode = new ObjectMapper().valueToTree(payload);
         UpdateMerchantDetailsRequest updateMerchantDetailsRequest = UpdateMerchantDetailsRequest.from(jsonNode);
         assertThat(updateMerchantDetailsRequest.getName(), is(name));

--- a/src/test/java/uk/gov/pay/adminusers/model/UserEntityTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/UserEntityTest.java
@@ -8,7 +8,8 @@ import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 
-import static com.google.common.collect.Lists.newArrayList;
+import java.util.List;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -47,9 +48,9 @@ public class UserEntityTest {
     public void creatingAUser_shouldSetGatewayAccountAndRole_whenServiceRoleIsSet() {
         UserEntity userEntity = new UserEntity();
         String gatewayAccountId = "1";
-        ServiceEntity service = new ServiceEntity(newArrayList(gatewayAccountId));
+        ServiceEntity service = new ServiceEntity(List.of(gatewayAccountId));
         Role role = role(1, "role", "hey");
-        role.setPermissions(newArrayList(permission(1, "perm1", "perm1 desc"), permission(2, "perm2", "perm2 desc")));
+        role.setPermissions(List.of(permission(1, "perm1", "perm1 desc"), permission(2, "perm2", "perm2 desc")));
         RoleEntity roleEntity = new RoleEntity(role);
         ServiceRoleEntity serviceRole = new ServiceRoleEntity(service, roleEntity);
 

--- a/src/test/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntityBuilder.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntityBuilder.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.adminusers.persistence.entity;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang.math.RandomUtils;
 import uk.gov.pay.adminusers.app.util.RandomIdGenerator;
 import uk.gov.pay.adminusers.model.GoLiveStage;
@@ -19,7 +18,7 @@ public final class ServiceEntityBuilder {
     private String externalId = RandomIdGenerator.randomUuid();
     private String name = Service.DEFAULT_NAME_VALUE;
     private MerchantDetailsEntity merchantDetailsEntity = MerchantDetailsEntityBuilder.aMerchantDetailsEntity().build();
-    private Map<String, Object> customBranding = ImmutableMap.of("image_url", "image url", "css_url", "css url");
+    private Map<String, Object> customBranding = Map.of("image_url", "image url", "css_url", "css url");
     private List<GatewayAccountIdEntity> gatewayAccountIds = new ArrayList<>();
     private Set<ServiceNameEntity> serviceName = new HashSet<>();
     private boolean redirectToServiceImmediatelyOnTerminalState = false;

--- a/src/test/java/uk/gov/pay/adminusers/resources/EmailRequestParserTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/EmailRequestParserTest.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,11 +26,11 @@ public class EmailRequestParserTest {
 
     @Test
     public void shouldCreateAnEmailRequestForAValidPayload() throws InvalidEmailRequestException {
-        Map<String, Object> body = ImmutableMap.of(
+        Map<String, Object> body = Map.of(
           "address", "aaa@bbb.test",
           "gateway_account_external_id", "DIRECT_DEBIT:23847roidfghdkkj",
           "template", "MANDATE_CANCELLED",
-          "personalisation", ImmutableMap.of(
+          "personalisation", Map.of(
                   "field 1", "theValueOfField1",
                   "field 2", "theValueOfField2"
                 )
@@ -41,7 +40,7 @@ public class EmailRequestParserTest {
         assertThat(emailRequest.getEmailAddress(), is("aaa@bbb.test"));
         assertThat(emailRequest.getGatewayAccountId(), is("DIRECT_DEBIT:23847roidfghdkkj"));
         assertThat(emailRequest.getTemplate(), is(EmailTemplate.MANDATE_CANCELLED));
-        assertThat(emailRequest.getPersonalisation(), is(ImmutableMap.of(
+        assertThat(emailRequest.getPersonalisation(), is(Map.of(
                 "field 1", "theValueOfField1",
                 "field 2", "theValueOfField2"
         )));
@@ -49,9 +48,9 @@ public class EmailRequestParserTest {
 
     @Test
     public void shouldThrowAnExceptionForAnInvalidPayload() throws InvalidEmailRequestException {
-        Map<String, Object> body = ImmutableMap.of(
+        Map<String, Object> body = Map.of(
                 "template", "MANDATE_CANCELLED",
-                "personalisation", ImmutableMap.of(
+                "personalisation", Map.of(
                         "field 1", "theValueOfField1",
                         "field 2", "theValueOfField2"
                 )

--- a/src/test/java/uk/gov/pay/adminusers/resources/EmailResourceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/EmailResourceIT.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import uk.gov.pay.adminusers.fixtures.ServiceDbFixture;
 import uk.gov.pay.adminusers.model.MerchantDetails;
@@ -14,11 +13,11 @@ public class EmailResourceIT extends IntegrationTest {
 
     private ObjectMapper objectMapper = new ObjectMapper();
     private static final String GATEWAY_ACCOUNT_ID = "DIRECT_DEBIT:mdshfsehdtfsdtjg";
-    private Map<String, Object> validEmailRequest = ImmutableMap.of(
+    private Map<String, Object> validEmailRequest = Map.of(
             "address", "cake@directdebitteam.test",
             "gateway_account_external_id", GATEWAY_ACCOUNT_ID,
             "template", "MANDATE_CANCELLED",
-            "personalisation", ImmutableMap.of(
+            "personalisation", Map.of(
                     "mandate reference", "mandatereference",
                     "org name", "cake service"
             )

--- a/src/test/java/uk/gov/pay/adminusers/resources/ForgottenPasswordResourceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ForgottenPasswordResourceIT.java
@@ -2,7 +2,8 @@ package uk.gov.pay.adminusers.resources;
 
 import org.junit.Test;
 
-import static com.google.common.collect.ImmutableMap.of;
+import java.util.Map;
+
 import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
@@ -25,7 +26,7 @@ public class ForgottenPasswordResourceIT extends IntegrationTest {
 
         givenSetup()
                 .when()
-                .body(mapper.writeValueAsString(of("username", username)))
+                .body(mapper.writeValueAsString(Map.of("username", username)))
                 .contentType(JSON)
                 .accept(JSON)
                 .post(FORGOTTEN_PASSWORDS_RESOURCE_URL)
@@ -38,7 +39,7 @@ public class ForgottenPasswordResourceIT extends IntegrationTest {
 
         givenSetup()
                 .when()
-                .body(mapper.writeValueAsString(of("username", "non-existent-user")))
+                .body(mapper.writeValueAsString(Map.of("username", "non-existent-user")))
                 .contentType(JSON)
                 .accept(JSON)
                 .post(FORGOTTEN_PASSWORDS_RESOURCE_URL)

--- a/src/test/java/uk/gov/pay/adminusers/resources/GovUkPayAgreementRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/GovUkPayAgreementRequestValidatorTest.java
@@ -2,12 +2,12 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.adminusers.utils.Errors;
 import uk.gov.pay.adminusers.validations.RequestValidations;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -25,14 +25,14 @@ public class GovUkPayAgreementRequestValidatorTest {
     
     @Test
     public void shouldPassValidation() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("user_external_id", "abcde1234"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_external_id", "abcde1234"));
         Optional<Errors> optionalErrors = validator.validateCreateRequest(payload);
         assertThat(optionalErrors.isPresent(), is(false));
     }
     
     @Test
     public void shouldFailValidation_whenUserExternalIdIsEmpty() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("user_external_id", ""));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_external_id", ""));
         Optional<Errors> optionalErrors = validator.validateCreateRequest(payload);
         assertThat(optionalErrors.isPresent(), is(true));
         assertThat(optionalErrors.get().getErrors().size(), is(1));
@@ -41,7 +41,7 @@ public class GovUkPayAgreementRequestValidatorTest {
     
     @Test
     public void shouldFailValidation_whenUserExternalIdIsNotString() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("user_external_id", true));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_external_id", true));
         Optional<Errors> optionalErrors = validator.validateCreateRequest(payload);
         assertThat(optionalErrors.isPresent(), is(true));
         assertThat(optionalErrors.get().getErrors().size(), is(1));
@@ -50,7 +50,7 @@ public class GovUkPayAgreementRequestValidatorTest {
     
     @Test
     public void shouldFailValidation_whenUserExternalIdIsMissing() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("luser_external_id", "abcde1234"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("luser_external_id", "abcde1234"));
         Optional<Errors> optionalErrors = validator.validateCreateRequest(payload);
         assertThat(optionalErrors.isPresent(), is(true));
         assertThat(optionalErrors.get().getErrors().size(), is(1));

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateServiceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateServiceIT.java
@@ -1,10 +1,11 @@
 package uk.gov.pay.adminusers.resources;
 
 
-import com.google.common.collect.ImmutableMap;
 import io.restassured.http.ContentType;
 import org.junit.Test;
 import uk.gov.pay.adminusers.fixtures.UserDbFixture;
+
+import java.util.Map;
 
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
@@ -24,7 +25,7 @@ public class InviteResourceCreateServiceIT extends IntegrationTest {
     public void shouldSuccess_WhenAllRequiredFieldsAreProvidedAndValid() throws Exception {
         String email = "example@example.gov.uk";
         String telephoneNumber = "01134960000";
-        ImmutableMap<String, String> payload = ImmutableMap.of("telephone_number", telephoneNumber, "email", email, "password", "plain_text_password");
+        Map<String, String> payload = Map.of("telephone_number", telephoneNumber, "email", email, "password", "plain_text_password");
 
         givenSetup()
                 .when()
@@ -44,7 +45,7 @@ public class InviteResourceCreateServiceIT extends IntegrationTest {
     @Test
     public void shouldFail_WhenMandatoryFieldsAreMissing() throws Exception {
         String telephoneNumber = "07700900000";
-        ImmutableMap<String, String> payload = ImmutableMap.of("telephone_number", telephoneNumber, "password", "plain_text_password");
+        Map<String, String> payload = Map.of("telephone_number", telephoneNumber, "password", "plain_text_password");
 
         givenSetup()
                 .when()
@@ -61,7 +62,7 @@ public class InviteResourceCreateServiceIT extends IntegrationTest {
     public void shouldFail_WhenEmailIsNotPublicSectorDomain() throws Exception {
         String email = "example@example.com";
         String telephoneNumber = "07700900000";
-        ImmutableMap<String, String> payload = ImmutableMap.of("telephone_number", telephoneNumber, "email", email, "password", "plain_text_password");
+        Map<String, String> payload = Map.of("telephone_number", telephoneNumber, "email", email, "password", "plain_text_password");
 
         givenSetup()
                 .when()
@@ -82,7 +83,7 @@ public class InviteResourceCreateServiceIT extends IntegrationTest {
         UserDbFixture.userDbFixture(databaseHelper).withUsername(username).withEmail(email).insertUser();
 
         String telephoneNumber = "01134960000";
-        ImmutableMap<String, String> payload = ImmutableMap.of("telephone_number", telephoneNumber, "email", email, "password", "plain_text_password");
+        Map<String, String> payload = Map.of("telephone_number", telephoneNumber, "email", email, "password", "plain_text_password");
 
         givenSetup()
                 .when()

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateUserIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateUserIT.java
@@ -1,12 +1,13 @@
 package uk.gov.pay.adminusers.resources;
 
-import com.google.common.collect.ImmutableMap;
 import io.restassured.http.ContentType;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.ServiceName;
 import uk.gov.pay.adminusers.model.User;
+
+import java.util.Map;
 
 import static java.lang.String.format;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
@@ -59,12 +60,11 @@ public class InviteResourceCreateUserIT extends IntegrationTest {
 
         String email = randomAlphanumeric(5) + "-invite@example.com";
 
-        ImmutableMap<Object, Object> invitationRequest = ImmutableMap.builder()
-                .put("sender", senderExternalId)
-                .put("email", email)
-                .put("role_name", roleAdminName)
-                .put("service_external_id", service.getExternalId())
-                .build();
+        Map<Object, Object> invitationRequest = Map.of(
+                "sender", senderExternalId,
+                "email", email,
+                "role_name", roleAdminName,
+                "service_external_id", service.getExternalId());
 
         givenSetup()
                 .when()
@@ -92,12 +92,11 @@ public class InviteResourceCreateUserIT extends IntegrationTest {
                 .withServiceExternalId(serviceExternalId)
                 .insertInvite();
 
-        ImmutableMap<Object, Object> invitationRequest = ImmutableMap.builder()
-                .put("sender", senderExternalId)
-                .put("email", existingUserEmail)
-                .put("role_name", roleAdminName)
-                .put("service_external_id", serviceExternalId)
-                .build();
+        Map<Object, Object> invitationRequest = Map.of(
+                "sender", senderExternalId,
+                "email", existingUserEmail,
+                "role_name", roleAdminName,
+                "service_external_id", serviceExternalId);
 
         givenSetup()
                 .when()
@@ -131,12 +130,11 @@ public class InviteResourceCreateUserIT extends IntegrationTest {
                 .insertUser();
 
 
-        ImmutableMap<Object, Object> invitationRequest = ImmutableMap.builder()
-                .put("sender", senderExternalId)
-                .put("email", existingUserEmail)
-                .put("role_name", roleAdminName)
-                .put("service_external_id", serviceExternalId)
-                .build();
+        Map<Object, Object> invitationRequest = Map.of(
+                "sender", senderExternalId,
+                "email", existingUserEmail,
+                "role_name", roleAdminName,
+                "service_external_id", serviceExternalId);
 
         givenSetup()
                 .when()
@@ -154,12 +152,11 @@ public class InviteResourceCreateUserIT extends IntegrationTest {
     public void createInvitation_shouldFail_whenServiceDoesNotExist() throws Exception {
 
         String nonExistentServiceId = "non existant service external id";
-        ImmutableMap<Object, Object> invitationRequest = ImmutableMap.builder()
-                .put("sender", senderExternalId)
-                .put("email", randomAlphanumeric(5) + "-invite@example.com")
-                .put("role_name", roleAdminName)
-                .put("service_external_id", nonExistentServiceId)
-                .build();
+        Map<Object, Object> invitationRequest = Map.of(
+                "sender", senderExternalId,
+                "email", randomAlphanumeric(5) + "-invite@example.com",
+                "role_name", roleAdminName,
+                "service_external_id", nonExistentServiceId);
 
         givenSetup()
                 .when()
@@ -175,12 +172,11 @@ public class InviteResourceCreateUserIT extends IntegrationTest {
     @Test
     public void createInvitation_shouldFail_whenRoleDoesNotExist() throws Exception {
 
-        ImmutableMap<Object, Object> invitationRequest = ImmutableMap.builder()
-                .put("sender", senderExternalId)
-                .put("email", randomAlphanumeric(5) + "-invite@example.com")
-                .put("role_name", "non-existing-role")
-                .put("service_external_id", service.getExternalId())
-                .build();
+        Map<Object, Object> invitationRequest = Map.of(
+                "sender", senderExternalId,
+                "email", randomAlphanumeric(5) + "-invite@example.com",
+                "role_name", "non-existing-role",
+                "service_external_id", service.getExternalId());
 
         givenSetup()
                 .when()
@@ -199,12 +195,11 @@ public class InviteResourceCreateUserIT extends IntegrationTest {
 
         String email = randomAlphanumeric(5) + "-invite@example.com";
 
-        ImmutableMap<Object, Object> invitationRequest = ImmutableMap.builder()
-                .put("sender", "does-not-exist")
-                .put("email", email)
-                .put("role_name", roleAdminName)
-                .put("service_external_id", service.getExternalId())
-                .build();
+        Map<Object, Object> invitationRequest = Map.of(
+                "sender", "does-not-exist",
+                "email", email,
+                "role_name", roleAdminName,
+                "service_external_id", service.getExternalId());
 
         givenSetup()
                 .when()
@@ -227,12 +222,11 @@ public class InviteResourceCreateUserIT extends IntegrationTest {
                 .withEmail(senderEmail)
                 .insertUser().getExternalId();
 
-        ImmutableMap<Object, Object> invitationRequest = ImmutableMap.builder()
-                .put("sender", senderWithNoAdminRole)
-                .put("email", randomUuid() + "-invite@example.com")
-                .put("role_name", roleAdminName)
-                .put("service_external_id", service.getExternalId())
-                .build();
+        Map<Object, Object> invitationRequest = Map.of(
+                "sender", senderWithNoAdminRole,
+                "email", randomUuid() + "-invite@example.com",
+                "role_name", roleAdminName,
+                "service_external_id", service.getExternalId());
 
         givenSetup()
                 .when()
@@ -258,12 +252,11 @@ public class InviteResourceCreateUserIT extends IntegrationTest {
                 .withEmail(senderEmail)
                 .insertUser().getExternalId();
 
-        ImmutableMap<Object, Object> invitationRequest = ImmutableMap.builder()
-                .put("sender", senderExternalId)
-                .put("email", randomUuid() + "-invite@example.com")
-                .put("role_name", roleAdminName)
-                .put("service_external_id", service.getExternalId())
-                .build();
+        Map<Object, Object> invitationRequest = Map.of(
+                "sender", senderExternalId,
+                "email", randomUuid() + "-invite@example.com",
+                "role_name", roleAdminName,
+                "service_external_id", service.getExternalId());
 
         givenSetup()
                 .when()

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGenerateOtpIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGenerateOtpIT.java
@@ -1,11 +1,13 @@
 package uk.gov.pay.adminusers.resources;
 
-import com.google.common.collect.ImmutableMap;
 import io.restassured.http.ContentType;
 import org.junit.Test;
 import uk.gov.pay.adminusers.fixtures.InviteDbFixture;
 
+import java.util.Map;
+
 import static java.lang.String.format;
+import static java.util.Collections.emptyMap;
 import static javax.ws.rs.core.Response.Status.*;
 import static org.apache.commons.lang3.RandomStringUtils.random;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.newId;
@@ -23,10 +25,9 @@ public class InviteResourceGenerateOtpIT extends IntegrationTest {
     @Test
     public void generateOtp_shouldSucceed_forUserInvite_evenWhenTokenIsExpired_sinceItShouldBeValidatedOnGetInvite() throws Exception {
         givenAnExistingUserInvite();
-        ImmutableMap<Object, Object> invitationRequest = ImmutableMap.builder()
-                .put("telephone_number", TELEPHONE_NUMBER)
-                .put("password", PASSWORD)
-                .build();
+        Map<Object, Object> invitationRequest = Map.of(
+                "telephone_number", TELEPHONE_NUMBER,
+                "password", PASSWORD);
 
         givenSetup()
                 .when()
@@ -39,10 +40,9 @@ public class InviteResourceGenerateOtpIT extends IntegrationTest {
 
     @Test
     public void generateOtp_should_FailforUserInvite_whenInviteDoesNotExist() throws Exception {
-        ImmutableMap<Object, Object> invitationRequest = ImmutableMap.builder()
-                .put("telephone_number", TELEPHONE_NUMBER)
-                .put("password", PASSWORD)
-                .build();
+        Map<Object, Object> invitationRequest = Map.of(
+                "telephone_number", TELEPHONE_NUMBER,
+                "password", PASSWORD);
 
         givenSetup()
                 .when()
@@ -56,8 +56,7 @@ public class InviteResourceGenerateOtpIT extends IntegrationTest {
     @Test
     public void generateOtp_shouldFail_forUserInvite_whenAllMandatoryFieldsAreMissing() throws Exception {
         givenAnExistingUserInvite();
-        ImmutableMap<Object, Object> invitationRequest = ImmutableMap.builder()
-                .build();
+        Map<Object, Object> invitationRequest = emptyMap();
 
         givenSetup()
                 .when()

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpIT.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.adminusers.resources;
 
-import com.google.common.collect.ImmutableMap;
 import com.warrenstrange.googleauth.GoogleAuthenticator;
-import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,6 +11,7 @@ import java.util.Map;
 
 import static com.google.common.io.BaseEncoding.base32;
 import static io.restassured.http.ContentType.JSON;
+import static java.util.Collections.emptyMap;
 import static javax.ws.rs.core.Response.Status.*;
 import static org.apache.commons.lang3.RandomStringUtils.random;
 import static org.hamcrest.Matchers.hasSize;
@@ -52,10 +51,9 @@ public class InviteResourceOtpIT extends IntegrationTest {
                 .insertInvite();
 
         // generate valid invitationOtpRequest and execute it
-        ImmutableMap<Object, Object> invitationOtpRequest = ImmutableMap.builder()
-                .put("code", code)
-                .put("otp", PASSCODE)
-                .build();
+        Map<Object, Object> invitationOtpRequest = Map.of(
+                "code", code,
+                "otp", PASSCODE);
 
         assertThat(databaseHelper.findInviteByCode(code).size(), is(1));
 
@@ -102,10 +100,9 @@ public class InviteResourceOtpIT extends IntegrationTest {
     @Test
     public void validateOtp_shouldFail_whenInvalidCode() throws Exception {
 
-        ImmutableMap<Object, Object> invitationOtpRequest = ImmutableMap.builder()
-                .put("code", "non-existent-code")
-                .put("otp", PASSCODE)
-                .build();
+        Map<Object, Object> invitationOtpRequest = Map.of(
+                "code", "non-existent-code",
+                "otp", PASSCODE);
 
         givenSetup()
                 .when()
@@ -128,10 +125,9 @@ public class InviteResourceOtpIT extends IntegrationTest {
                 .insertInvite();
 
         // generate invalid invitationOtpRequest and execute it
-        ImmutableMap<Object, Object> invitationOtpRequest = ImmutableMap.builder()
-                .put("code", code)
-                .put("otp", 123456)
-                .build();
+        Map<Object, Object> invitationOtpRequest = Map.of(
+                "code", code,
+                "otp", 123456);
 
         givenSetup()
                 .when()
@@ -155,10 +151,9 @@ public class InviteResourceOtpIT extends IntegrationTest {
                 .insertInvite();
 
         // generate invalid invitationOtpRequest and execute it
-        ImmutableMap<Object, Object> invitationOtpRequest = ImmutableMap.builder()
-                .put("code", code)
-                .put("otp", 123456)
-                .build();
+        Map<Object, Object> invitationOtpRequest = Map.of(
+                "code", code,
+                "otp", 123456);
 
         givenSetup()
                 .when()
@@ -178,13 +173,9 @@ public class InviteResourceOtpIT extends IntegrationTest {
 
     @Test
     public void validateOtp_shouldFail_whenAllMandatoryFieldsAreMissing() throws Exception {
-
-        ImmutableMap<Object, Object> invitationRequest = ImmutableMap.builder()
-                .build();
-
         givenSetup()
                 .when()
-                .body(mapper.writeValueAsString(invitationRequest))
+                .body(mapper.writeValueAsString(emptyMap()))
                 .contentType(JSON)
                 .post(INVITES_VALIDATE_OTP_RESOURCE_URL)
                 .then()
@@ -206,10 +197,9 @@ public class InviteResourceOtpIT extends IntegrationTest {
 
         // generate new invitationOtpRequest with new telephone number
         String newTelephoneNumber = "+447452222222";
-        ImmutableMap<Object, Object> resendRequest = ImmutableMap.builder()
-                .put("code", code)
-                .put("telephone_number", newTelephoneNumber)
-                .build();
+        Map<Object, Object> resendRequest = Map.of(
+                "code", code,
+                "telephone_number", newTelephoneNumber);
 
         givenSetup()
                 .when()
@@ -229,12 +219,9 @@ public class InviteResourceOtpIT extends IntegrationTest {
     @Test
     public void resendOtp_shouldFail_whenAllMandatoryFieldsAreMissing() throws Exception {
 
-        ImmutableMap<Object, Object> invitationRequest = ImmutableMap.builder()
-                .build();
-
         givenSetup()
                 .when()
-                .body(mapper.writeValueAsString(invitationRequest))
+                .body(mapper.writeValueAsString(emptyMap()))
                 .contentType(JSON)
                 .post(INVITES_RESEND_OTP_RESOURCE_URL)
                 .then()
@@ -248,10 +235,9 @@ public class InviteResourceOtpIT extends IntegrationTest {
                 .withOtpKey(OTP_KEY)
                 .insertInvite();
 
-        ImmutableMap<Object, Object> sendRequest = ImmutableMap.builder()
-                .put("code", code)
-                .put("otp", PASSCODE)
-                .build();
+        Map<Object, Object> sendRequest = Map.of(
+                "code", code,
+                "otp", PASSCODE);
 
         givenSetup()
                 .when()
@@ -271,10 +257,9 @@ public class InviteResourceOtpIT extends IntegrationTest {
 
         int invalidOtp = 111111;
 
-        ImmutableMap<Object, Object> sendRequest = ImmutableMap.builder()
-                .put("code", code)
-                .put("otp", invalidOtp)
-                .build();
+        Map<Object, Object> sendRequest = Map.of(
+                "code", code,
+                "otp", invalidOtp);
 
         givenSetup()
                 .when()

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceServiceCompleteIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceServiceCompleteIT.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.adminusers.resources;
 
-import com.google.common.collect.ImmutableMap;
 import io.restassured.response.ValidatableResponse;
 import org.junit.Test;
 
@@ -69,7 +68,7 @@ public class InviteResourceServiceCompleteIT extends IntegrationTest {
         String gatewayAccountId1 = String.valueOf(randomInt());
         String gatewayAccountId2 = String.valueOf(randomInt());
 
-        ImmutableMap<String, List<String>> payload = ImmutableMap.of("gateway_account_ids", asList(gatewayAccountId1, gatewayAccountId2));
+        Map<String, List<String>> payload = Map.of("gateway_account_ids", asList(gatewayAccountId1, gatewayAccountId2));
 
         String inviteCode = inviteDbFixture(databaseHelper)
                 .withTelephoneNumber(telephoneNumber)

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteUserRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteUserRequestValidatorTest.java
@@ -2,13 +2,13 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.adminusers.utils.Errors;
 import uk.gov.pay.adminusers.validations.RequestValidations;
 
 import javax.ws.rs.WebApplicationException;
+import java.util.Map;
 import java.util.Optional;
 
 import static junit.framework.TestCase.assertFalse;
@@ -279,7 +279,7 @@ public class InviteUserRequestValidatorTest {
 
     @Test
     public void shouldSuccess_ifAllFieldsArePresentAndValidEmailDomain() {
-        ImmutableMap<String, String> payload = ImmutableMap.of("email", "example@example.gov.uk", "telephone_number", "01134960000", "password", "super-secure-password");
+        Map<String, String> payload = Map.of("email", "example@example.gov.uk", "telephone_number", "01134960000", "password", "super-secure-password");
         JsonNode payloadNode = objectMapper.valueToTree(payload);
         Optional<Errors> errors = validator.validateCreateServiceRequest(payloadNode);
 
@@ -288,7 +288,7 @@ public class InviteUserRequestValidatorTest {
 
     @Test
     public void shouldFail_ifMissingRequiredField() {
-        ImmutableMap<String, String> payload = ImmutableMap.of( "telephone_number", "01134960000", "password", "super-secure-password");
+        Map<String, String> payload = Map.of( "telephone_number", "01134960000", "password", "super-secure-password");
         JsonNode payloadNode = objectMapper.valueToTree(payload);
         Optional<Errors> errors = validator.validateCreateServiceRequest(payloadNode);
 
@@ -299,7 +299,7 @@ public class InviteUserRequestValidatorTest {
 
     @Test
     public void shouldFail_ifInvalidEmailFormat() {
-        ImmutableMap<String, String> payload = ImmutableMap.of( "email", "exampleatexample.com", "telephone_number", "01134960000", "password", "super-secure-password");
+        Map<String, String> payload = Map.of( "email", "exampleatexample.com", "telephone_number", "01134960000", "password", "super-secure-password");
         JsonNode payloadNode = objectMapper.valueToTree(payload);
         Optional<Errors> errors = validator.validateCreateServiceRequest(payloadNode);
 
@@ -310,14 +310,14 @@ public class InviteUserRequestValidatorTest {
 
     @Test(expected = WebApplicationException.class)
     public void shouldFail_ifEmailAddressNotPublicSector() {
-        ImmutableMap<String, String> payload = ImmutableMap.of( "email", "example@example.com","telephone_number", "01134960000", "password", "super-secure-password");
+        Map<String, String> payload = Map.of( "email", "example@example.com","telephone_number", "01134960000", "password", "super-secure-password");
         JsonNode payloadNode = objectMapper.valueToTree(payload);
         validator.validateCreateServiceRequest(payloadNode);
     }
 
     @Test
     public void shouldFail_ifTelephoneNumberIsInvalid() {
-        ImmutableMap<String, String> payload = ImmutableMap.of( "email", "example@example.gov.uk","telephone_number", "0770090000A", "password", "super-secure-password");
+        Map<String, String> payload = Map.of( "email", "example@example.gov.uk","telephone_number", "0770090000A", "password", "super-secure-password");
         JsonNode payloadNode = objectMapper.valueToTree(payload);
         Optional<Errors> errors = validator.validateCreateServiceRequest(payloadNode);
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/ResetPasswordResourceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ResetPasswordResourceIT.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.adminusers.resources;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -36,10 +35,9 @@ public class ResetPasswordResourceIT extends IntegrationTest {
         String forgottenPasswordCode = forgottenPasswordDbFixture(databaseHelper, userId).insertForgottenPassword();
         String password = "iPromiseIWon'tForgetThisPassword";
 
-        ImmutableMap<Object, Object> payload = ImmutableMap.builder()
-                .put("forgotten_password_code", forgottenPasswordCode)
-                .put("new_password", password)
-                .build();
+        Map<Object, Object> payload = Map.of(
+                "forgotten_password_code", forgottenPasswordCode,
+                "new_password", password);
 
         givenSetup()
                 .when()
@@ -61,10 +59,9 @@ public class ResetPasswordResourceIT extends IntegrationTest {
     @Test
     public void resetPassword_shouldReturn400_whenCodeIsInvalid_andCurrentEncryptedPasswordShouldNotChange() throws Exception {
 
-        ImmutableMap<Object, Object> payload = ImmutableMap.builder()
-                .put("forgotten_password_code", "aCodeThatDoesNotExist")
-                .put("new_password", "iPromiseIWon'tForgetThisPassword")
-                .build();
+        Map<Object, Object> payload = Map.of(
+                "forgotten_password_code", "aCodeThatDoesNotExist",
+                "new_password", "iPromiseIWon'tForgetThisPassword");
 
         givenSetup()
                 .when()
@@ -89,10 +86,9 @@ public class ResetPasswordResourceIT extends IntegrationTest {
 
         String expiredForgottenPasswordCode = forgottenPasswordDbFixture(databaseHelper, userId).expired().insertForgottenPassword();
 
-        ImmutableMap<Object, Object> payload = ImmutableMap.builder()
-                .put("forgotten_password_code", expiredForgottenPasswordCode)
-                .put("new_password", "iPromiseIWon'tForgetThisPassword")
-                .build();
+        Map<Object, Object> payload = Map.of(
+                "forgotten_password_code", expiredForgottenPasswordCode,
+                "new_password", "iPromiseIWon'tForgetThisPassword");
 
         givenSetup()
                 .when()

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceGovUkPayAgreementResourceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceGovUkPayAgreementResourceIT.java
@@ -2,7 +2,6 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.adminusers.fixtures.GovUkPayAgreementDbFixture;
@@ -11,6 +10,7 @@ import uk.gov.pay.adminusers.model.User;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
@@ -38,7 +38,7 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
     
     @Test
     public void shouldCreateGovUkPayAgreement() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("user_external_id", user.getExternalId()));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_external_id", user.getExternalId()));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -51,7 +51,7 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
 
     @Test
     public void shouldReturn_404_whenServiceNotFound() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("user_external_id", user.getExternalId()));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_external_id", user.getExternalId()));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -63,7 +63,7 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
 
     @Test
     public void shouldReturn_400_whenUserNotFound() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("user_external_id", "abcde1234"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_external_id", "abcde1234"));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -76,7 +76,7 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
     
     @Test
     public void shouldReturn_400_whenUserExternalIdIsNotAString() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("user_external_id", 100));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_external_id", 100));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -90,7 +90,7 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
 
     @Test
     public void shouldReturn_400_whenUserExternalIdIsEmpty() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("user_external_id", ""));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_external_id", ""));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -104,7 +104,7 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
 
     @Test
     public void shouldReturn_400_whenUserExternalIdIsMissing() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("user_id", user.getExternalId()));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_id", user.getExternalId()));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -122,7 +122,7 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
                 .withServiceId(service.getId())
                 .insert();
 
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("user_external_id", user.getExternalId()));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_external_id", user.getExternalId()));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -138,7 +138,7 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
     public void shouldReturn_400_whenUserDoesNotBelongToService() {
         user = userDbFixture(databaseHelper)
                 .insertUser();
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("user_external_id", user.getExternalId()));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_external_id", user.getExternalId()));
         givenSetup()
                 .when()
                 .accept(JSON)

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceStripeAgreementIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceStripeAgreementIT.java
@@ -2,7 +2,6 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.adminusers.fixtures.StripeAgreementDbFixture;
@@ -10,9 +9,11 @@ import uk.gov.pay.adminusers.model.Service;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
+import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
@@ -30,7 +31,7 @@ public class ServiceResourceStripeAgreementIT extends IntegrationTest {
 
     @Test
     public void shouldCreateStripeAgreement() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of(FIELD_IP_ADDRESS, "0.0.0.0"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of(FIELD_IP_ADDRESS, "0.0.0.0"));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -42,7 +43,7 @@ public class ServiceResourceStripeAgreementIT extends IntegrationTest {
 
     @Test
     public void shouldReturn_NOT_FOUND_whenServiceNotFound() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of(FIELD_IP_ADDRESS, "0.0.0.0"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of(FIELD_IP_ADDRESS, "0.0.0.0"));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -58,7 +59,7 @@ public class ServiceResourceStripeAgreementIT extends IntegrationTest {
                 .withServiceId(service.getId())
                 .insert();
 
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of(FIELD_IP_ADDRESS, "0.0.0.0"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of(FIELD_IP_ADDRESS, "0.0.0.0"));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -72,7 +73,7 @@ public class ServiceResourceStripeAgreementIT extends IntegrationTest {
 
     @Test
     public void shouldReturn_422_whenProvidedInvalidIPAddress() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of(FIELD_IP_ADDRESS, "257.0.0.0"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of(FIELD_IP_ADDRESS, "257.0.0.0"));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -86,7 +87,7 @@ public class ServiceResourceStripeAgreementIT extends IntegrationTest {
 
     @Test
     public void shouldReturn_422_whenIpAddressIsNotAString() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of(FIELD_IP_ADDRESS, 100));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of(FIELD_IP_ADDRESS, 100));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -100,7 +101,7 @@ public class ServiceResourceStripeAgreementIT extends IntegrationTest {
 
     @Test
     public void shouldReturn_422_whenIpAddressNotProvided() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of());
+        JsonNode payload = new ObjectMapper().valueToTree(emptyMap());
         givenSetup()
                 .when()
                 .accept(JSON)

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateCustomBrandingIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateCustomBrandingIT.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.adminusers.resources;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.ServiceName;
@@ -9,6 +8,7 @@ import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
+import static java.util.Collections.emptyMap;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
@@ -23,7 +23,7 @@ public class ServiceResourceUpdateCustomBrandingIT extends IntegrationTest {
         Service service = Service.from(randomInt(), serviceExternalId, new ServiceName("existing-name"));
         databaseHelper.addService(service, randomInt().toString());
 
-        Map<String, Object> payload = ImmutableMap.of("path", "custom_branding", "op", "replace", "value", ImmutableMap.of("image_url","image url","css_url","css url"));
+        Map<String, Object> payload = Map.of("path", "custom_branding", "op", "replace", "value", Map.of("image_url","image url","css_url","css url"));
 
         givenSetup()
                 .when()
@@ -41,11 +41,11 @@ public class ServiceResourceUpdateCustomBrandingIT extends IntegrationTest {
     @Test
     public void shouldReplaceWithEmpty_whenUpdatingCustomBranding_withEmptyObject() throws Exception {
         String serviceExternalId = randomUuid();
-        Map<String, Object> existingBranding = ImmutableMap.of("css_url","existing css", "image_url","existing image");
+        Map<String, Object> existingBranding = Map.of("css_url","existing css", "image_url","existing image");
         Service service = Service.from(randomInt(), serviceExternalId, new ServiceName("existing-name"));
         service.setCustomBranding(existingBranding);
 
-        Map<String, Object> payloadWithEmptyBranding = ImmutableMap.of("path", "custom_branding", "op", "replace", "value", ImmutableMap.of());
+        Map<String, Object> payloadWithEmptyBranding = Map.of("path", "custom_branding", "op", "replace", "value", emptyMap());
         databaseHelper.addService(service, randomInt().toString());
 
 
@@ -66,11 +66,11 @@ public class ServiceResourceUpdateCustomBrandingIT extends IntegrationTest {
 
         String serviceExternalId = randomUuid();
         Service service = Service.from(randomInt(), serviceExternalId, new ServiceName("existing-name"));
-        Map<String, Object> customBranding = ImmutableMap.of("css_url","existing css", "image_url","existing image");
+        Map<String, Object> customBranding = Map.of("css_url","existing css", "image_url","existing image");
         service.setCustomBranding(customBranding);
         databaseHelper.addService(service, randomInt().toString());
 
-        Map<String, Object> payload = ImmutableMap.of("path", "custom_branding", "op", "replace", "value", "blah");
+        Map<String, Object> payload = Map.of("path", "custom_branding", "op", "replace", "value", "blah");
 
         givenSetup()
                 .when()
@@ -85,7 +85,7 @@ public class ServiceResourceUpdateCustomBrandingIT extends IntegrationTest {
     @Test
     public void shouldReturn404_whenUpdatingServiceCustomisations_ifNotFound() throws Exception {
 
-        Map<String, Object> payload = ImmutableMap.of("path", "custom_branding", "op", "replace", "value", ImmutableMap.of("image_url","image url","css_url","css url"));
+        Map<String, Object> payload = Map.of("path", "custom_branding", "op", "replace", "value", Map.of("image_url","image url","css_url","css url"));
 
         givenSetup()
                 .when()

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateGoLiveStageIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateGoLiveStageIT.java
@@ -2,9 +2,10 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.GoLiveStage;
+
+import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
@@ -18,7 +19,7 @@ public class ServiceResourceUpdateGoLiveStageIT extends IntegrationTest {
     public void shouldUpdateGoLiveStage() {
         String serviceExternalId = serviceDbFixture(databaseHelper).insertService().getExternalId();
         JsonNode payload = new ObjectMapper()
-                .valueToTree(ImmutableMap.of(
+                .valueToTree(Map.of(
                         "op", "replace",
                         "path", "current_go_live_stage",
                         "value", "CHOSEN_PSP_STRIPE"));

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateMerchantDetailsIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateMerchantDetailsIT.java
@@ -2,7 +2,6 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.ServiceName;
@@ -27,16 +26,15 @@ public class ServiceResourceUpdateMerchantDetailsIT extends IntegrationTest {
         String serviceExternalId = randomUuid();
         Service service = Service.from(randomInt(), serviceExternalId, new ServiceName("existing-name"));
         databaseHelper.addService(service, randomInt().toString());
-        Map<String, Object> payload = ImmutableMap.<String, Object>builder()
-                .put("name", "somename")
-                .put("telephone_number", "03069990000")
-                .put("address_line1", "line1")
-                .put("address_line2", "line2")
-                .put("address_city", "city")
-                .put("address_country", "country")
-                .put("address_postcode", "postcode")
-                .put("email", "dd-merchant@example.com")
-                .build();
+        Map<String, Object> payload = Map.of(
+                "name", "somename",
+                "telephone_number", "03069990000",
+                "address_line1", "line1",
+                "address_line2", "line2",
+                "address_city", "city",
+                "address_country", "country",
+                "address_postcode", "postcode",
+                "email", "dd-merchant@example.com");
 
         givenSetup()
                 .when()
@@ -61,13 +59,12 @@ public class ServiceResourceUpdateMerchantDetailsIT extends IntegrationTest {
         String serviceExternalId = randomUuid();
         Service service = Service.from(randomInt(), serviceExternalId, new ServiceName("existing-name"));
         databaseHelper.addService(service, randomInt().toString());
-        Map<String, Object> payload = ImmutableMap.<String, Object>builder()
-                .put("name", "somename")
-                .put("address_line1", "line1")
-                .put("address_city", "city")
-                .put("address_country", "country")
-                .put("address_postcode", "postcode")
-                .build();
+        Map<String, Object> payload = Map.of(
+                "name", "somename",
+                "address_line1", "line1",
+                "address_city", "city",
+                "address_country", "country",
+                "address_postcode", "postcode");
 
         givenSetup()
                 .when()
@@ -92,14 +89,13 @@ public class ServiceResourceUpdateMerchantDetailsIT extends IntegrationTest {
         String serviceExternalId = randomUuid();
         Service service = Service.from(randomInt(), serviceExternalId, new ServiceName("existing-name"));
         databaseHelper.addService(service, randomInt().toString());
-        Map<String, Object> payload = ImmutableMap.<String, Object>builder()
-                .put("telephone_number", "03069990000")
-                .put("address_line1", "line1")
-                .put("address_line2", "line2")
-                .put("address_city", "city")
-                .put("address_country", "country")
-                .put("address_postcode", "postcode")
-                .build();
+        Map<String, Object> payload = Map.of(
+                "telephone_number", "03069990000",
+                "address_line1", "line1",
+                "address_line2", "line2",
+                "address_city", "city",
+                "address_country", "country",
+                "address_postcode", "postcode");
 
         givenSetup()
                 .when()
@@ -120,12 +116,12 @@ public class ServiceResourceUpdateMerchantDetailsIT extends IntegrationTest {
         String addressCountry = "Somewhere";
         ArrayNode payload = mapper.createArrayNode();
 
-        payload.add(mapper.valueToTree(ImmutableMap.of(
+        payload.add(mapper.valueToTree(Map.of(
                 "op", "replace",
                 "path", "merchant_details/address_line1",
                 "value", addressLine1)));
 
-        payload.add(mapper.valueToTree(ImmutableMap.of(
+        payload.add(mapper.valueToTree(Map.of(
                 "op", "replace",
                 "path", "merchant_details/address_country",
                 "value", addressCountry)));
@@ -149,7 +145,7 @@ public class ServiceResourceUpdateMerchantDetailsIT extends IntegrationTest {
                 .getExternalId();
 
         String addressLine1 = "1 Spider Lane";
-        JsonNode payload = mapper.valueToTree(ImmutableMap.of(
+        JsonNode payload = mapper.valueToTree(Map.of(
                 "op", "replace",
                 "path", "merchant_details/address_line1",
                 "value", addressLine1));

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateNameIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateNameIT.java
@@ -2,10 +2,11 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.Service;
+
+import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
@@ -23,7 +24,7 @@ public class ServiceResourceUpdateNameIT extends IntegrationTest {
     }
     @Test
     public void shouldUpdateBothNameAndEnglishServiceName_whenUpdatingEnglishName() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace", "path", "service_name/en", "value", "New Service Name"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "replace", "path", "service_name/en", "value", "New Service Name"));
         givenSetup()
                 .when()
                 .accept(JSON)

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
@@ -2,13 +2,14 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Test;
 import uk.gov.pay.adminusers.validations.RequestValidations;
 
 import java.util.List;
+import java.util.Map;
 
+import static java.util.Collections.emptyMap;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -22,7 +23,7 @@ public class ServiceUpdateOperationValidatorTest {
 
     @Test
     public void shouldFail_whenUpdate_whenMissingRequiredField() {
-        ImmutableMap<String, String> payload = ImmutableMap.of("value", "example-name");
+        Map<String, String> payload = Map.of("value", "example-name");
 
         List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
 
@@ -33,7 +34,7 @@ public class ServiceUpdateOperationValidatorTest {
 
     @Test
     public void shouldFail_whenUpdate_whenInvalidPath() {
-        ImmutableMap<String, String> payload = ImmutableMap.of(
+        Map<String, String> payload = Map.of(
                 "path", "xyz",
                 "op", "replace",
                 "value", "example-name");
@@ -51,13 +52,13 @@ public class ServiceUpdateOperationValidatorTest {
 
     @Test
     public void shouldSuccess_replacingCustomBranding() {
-        ImmutableMap<String, String> branding = ImmutableMap.of("image_url", "image url", "css_url", "css url");
+        Map<String, String> branding = Map.of("image_url", "image url", "css_url", "css url");
         replaceShouldSucceed("custom_branding", branding);
     }
 
     @Test
     public void shouldSuccess_replacingCustomBranding_forEmptyObject() {
-        replaceShouldSucceed("custom_branding", ImmutableMap.of());
+        replaceShouldSucceed("custom_branding", emptyMap());
     }
 
     @Test
@@ -97,7 +98,7 @@ public class ServiceUpdateOperationValidatorTest {
 
     @Test
     public void shouldFail_whenUpdateServiceName_whenPathContainsUnsupportedLanguage() {
-        ImmutableMap<String, String> payload = ImmutableMap.of(
+        Map<String, String> payload = Map.of(
                 "path", "service_name/xx",
                 "op", "replace",
                 "value", "example-name");
@@ -476,7 +477,7 @@ public class ServiceUpdateOperationValidatorTest {
     }
     
     private void shouldFailForAddOperation(String path, Object value) {
-        ImmutableMap<String, Object> payload = ImmutableMap.of(
+        Map<String, Object> payload = Map.of(
                 "path", path,
                 "op", "add",
                 "value", value);
@@ -567,7 +568,7 @@ public class ServiceUpdateOperationValidatorTest {
     }
 
     private void replaceShouldSucceed(String path, Object value) {
-        ImmutableMap<String, Object> payload = ImmutableMap.of(
+        Map<String, Object> payload = Map.of(
                 "path", path,
                 "op", "replace",
                 "value", value);

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserRequestValidatorTest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Before;
@@ -12,6 +11,7 @@ import uk.gov.pay.adminusers.validations.RequestValidations;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
 import static junit.framework.TestCase.assertFalse;
@@ -117,7 +117,7 @@ public class UserRequestValidatorTest {
 
     @Test
     public void shouldError_ifSessionVersionNotNumeric_whenPatching() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("op", "append", "path", "sessionVersion", "value", "1r"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "append", "path", "sessionVersion", "value", "1r"));
         Optional<Errors> optionalErrors = validator.validatePatchRequest(payload);
 
         assertTrue(optionalErrors.isPresent());
@@ -129,7 +129,7 @@ public class UserRequestValidatorTest {
 
     @Test
     public void shouldError_ifDisabledNotBoolean_whenPatching() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace", "path", "disabled", "value", "1r"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "replace", "path", "disabled", "value", "1r"));
         Optional<Errors> optionalErrors = validator.validatePatchRequest(payload);
 
         assertTrue(optionalErrors.isPresent());
@@ -141,7 +141,7 @@ public class UserRequestValidatorTest {
 
     @Test
     public void shouldSuccess_forDisabled_whenPatching() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace", "path", "disabled", "value", "true"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "replace", "path", "disabled", "value", "true"));
         Optional<Errors> optionalErrors = validator.validatePatchRequest(payload);
 
         assertFalse(optionalErrors.isPresent());
@@ -149,7 +149,7 @@ public class UserRequestValidatorTest {
 
     @Test
     public void shouldSuccess_forSessionVersion_whenPatching() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("op", "append", "path", "sessionVersion", "value", "2"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "append", "path", "sessionVersion", "value", "2"));
         Optional<Errors> optionalErrors = validator.validatePatchRequest(payload);
 
         assertFalse(optionalErrors.isPresent());
@@ -157,7 +157,7 @@ public class UserRequestValidatorTest {
 
     @Test
     public void shouldSuccess_replacingTelephoneNumber_whenPatchingLocalTelephoneNumber() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace", "path", "telephone_number", "value", "01134960000"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "replace", "path", "telephone_number", "value", "01134960000"));
         Optional<Errors> optionalErrors = validator.validatePatchRequest(payload);
 
         assertFalse(optionalErrors.isPresent());
@@ -165,7 +165,7 @@ public class UserRequestValidatorTest {
 
     @Test
     public void shouldSuccess_replacingTelephoneNumber_whenPatchingInternationalTelephoneNumber() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace", "path", "telephone_number", "value", "+441134960000"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "replace", "path", "telephone_number", "value", "+441134960000"));
         Optional<Errors> optionalErrors = validator.validatePatchRequest(payload);
 
         assertFalse(optionalErrors.isPresent());
@@ -173,7 +173,7 @@ public class UserRequestValidatorTest {
 
     @Test
     public void shouldError_replacingTelephoneNumber_whenPatchingInvalidTelephoneNumber() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace", "path", "telephone_number", "value", "(╯°□°）╯︵ ┻━┻"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "replace", "path", "telephone_number", "value", "(╯°□°）╯︵ ┻━┻"));
         Optional<Errors> optionalErrors = validator.validatePatchRequest(payload);
 
         Errors errors = optionalErrors.get();
@@ -184,7 +184,7 @@ public class UserRequestValidatorTest {
 
     @Test
     public void shouldSuccess_whenAddingServiceRole() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("service_external_id", "blah-blah", "role_name", "blah"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("service_external_id", "blah-blah", "role_name", "blah"));
         Optional<Errors> optionalErrors = validator.validateAssignServiceRequest(payload);
 
         assertFalse(optionalErrors.isPresent());
@@ -192,7 +192,7 @@ public class UserRequestValidatorTest {
 
     @Test
     public void shouldError_whenAddingServiceRole_ifRequiredParamMissing() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("service_external_id", "blah-blah"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("service_external_id", "blah-blah"));
         Optional<Errors> optionalErrors = validator.validateAssignServiceRequest(payload);
 
         Errors errors = optionalErrors.get();
@@ -266,7 +266,7 @@ public class UserRequestValidatorTest {
 
     @Test
     public void shouldSuccess_ifValidSearchRequest_whenFindingAUser() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("username", "some-existing-user"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("username", "some-existing-user"));
         Optional<Errors> optionalErrors = validator.validateFindRequest(payload);
 
         assertThat(optionalErrors.isPresent(), is(false));
@@ -290,7 +290,7 @@ public class UserRequestValidatorTest {
 
     @Test
     public void shouldSuccess_ifProvisionalTrue_whenValidateNewSecondFactorPasscodeRequest() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("provisional", true));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("provisional", true));
 
         Optional<Errors> optionalErrors = validator.validateNewSecondFactorPasscodeRequest(payload);
 
@@ -299,7 +299,7 @@ public class UserRequestValidatorTest {
 
     @Test
     public void shouldSuccess_ifProvisionalFalse_whenValidateNewSecondFactorPasscodeRequest() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("provisional", false));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("provisional", false));
 
         Optional<Errors> optionalErrors = validator.validateNewSecondFactorPasscodeRequest(payload);
 
@@ -308,7 +308,7 @@ public class UserRequestValidatorTest {
 
     @Test
     public void shouldError_ifProvisionalNotBoolean_whenValidateNewSecondFactorPasscodeRequest() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("provisional", "maybe"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("provisional", "maybe"));
 
         Optional<Errors> optionalErrors = validator.validateNewSecondFactorPasscodeRequest(payload);
 
@@ -321,7 +321,7 @@ public class UserRequestValidatorTest {
 
     @Test
     public void shouldError_ifCodeMissing_whenValidate2faActivateRequest() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("second_factor", "SMS"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("second_factor", "SMS"));
 
         Optional<Errors> optionalErrors = validator.validate2faActivateRequest(payload);
 
@@ -334,7 +334,7 @@ public class UserRequestValidatorTest {
 
     @Test
     public void shouldError_ifCodeNotNumeric_whenValidate2faActivateRequest() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("code", "I am not a number, I’m a free man!",
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("code", "I am not a number, I’m a free man!",
                 "second_factor", "SMS"));
 
         Optional<Errors> optionalErrors = validator.validate2faActivateRequest(payload);
@@ -348,7 +348,7 @@ public class UserRequestValidatorTest {
 
     @Test
     public void shouldError_ifSecondFactorMissing_whenValidate2faActivateRequest() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("code", 123456));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("code", 123456));
 
         Optional<Errors> optionalErrors = validator.validate2faActivateRequest(payload);
 
@@ -361,7 +361,7 @@ public class UserRequestValidatorTest {
 
     @Test
     public void shouldError_ifSecondFactorInvalid_whenValidate2faActivateRequest() {
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("code", 123456,
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("code", 123456,
                 "second_factor", "PINKY_SWEAR"));
 
         Optional<Errors> optionalErrors = validator.validate2faActivateRequest(payload);

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationIT.java
@@ -1,12 +1,12 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import uk.gov.pay.adminusers.fixtures.UserDbFixture;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.service.PasswordHasher;
 
+import java.util.Map;
 import java.util.UUID;
 
 import static io.restassured.http.ContentType.JSON;
@@ -26,10 +26,9 @@ public class UserResourceAuthenticationIT extends IntegrationTest {
 
         String username = createAValidUser(service);
 
-        ImmutableMap<Object, Object> authPayload = ImmutableMap.builder()
-                .put("username", username)
-                .put("password", "password-" + username)
-                .build();
+        Map<Object, Object> authPayload = Map.of(
+                "username", username,
+                "password", "password-" + username);
 
         givenSetup()
                 .when()
@@ -65,10 +64,9 @@ public class UserResourceAuthenticationIT extends IntegrationTest {
                 .withEmail(email)
                 .withPassword(encryptedPassword).insertUser();
 
-        ImmutableMap<Object, Object> authPayload = ImmutableMap.builder()
-                .put("username", username)
-                .put("password", password)
-                .build();
+        Map<Object, Object> authPayload = Map.of(
+                "username", username,
+                "password", password);
 
         givenSetup()
                 .when()
@@ -90,10 +88,9 @@ public class UserResourceAuthenticationIT extends IntegrationTest {
 
         String username = createAValidUser(service);
 
-        ImmutableMap<Object, Object> authPayload = ImmutableMap.builder()
-                .put("username", username)
-                .put("password", "invalid-password")
-                .build();
+        Map<Object, Object> authPayload = Map.of(
+                "username", username,
+                "password", "invalid-password");
 
         givenSetup()
                 .when()
@@ -109,15 +106,14 @@ public class UserResourceAuthenticationIT extends IntegrationTest {
 
     private String createAValidUser(Service service) throws JsonProcessingException {
         String username = randomAlphanumeric(10) + UUID.randomUUID();
-        ImmutableMap<Object, Object> userPayload = ImmutableMap.builder()
-                .put("username", username)
-                .put("password", "password-" + username)
-                .put("email", "user-" + username + "@example.com")
-                .put("service_external_ids", new String[]{service.getExternalId()})
-                .put("telephone_number", "+441134960000")
-                .put("otp_key", "34f34")
-                .put("role_name", "admin")
-                .build();
+        Map<Object, Object> userPayload = Map.of(
+                "username", username,
+                "password", "password-" + username,
+                "email", "user-" + username + "@example.com",
+                "service_external_ids", new String[]{service.getExternalId()},
+                "telephone_number", "+441134960000",
+                "otp_key", "34f34",
+                "role_name", "admin");
 
         givenSetup()
                 .when()

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateIT.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.adminusers.resources;
 
-import com.google.common.collect.ImmutableMap;
 import io.restassured.response.ValidatableResponse;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.Service;
@@ -11,6 +10,7 @@ import java.util.Map;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static java.lang.String.valueOf;
+import static java.util.Collections.emptyMap;
 import static org.apache.commons.lang3.RandomUtils.nextInt;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
@@ -26,13 +26,12 @@ public class UserResourceCreateIT extends IntegrationTest {
     @Test
     public void shouldCreateAUser_Successfully() throws Exception {
         String username = randomUuid();
-        ImmutableMap<Object, Object> userPayload = ImmutableMap.builder()
-                .put("username", username)
-                .put("email", "user-" + username + "@example.com")
-                .put("telephone_number", "+441134960000")
-                .put("otp_key", "34f34")
-                .put("role_name", "admin")
-                .build();
+        Map<Object, Object> userPayload = Map.of(
+                "username", username,
+                "email", "user-" + username + "@example.com",
+                "telephone_number", "+441134960000",
+                "otp_key", "34f34",
+                "role_name", "admin");
 
         ValidatableResponse response = givenSetup().when()
                 .body(mapper.writeValueAsString(userPayload))
@@ -77,14 +76,13 @@ public class UserResourceCreateIT extends IntegrationTest {
         String serviceExternalId = service.getExternalId();
         String username = randomUuid();
 
-        ImmutableMap<Object, Object> userPayload = ImmutableMap.builder()
-                .put("username", username)
-                .put("email", "user-" + username + "@example.com")
-                .put("service_external_ids", new String[]{valueOf(serviceExternalId)})
-                .put("telephone_number", "+441134960000")
-                .put("otp_key", "34f34")
-                .put("role_name", "admin")
-                .build();
+        Map<Object, Object> userPayload = Map.of(
+                "username", username,
+                "email", "user-" + username + "@example.com",
+                "service_external_ids", new String[]{valueOf(serviceExternalId)},
+                "telephone_number", "+441134960000",
+                "otp_key", "34f34",
+                "role_name", "admin");
 
         ValidatableResponse response = givenSetup().when()
                 .body(mapper.writeValueAsString(userPayload))
@@ -129,14 +127,13 @@ public class UserResourceCreateIT extends IntegrationTest {
     @Test
     public void shouldError400_IfRoleDoesNotExist() throws Exception {
         String username = randomUuid();
-        ImmutableMap<Object, Object> userPayload = ImmutableMap.builder()
-                .put("username", username)
-                .put("email", "user-" + username + "@example.com")
-                .put("gateway_account_ids", new String[]{"1", "2"})
-                .put("telephone_number", "01134960000")
-                .put("otp_key", "34f34")
-                .put("role_name", "invalid-role")
-                .build();
+        Map<Object, Object> userPayload = Map.of(
+                "username", username,
+                "email", "user-" + username + "@example.com",
+                "gateway_account_ids", new String[]{"1", "2"},
+                "telephone_number", "01134960000",
+                "otp_key", "34f34",
+                "role_name", "invalid-role");
 
         givenSetup()
                 .when()
@@ -152,7 +149,7 @@ public class UserResourceCreateIT extends IntegrationTest {
 
     @Test
     public void shouldError400_whenFieldsMissingForUserCreation() throws Exception {
-        ImmutableMap<Object, Object> invalidPayload = ImmutableMap.builder().build();
+        Map<Object, Object> invalidPayload = emptyMap();
 
         givenSetup()
                 .when()
@@ -178,13 +175,12 @@ public class UserResourceCreateIT extends IntegrationTest {
         String email = username + "@example.com";
         userDbFixture(databaseHelper).withUsername(username).withEmail(email).insertUser();
 
-        ImmutableMap<Object, Object> userPayload = ImmutableMap.builder()
-                .put("username", username)
-                .put("email", email)
-                .put("gateway_account_ids", new String[]{gatewayAccount})
-                .put("telephone_number", "01134960000")
-                .put("role_name", "admin")
-                .build();
+        Map<Object, Object> userPayload = Map.of(
+                "username", username,
+                "email", email,
+                "gateway_account_ids", new String[]{gatewayAccount},
+                "telephone_number", "01134960000",
+                "role_name", "admin");
 
         givenSetup()
                 .when()

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateServiceRoleIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateServiceRoleIT.java
@@ -2,12 +2,13 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.User;
+
+import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
@@ -28,7 +29,7 @@ public class UserResourceCreateServiceRoleIT extends IntegrationTest {
         String email = username + "@example.com";
         User user = userDbFixture(databaseHelper).withUsername(username).withEmail(email).insertUser();
 
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("service_external_id", service.getExternalId(), "role_name", role.getName()));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("service_external_id", service.getExternalId(), "role_name", role.getName()));
 
         givenSetup()
                 .when()
@@ -51,7 +52,7 @@ public class UserResourceCreateServiceRoleIT extends IntegrationTest {
         String email = username + "@example.com";
         User user = userDbFixture(databaseHelper).withUsername(username).withEmail(email).insertUser();
 
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("role_name", role.getName()));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("role_name", role.getName()));
 
         givenSetup()
                 .when()
@@ -74,7 +75,7 @@ public class UserResourceCreateServiceRoleIT extends IntegrationTest {
         String email = username + "@example.com";
         User user = userDbFixture(databaseHelper).withServiceRole(service.getId(), role.getId()).withUsername(username).withEmail(email).insertUser();
 
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("service_external_id", service.getExternalId(), "role_name", roleName));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("service_external_id", service.getExternalId(), "role_name", roleName));
 
         givenSetup()
                 .when()

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceFindIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceFindIT.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.adminusers.resources;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.User;
@@ -27,7 +26,7 @@ public class UserResourceFindIT extends IntegrationTest {
     @Test
     public void shouldFindSuccessfully_existingUserByUserName() throws Exception {
 
-        Map<String, String> findPayload = ImmutableMap.of("username", username);
+        Map<String, String> findPayload = Map.of("username", username);
 
         givenSetup()
                 .when()
@@ -41,7 +40,7 @@ public class UserResourceFindIT extends IntegrationTest {
 
     @Test
     public void shouldError404_ifUserNotFound() throws Exception {
-        Map<String, String> findPayload = ImmutableMap.of("username", "unknown-user@somewhere.com");
+        Map<String, String> findPayload = Map.of("username", "unknown-user@somewhere.com");
 
         givenSetup()
                 .when()
@@ -55,7 +54,7 @@ public class UserResourceFindIT extends IntegrationTest {
 
     @Test
     public void shouldError400_ifFieldsMissing() throws Exception {
-        Map<String, String> findPayload = ImmutableMap.of("", "");
+        Map<String, String> findPayload = Map.of("", "");
 
         givenSetup()
                 .when()

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourcePatchIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourcePatchIT.java
@@ -2,10 +2,11 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.User;
+
+import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
@@ -30,7 +31,7 @@ public class UserResourcePatchIT extends IntegrationTest {
     @Test
     public void shouldIncreaseSessionVersion_whenPatchAttempt() {
 
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("op", "append", "path", "sessionVersion", "value", 2));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "append", "path", "sessionVersion", "value", 2));
 
         givenSetup()
                 .when()
@@ -46,7 +47,7 @@ public class UserResourcePatchIT extends IntegrationTest {
     public void shouldUpdateTelephoneNumber_whenPatchAttempt() {
 
         String newTelephoneNumber = "+441134960000";
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace", "path", "telephone_number", "value", newTelephoneNumber));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "replace", "path", "telephone_number", "value", newTelephoneNumber));
 
         givenSetup()
                 .when()
@@ -63,7 +64,7 @@ public class UserResourcePatchIT extends IntegrationTest {
     public void shouldUpdateFeatures_whenPatchAttempt() {
 
         String newFeatures = "SUPER_FEATURE_1, SECRET_SQUIRREL_FEATURE";
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace", "path", "features", "value", newFeatures));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "replace", "path", "features", "value", newFeatures));
 
         givenSetup()
                 .when()
@@ -79,7 +80,7 @@ public class UserResourcePatchIT extends IntegrationTest {
     @Test
     public void shouldDisableUser_whenPatchAttempt() {
 
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace", "path", "disabled", "value", "true"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "replace", "path", "disabled", "value", "true"));
 
         givenSetup()
                 .when()
@@ -94,7 +95,7 @@ public class UserResourcePatchIT extends IntegrationTest {
     @Test
     public void shouldReturn404_whenUnknownExternalIdIsSupplied() {
 
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("op", "append", "path", "sessionVersion", "value", 1));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "append", "path", "sessionVersion", "value", 1));
 
         givenSetup()
                 .when()
@@ -108,7 +109,7 @@ public class UserResourcePatchIT extends IntegrationTest {
     @Test
     public void shouldError_whenPatchRequiredFieldsAreMissing() {
 
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("blah", "sessionVersion", "value", 1));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("blah", "sessionVersion", "value", 1));
 
         givenSetup()
                 .when()

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceSecondFactorAuthenticationIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceSecondFactorAuthenticationIT.java
@@ -1,11 +1,12 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.collect.ImmutableMap;
 import com.warrenstrange.googleauth.GoogleAuthenticator;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.User;
+
+import java.util.Map;
 
 import static com.google.common.io.BaseEncoding.base32;
 import static io.restassured.http.ContentType.JSON;
@@ -45,7 +46,7 @@ public class UserResourceSecondFactorAuthenticationIT extends IntegrationTest {
 
     @Test
     public void shouldCreate2FA_forAValidNewSecondFactorPasscodeRequest_withProvisionalFalse() throws JsonProcessingException {
-        ImmutableMap<String, Boolean> body = ImmutableMap.of("provisional", false);
+        Map<String, Boolean> body = Map.of("provisional", false);
 
         givenSetup()
                 .when()
@@ -60,7 +61,7 @@ public class UserResourceSecondFactorAuthenticationIT extends IntegrationTest {
     public void shouldCreate2FA_forAValidNewSecondFactorPasscodeRequest_withProvisionalTrue() throws JsonProcessingException {
         databaseHelper.updateProvisionalOtpKey(username, "ABCDEFGHIJKLMNOP");
 
-        ImmutableMap<String, Boolean> body = ImmutableMap.of("provisional", true);
+        Map<String, Boolean> body = Map.of("provisional", true);
 
         givenSetup()
                 .when()
@@ -73,7 +74,7 @@ public class UserResourceSecondFactorAuthenticationIT extends IntegrationTest {
 
     @Test
     public void shouldReturnNotFound_forAValidNewSecondFactorPasscodeRequest_withProvisionalTrue_ifNoProvisionalOtpKey() throws JsonProcessingException {
-        ImmutableMap<String, Boolean> body = ImmutableMap.of("provisional", true);
+        Map<String, Boolean> body = Map.of("provisional", true);
 
         givenSetup()
                 .when()
@@ -88,7 +89,7 @@ public class UserResourceSecondFactorAuthenticationIT extends IntegrationTest {
     public void shouldAuthenticate2FA_forAValid2FAAuthRequest() throws Exception {
         GoogleAuthenticator testAuthenticator = new GoogleAuthenticator();
         int passcode = testAuthenticator.getTotpPassword(base32().encode(OTP_KEY.getBytes()));
-        ImmutableMap<String, Integer> authBody = ImmutableMap.of("code", passcode);
+        Map<String, Integer> authBody = Map.of("code", passcode);
 
         givenSetup()
                 .when()
@@ -116,7 +117,7 @@ public class UserResourceSecondFactorAuthenticationIT extends IntegrationTest {
     @Test
     public void shouldReturnUnauthorized_onInvalid2FACode_during2FAAuth() throws Exception {
         int invalidPasscode = 111111;
-        ImmutableMap<String, Integer> authBody = ImmutableMap.of("code", invalidPasscode);
+        Map<String, Integer> authBody = Map.of("code", invalidPasscode);
 
         givenSetup()
                 .when()
@@ -132,7 +133,7 @@ public class UserResourceSecondFactorAuthenticationIT extends IntegrationTest {
         databaseHelper.updateLoginCount(username, 10);
 
         int invalidPasscode = 111111;
-        ImmutableMap<String, Integer> authBody = ImmutableMap.of("code", invalidPasscode);
+        Map<String, Integer> authBody = Map.of("code", invalidPasscode);
 
         givenSetup()
                 .when()

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceSecondFactorProvisioningIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceSecondFactorProvisioningIT.java
@@ -1,11 +1,12 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.collect.ImmutableMap;
 import com.warrenstrange.googleauth.GoogleAuthenticator;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.User;
+
+import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
@@ -74,7 +75,7 @@ public class UserResourceSecondFactorProvisioningIT extends IntegrationTest {
         givenSetup()
                 .when()
                 .accept(JSON)
-                .body(mapper.writeValueAsString(ImmutableMap.of("second_factor", "APP", "code", passCode)))
+                .body(mapper.writeValueAsString(Map.of("second_factor", "APP", "code", passCode)))
                 .post(format(USER_2FA_ACTIVATE_URL, externalId))
                 .then()
                 .statusCode(200)
@@ -102,7 +103,7 @@ public class UserResourceSecondFactorProvisioningIT extends IntegrationTest {
         givenSetup()
                 .when()
                 .accept(JSON)
-                .body(mapper.writeValueAsString(ImmutableMap.of("second_factor", "NOT VALID", "code", passCode)))
+                .body(mapper.writeValueAsString(Map.of("second_factor", "NOT VALID", "code", passCode)))
                 .post(format(USER_2FA_ACTIVATE_URL, externalId))
                 .then()
                 .statusCode(400);
@@ -125,7 +126,7 @@ public class UserResourceSecondFactorProvisioningIT extends IntegrationTest {
         givenSetup()
                 .when()
                 .accept(JSON)
-                .body(mapper.writeValueAsString(ImmutableMap.of("second_factor", "APP", "code", passCode + 1)))
+                .body(mapper.writeValueAsString(Map.of("second_factor", "APP", "code", passCode + 1)))
                 .post(format(USER_2FA_ACTIVATE_URL, externalId))
                 .then()
                 .statusCode(401);

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceUpdateServiceRoleIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceUpdateServiceRoleIT.java
@@ -2,11 +2,12 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.User;
+
+import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
@@ -31,7 +32,7 @@ public class UserResourceUpdateServiceRoleIT extends IntegrationTest {
         String email2 = username2 + "@example.com";
         userDbFixture(databaseHelper).withServiceRole(service, role.getId()).withUsername(username2).withEmail(email2).insertUser();
 
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("role_name", "view-and-refund"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("role_name", "view-and-refund"));
 
         givenSetup()
                 .when()
@@ -48,7 +49,7 @@ public class UserResourceUpdateServiceRoleIT extends IntegrationTest {
     @Test
     public void shouldError404_ifUserNotFound_whenUpdatingServiceRole() {
         String serviceExternalId = serviceDbFixture(databaseHelper).insertService().getExternalId();
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("role_name", "view-and-refund"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("role_name", "view-and-refund"));
 
         givenSetup()
                 .when()
@@ -68,7 +69,7 @@ public class UserResourceUpdateServiceRoleIT extends IntegrationTest {
         String email = username + "@example.com";
         User user = userDbFixture(databaseHelper).withServiceRole(service, role.getId()).withUsername(username).withEmail(email).insertUser();
 
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("role_name", "view-and-refund"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("role_name", "view-and-refund"));
 
         givenSetup()
                 .when()

--- a/src/test/java/uk/gov/pay/adminusers/service/EmailServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/EmailServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.adminusers.service;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -81,7 +80,7 @@ public class EmailServiceTest {
     @Test
     public void shouldSendAnEmailForOneOffPaymentConfirmed() throws InvalidMerchantDetailsException {
         EmailTemplate template = EmailTemplate.ONE_OFF_PAYMENT_CONFIRMED;
-        Map<String, String> personalisation = ImmutableMap.of(
+        Map<String, String> personalisation = Map.of(
                 "field 1", "theValueOfField1",
                 "field 2", "theValueOfField2"
         );
@@ -113,7 +112,7 @@ public class EmailServiceTest {
     @Test
     public void shouldSendAnEmailForOnDemandPaymentConfirmed() throws InvalidMerchantDetailsException {
         EmailTemplate template = EmailTemplate.ON_DEMAND_PAYMENT_CONFIRMED;
-        Map<String, String> personalisation = ImmutableMap.of(
+        Map<String, String> personalisation = Map.of(
                 "field 1", "theValueOfField1",
                 "field 2", "theValueOfField2"
         );
@@ -145,7 +144,7 @@ public class EmailServiceTest {
     @Test
     public void shouldSendAnEmailForPaymentFailed() throws InvalidMerchantDetailsException {
         EmailTemplate template = EmailTemplate.PAYMENT_FAILED;
-        Map<String, String> personalisation = ImmutableMap.of(
+        Map<String, String> personalisation = Map.of(
                 "field 1", "theValueOfField1",
                 "field 2", "theValueOfField2"
         );
@@ -175,7 +174,7 @@ public class EmailServiceTest {
     @Test
     public void shouldSendAnEmailForMandateFailed() throws InvalidMerchantDetailsException {
         EmailTemplate template = EmailTemplate.MANDATE_FAILED;
-        Map<String, String> personalisation = ImmutableMap.of(
+        Map<String, String> personalisation = Map.of(
                 "field 1", "theValueOfField1",
                 "field 2", "theValueOfField2"
         );
@@ -207,7 +206,7 @@ public class EmailServiceTest {
     @Test
     public void shouldSendAnEmailForOnDemandMandateCreated() throws InvalidMerchantDetailsException {
         EmailTemplate template = EmailTemplate.ON_DEMAND_MANDATE_CREATED;
-        Map<String, String> personalisation = ImmutableMap.of(
+        Map<String, String> personalisation = Map.of(
                 "field 1", "theValueOfField1",
                 "field 2", "theValueOfField2"
         );
@@ -239,7 +238,7 @@ public class EmailServiceTest {
     @Test
     public void shouldSendAnEmailForOneOffMandateCreated() throws InvalidMerchantDetailsException {
         EmailTemplate template = EmailTemplate.ONE_OFF_MANDATE_CREATED;
-        Map<String, String> personalisation = ImmutableMap.of(
+        Map<String, String> personalisation = Map.of(
                 "field 1", "theValueOfField1",
                 "field 2", "theValueOfField2"
         );
@@ -271,7 +270,7 @@ public class EmailServiceTest {
     @Test
     public void shouldThrowAnExceptionIfMerchantDetailsAreMissing() throws InvalidMerchantDetailsException {
         EmailTemplate template = EmailTemplate.MANDATE_FAILED;
-        Map<String, String> personalisation = ImmutableMap.of(
+        Map<String, String> personalisation = Map.of(
                 "field 1", "theValueOfField1",
                 "field 2", "theValueOfField2"
         );
@@ -297,7 +296,7 @@ public class EmailServiceTest {
     @Test
     public void shouldNotDisplayCountryNameForInvalidCountryCode() throws InvalidMerchantDetailsException {
         EmailTemplate template = EmailTemplate.ONE_OFF_PAYMENT_CONFIRMED;
-        Map<String, String> personalisation = ImmutableMap.of(
+        Map<String, String> personalisation = Map.of(
                 "field 1", "theValueOfField1",
                 "field 2", "theValueOfField2"
         );

--- a/src/test/java/uk/gov/pay/adminusers/service/InviteFinderTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/InviteFinderTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.adminusers.service;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -126,7 +125,7 @@ public class InviteFinderTest {
         when(mockUserDao.findByEmail(firstEmail)).thenReturn(Optional.empty());
         when(mockUserDao.findByEmail(secondEmail)).thenReturn(Optional.empty());
         when(mockInviteDao.findAllByServiceId(externalServiceId)).thenReturn(
-                ImmutableList.of(firstInviteEntity, secondInviteEntity, disabledInviteEntity, expiredInviteEntity)
+                List.of(firstInviteEntity, secondInviteEntity, disabledInviteEntity, expiredInviteEntity)
         );
         List<Invite> invites = inviteFinder.findAllActiveInvites(externalServiceId);
         assertThat(invites.size(), is(2));

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCreatorTest.java
@@ -19,10 +19,11 @@ import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 
 import javax.ws.rs.WebApplicationException;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
@@ -57,7 +58,7 @@ public class ServiceInviteCreatorTest {
         InviteServiceRequest request = new InviteServiceRequest("password", email, "01134960000");
         RoleEntity roleEntity = new RoleEntity(Role.role(2, "admin", "Adminstrator"));
         when(userDao.findByEmail(email)).thenReturn(Optional.empty());
-        when(inviteDao.findByEmail(email)).thenReturn(newArrayList());
+        when(inviteDao.findByEmail(email)).thenReturn(emptyList());
         when(roleDao.findByRoleName("admin")).thenReturn(Optional.of(roleEntity));
         when(notificationService.sendServiceInviteEmail(eq(email), anyString())).thenReturn(CompletableFuture.completedFuture("done"));
         when(linksConfig.getSelfserviceInvitesUrl()).thenReturn("http://selfservice/invites");
@@ -81,7 +82,7 @@ public class ServiceInviteCreatorTest {
         InviteServiceRequest request = new InviteServiceRequest("password", email, "01134960000");
         RoleEntity roleEntity = new RoleEntity(Role.role(2, "admin", "Adminstrator"));
         when(userDao.findByEmail(email)).thenReturn(Optional.empty());
-        when(inviteDao.findByEmail(email)).thenReturn(newArrayList());
+        when(inviteDao.findByEmail(email)).thenReturn(emptyList());
         when(roleDao.findByRoleName("admin")).thenReturn(Optional.of(roleEntity));
         when(notificationService.sendServiceInviteEmail(eq(email), anyString())).thenReturn(CompletableFuture.supplyAsync(() -> {
             throw new RuntimeException("done");
@@ -113,7 +114,7 @@ public class ServiceInviteCreatorTest {
         when(userDao.findByEmail(email)).thenReturn(Optional.empty());
         when(sender.getExternalId()).thenReturn("inviter-id");
         when(sender.getEmail()).thenReturn("inviter@example.com");
-        when(inviteDao.findByEmail(email)).thenReturn(newArrayList(validInvite));
+        when(inviteDao.findByEmail(email)).thenReturn(List.of(validInvite));
         when(linksConfig.getSelfserviceInvitesUrl()).thenReturn("http://selfservice/invites");
         when(notificationService.sendServiceInviteEmail(eq(email), anyString()))
                 .thenReturn(CompletableFuture.completedFuture("done"));
@@ -142,7 +143,7 @@ public class ServiceInviteCreatorTest {
         when(userDao.findByEmail(email)).thenReturn(Optional.empty());
         when(sender.getExternalId()).thenReturn("inviter-id");
         when(sender.getEmail()).thenReturn("inviter@example.com");
-        when(inviteDao.findByEmail(email)).thenReturn(newArrayList(validInvite));
+        when(inviteDao.findByEmail(email)).thenReturn(List.of(validInvite));
         when(linksConfig.getSelfserviceInvitesUrl()).thenReturn("http://selfservice/invites");
         when(notificationService.sendServiceInviteEmail(eq(email), matches("^http://selfservice/invites/[0-9a-z]{32}$")))
                 .thenReturn(CompletableFuture.completedFuture("done"));
@@ -198,7 +199,7 @@ public class ServiceInviteCreatorTest {
         String email = "email@example.gov.uk";
         InviteServiceRequest request = new InviteServiceRequest("password", email, "01134960000");
         when(userDao.findByEmail(email)).thenReturn(Optional.empty());
-        when(inviteDao.findByEmail(email)).thenReturn(newArrayList());
+        when(inviteDao.findByEmail(email)).thenReturn(emptyList());
         when(roleDao.findByRoleName("admin")).thenReturn(Optional.empty());
 
         thrown.expect(WebApplicationException.class);

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceRoleCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceRoleCreatorTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.adminusers.service;
 
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -24,7 +23,7 @@ import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 import javax.ws.rs.WebApplicationException;
 import java.util.Optional;
 
-import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
@@ -131,7 +130,7 @@ public class ServiceRoleCreatorTest {
 
     private User aUser(String externalId) {
         return User.from(randomInt(), externalId, "random-name", "random-password", "random@example.com",
-                "784rh", "8948924", newArrayList(), null, SecondFactorMethod.SMS,
+                "784rh", "8948924", emptyList(), null, SecondFactorMethod.SMS,
                 null, null, null);
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceRoleUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceRoleUpdaterTest.java
@@ -25,7 +25,7 @@ import javax.ws.rs.WebApplicationException;
 import java.util.Collections;
 import java.util.Optional;
 
-import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
@@ -172,7 +172,7 @@ public class ServiceRoleUpdaterTest {
 
     private User aUser(String externalId) {
         return User.from(randomInt(), externalId, "random-name", "random-password", "random@example.com",
-                "784rh", "8948924", newArrayList(), null, SecondFactorMethod.SMS,
+                "784rh", "8948924", emptyList(), null, SecondFactorMethod.SMS,
                 null, null, null);
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceUpdaterTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -20,12 +19,10 @@ import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
 import javax.ws.rs.WebApplicationException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.String.valueOf;
 import static java.util.Arrays.asList;
 import static java.util.Optional.of;
@@ -108,7 +105,7 @@ public class ServiceUpdaterTest {
     public void shouldSuccess_updateCustomBranding_whenBrandingProvided() {
         ServiceUpdateRequest request = mock(ServiceUpdateRequest.class);
         ServiceEntity serviceEntity = mock(ServiceEntity.class);
-        Map<String, Object> customBranding = ImmutableMap.of("image_url", "image url", "css_url", "css url");
+        Map<String, Object> customBranding = Map.of("image_url", "image url", "css_url", "css url");
 
         when(request.getPath()).thenReturn("custom_branding");
         when(request.valueAsObject()).thenReturn(customBranding);
@@ -197,7 +194,7 @@ public class ServiceUpdaterTest {
 
     @Test
     public void shouldUpdateRedirectImmediatelySuccessfully() {
-        ServiceUpdateRequest request = ServiceUpdateRequest.from(new ObjectNode(JsonNodeFactory.instance, ImmutableMap.of(
+        ServiceUpdateRequest request = ServiceUpdateRequest.from(new ObjectNode(JsonNodeFactory.instance, Map.of(
                 "path", new TextNode("redirect_to_service_immediately_on_terminal_state"),
                 "value", BooleanNode.valueOf(true),
                 "op", new TextNode("replace"))));
@@ -215,7 +212,7 @@ public class ServiceUpdaterTest {
 
     @Test
     public void shouldUpdateCollectBillingAddressSuccessfully() {
-        ServiceUpdateRequest request = ServiceUpdateRequest.from(new ObjectNode(JsonNodeFactory.instance, ImmutableMap.of(
+        ServiceUpdateRequest request = ServiceUpdateRequest.from(new ObjectNode(JsonNodeFactory.instance, Map.of(
                 "path", new TextNode("collect_billing_address"),
                 "value", BooleanNode.valueOf(false),
                 "op", new TextNode("replace"))));
@@ -276,7 +273,7 @@ public class ServiceUpdaterTest {
         String email = "someone@example.com";
         String telephoneNumber = "000";
 
-        ArrayList<ServiceUpdateRequest> serviceUpdateRequests = newArrayList(
+        List<ServiceUpdateRequest> serviceUpdateRequests = List.of(
                 serviceUpdateRequest("replace", "merchant_details/name", name),
                 serviceUpdateRequest("replace", "merchant_details/address_line1", addressLine1),
                 serviceUpdateRequest("replace", "merchant_details/address_line2", addressLine2),
@@ -328,7 +325,7 @@ public class ServiceUpdaterTest {
 
     private static ServiceUpdateRequest serviceUpdateRequest(String op, String path, String value) {
         return ServiceUpdateRequest.from(
-                new ObjectNode(JsonNodeFactory.instance, ImmutableMap.of(
+                new ObjectNode(JsonNodeFactory.instance, Map.of(
                         "op", new TextNode(op),
                         "path", new TextNode(path),
                         "value", new TextNode(value))));

--- a/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.adminusers.service;
 
-
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Before;
@@ -32,10 +31,11 @@ import uk.gov.pay.commons.model.SupportedLanguage;
 import javax.ws.rs.WebApplicationException;
 import java.time.ZonedDateTime;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Collections.emptyList;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertFalse;
@@ -162,7 +162,7 @@ public class UserInviteCreatorTest {
         InviteEntity anInvite = anInvite(email, inviteCode, "otpKey", someOtherSender, service, role);
 
 
-        when(mockInviteDao.findByEmail(email)).thenReturn(newArrayList(anInvite));
+        when(mockInviteDao.findByEmail(email)).thenReturn(List.of(anInvite));
         InviteUserRequest inviteUserRequest = inviteRequestFrom(senderExternalId, email, roleName);
         thrown.expect(WebApplicationException.class);
         thrown.expectMessage("HTTP 409 Conflict");
@@ -288,7 +288,7 @@ public class UserInviteCreatorTest {
         nonMatchingServiceInvite.setService(serviceEntity);
         nonMatchingServiceInvite.setExpiryDate(ZonedDateTime.now().plusDays(1));
 
-        when(mockInviteDao.findByEmail(email)).thenReturn(newArrayList(expiredInvite, disabledInvite, emptyServiceInvite, nonMatchingServiceInvite, validInvite));
+        when(mockInviteDao.findByEmail(email)).thenReturn(List.of(expiredInvite, disabledInvite, emptyServiceInvite, nonMatchingServiceInvite, validInvite));
 
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(UserEntity.from(aUser(email))));
         CompletableFuture<String> notifyPromise = CompletableFuture.completedFuture("random-notify-id");
@@ -321,7 +321,7 @@ public class UserInviteCreatorTest {
 
         String inviteCode = randomUuid();
         InviteEntity anInvite = anInvite(email, inviteCode, "otpKey", sameSender, service, role);
-        when(mockInviteDao.findByEmail(email)).thenReturn(newArrayList(anInvite));
+        when(mockInviteDao.findByEmail(email)).thenReturn(List.of(anInvite));
         return anInvite;
     }
 
@@ -332,7 +332,7 @@ public class UserInviteCreatorTest {
         service.setExternalId(serviceExternalId);
 
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
-        when(mockInviteDao.findByEmail(email)).thenReturn(newArrayList());
+        when(mockInviteDao.findByEmail(email)).thenReturn(emptyList());
         when(mockServiceDao.findByExternalId(serviceExternalId)).thenReturn(Optional.of(service));
         when(mockRoleDao.findByRoleName(roleName)).thenReturn(Optional.of(new RoleEntity()));
         when(linksConfig.getSelfserviceInvitesUrl()).thenReturn("http://selfservice/invites");

--- a/src/test/java/uk/gov/pay/adminusers/service/UserOtpDispatcherTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserOtpDispatcherTest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.adminusers.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,6 +13,7 @@ import uk.gov.pay.adminusers.model.InviteType;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -51,7 +51,7 @@ public class UserOtpDispatcherTest {
         inviteEntity.setType(InviteType.USER);
         inviteEntity.setOtpKey("otp-key");
 
-        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("telephone_number", telephone, "password", "random"));
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("telephone_number", telephone, "password", "random"));
         userOtpDispatcher = userOtpDispatcher.withData(InviteOtpRequest.from(payload));
 
         when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));

--- a/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.adminusers.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,11 +31,12 @@ import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.util.Collections.emptyList;
 import static org.exparity.hamcrest.date.ZonedDateTimeMatchers.within;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
@@ -235,7 +235,7 @@ public class UserServicesTest {
     public void shouldReturnUser_whenIncrementingSessionVersion_ifUserFound() {
         User user = aUser();
 
-        JsonNode node = new ObjectMapper().valueToTree(ImmutableMap.of("path", "sessionVersion", "op", "append", "value", "2"));
+        JsonNode node = new ObjectMapper().valueToTree(Map.of("path", "sessionVersion", "op", "append", "value", "2"));
         UserEntity userEntity = aUserEntityWithTrimmings(user);
 
         Optional<UserEntity> userEntityOptional = Optional.of(userEntity);
@@ -252,7 +252,7 @@ public class UserServicesTest {
     public void shouldReturnUser_withDisabled_ifUserFoundDuringPatch() {
         User user = aUser();
 
-        JsonNode node = new ObjectMapper().valueToTree(ImmutableMap.of("path", "disabled", "op", "replace", "value", "true"));
+        JsonNode node = new ObjectMapper().valueToTree(Map.of("path", "disabled", "op", "replace", "value", "true"));
 
         UserEntity userEntity = aUserEntityWithTrimmings(user);
 
@@ -274,7 +274,7 @@ public class UserServicesTest {
         user.setDisabled(Boolean.TRUE);
         user.setLoginCounter(11);
 
-        JsonNode node = new ObjectMapper().valueToTree(ImmutableMap.of("path", "disabled", "op", "replace", "value", "false"));
+        JsonNode node = new ObjectMapper().valueToTree(Map.of("path", "disabled", "op", "replace", "value", "false"));
         UserEntity userEntity = aUserEntityWithTrimmings(user);
         Optional<UserEntity> userEntityOptional = Optional.of(userEntity);
         when(userDao.findByExternalId(USER_EXTERNAL_ID)).thenReturn(userEntityOptional);
@@ -296,7 +296,7 @@ public class UserServicesTest {
         userEntity.setTelephoneNumber("+447700900000");
 
         String newTelephoneNumber = "+441134960000";
-        JsonNode node = new ObjectMapper().valueToTree(ImmutableMap.of("path", "telephone_number", "op", "replace", "value", newTelephoneNumber));
+        JsonNode node = new ObjectMapper().valueToTree(Map.of("path", "telephone_number", "op", "replace", "value", newTelephoneNumber));
         Optional<UserEntity> userEntityOptional = Optional.of(userEntity);
         ArgumentCaptor<UserEntity> argumentCaptor = ArgumentCaptor.forClass(UserEntity.class);
 
@@ -320,7 +320,7 @@ public class UserServicesTest {
         userEntity.setFeatures("1");
 
         String newFeature = "1,2,3";
-        JsonNode node = new ObjectMapper().valueToTree(ImmutableMap.of("path", "features", "op", "replace", "value", newFeature));
+        JsonNode node = new ObjectMapper().valueToTree(Map.of("path", "features", "op", "replace", "value", newFeature));
         Optional<UserEntity> userEntityOptional = Optional.of(userEntity);
         ArgumentCaptor<UserEntity> argumentCaptor = ArgumentCaptor.forClass(UserEntity.class);
 
@@ -725,13 +725,13 @@ public class UserServicesTest {
 
     private User aUser() {
         return User.from(randomInt(), USER_EXTERNAL_ID, USER_USERNAME, "random-password",
-                "email@example.com","784rh", "8948924", newArrayList(),
+                "email@example.com","784rh", "8948924", emptyList(),
                 null, SecondFactorMethod.SMS,null, null, null);
     }
 
     private User anotherUser() {
         return User.from(randomInt(), ANOTHER_USER_EXTERNAL_ID, ANOTHER_USER_USERNAME, "random-password",
-                "email@example.com", "784rh", "8948924", newArrayList(),
+                "email@example.com", "784rh", "8948924", emptyList(),
                 null, SecondFactorMethod.SMS, null, null, null);
     }
 
@@ -746,7 +746,7 @@ public class UserServicesTest {
     private UserEntity aUserEntityWithTrimmings(User user) {
         UserEntity userEntity = UserEntity.from(user);
 
-        ServiceEntity serviceEntity = new ServiceEntity(newArrayList("a-gateway-account"));
+        ServiceEntity serviceEntity = new ServiceEntity(List.of("a-gateway-account"));
         serviceEntity.addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.ENGLISH, Service.DEFAULT_NAME_VALUE));
         serviceEntity.setId(randomInt());
 

--- a/src/test/java/uk/gov/pay/adminusers/utils/ErrorsTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/ErrorsTest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.adminusers.utils;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -26,7 +25,7 @@ public class ErrorsTest {
 
     @Test
     public void shouldMarshalMultipleErrorsCorrectly() throws Exception {
-        List<String> errorList = ImmutableList.of("Error 1", "Error 2", "Error 3");
+        List<String> errorList = List.of("Error 1", "Error 2", "Error 3");
         Errors errors = Errors.from(errorList);
 
         String errorsJson = mapper.writeValueAsString(errors);


### PR DESCRIPTION
Now that we have {List,Map}.of and friends, we don't need to lean on guava for
its collections classes any more.

Remove guava collections from tests