### PR TITLE
REP: Stop misusing asynchronous calls to Notify

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersModule.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersModule.java
@@ -98,7 +98,6 @@ public class AdminUsersModule extends AbstractModule {
     @Provides
     private NotificationService provideUserNotificationService() {
         return new NotificationService(
-                environment.lifecycle().executorService("2fa-sms-%d").build(),
                 configuration.getNotifyConfiguration(),
                 configuration.getNotifyDirectDebitConfiguration(),
                 environment.metrics());

--- a/src/main/java/uk/gov/pay/adminusers/service/EmailService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/EmailService.java
@@ -16,7 +16,6 @@ import uk.gov.pay.commons.model.SupportedLanguage;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.StringJoiner;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 import static uk.gov.pay.adminusers.model.PaymentType.DIRECT_DEBIT;
@@ -117,11 +116,11 @@ public class EmailService {
                 .orElseThrow(() -> new ServiceNotFoundException("Service not found"));
     }
 
-    public CompletableFuture<String> sendEmail(String email, String gatewayAccountId, EmailTemplate template, Map<String, String> dynamicContent) throws InvalidMerchantDetailsException {
+    public String sendEmail(String email, String gatewayAccountId, EmailTemplate template, Map<String, String> dynamicContent) throws InvalidMerchantDetailsException {
         StaticEmailContent staticEmailContent = getTemplateMappingsFor(gatewayAccountId).get(template);
         Map<String, String> staticContent = new HashMap<>(staticEmailContent.getPersonalisation());
         staticContent.putAll(dynamicContent);
         LOGGER.info("Sending direct debit email for " + template.toString());
-        return notificationService.sendEmailAsync(DIRECT_DEBIT, staticEmailContent.getTemplateId(), email, staticContent);
+        return notificationService.sendEmail(DIRECT_DEBIT, staticEmailContent.getTemplateId(), email, staticContent);
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteService.java
@@ -62,14 +62,15 @@ public class InviteService {
             inviteDao.merge(invite);
             int newPassCode = secondFactorAuthenticator.newPassCode(invite.getOtpKey());
             String passcode = String.format(Locale.ENGLISH, SIX_DIGITS_WITH_LEADING_ZEROS, newPassCode);
-            notificationService.sendSecondFactorPasscodeSms(inviteOtpRequest.getTelephoneNumber(), passcode)
-                    .thenAcceptAsync(notificationId -> LOGGER.info("sent 2FA token successfully for invite code [{}], notification id [{}]",
-                            inviteOtpRequest.getCode(), notificationId))
-                    .exceptionally(exception -> {
-                        LOGGER.error(format("error sending 2FA token for invite code [%s]", inviteOtpRequest.getCode()), exception);
-                        return null;
-                    });
+            
             LOGGER.info("New 2FA token generated for invite code [{}]", inviteOtpRequest.getCode());
+            
+            try {
+                String notificationId = notificationService.sendSecondFactorPasscodeSms(inviteOtpRequest.getTelephoneNumber(), passcode);
+                LOGGER.info("sent 2FA token successfully for invite code [{}], notification id [{}]", inviteOtpRequest.getCode(), notificationId);
+            } catch (Exception e) {
+                LOGGER.error(format("error sending 2FA token for invite code [%s]", inviteOtpRequest.getCode()), e);
+            }
         } else {
             throw notFoundInviteException(inviteOtpRequest.getCode());
         }

--- a/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
@@ -10,9 +10,6 @@ import uk.gov.service.notify.SendEmailResponse;
 import uk.gov.service.notify.SendSmsResponse;
 
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
@@ -21,7 +18,6 @@ import static uk.gov.pay.adminusers.model.Service.DEFAULT_NAME_VALUE;
 
 public class NotificationService {
 
-    private final ExecutorService executorService;
     private final NotifyClientProvider notifyClientProvider;
     private final MetricRegistry metricRegistry;
     private final NotifyConfiguration notifyConfiguration;
@@ -32,11 +28,9 @@ public class NotificationService {
     private final String forgottenPasswordEmailTemplateId;
     private final String inviteExistingUserEmailTemplateId;
 
-    public NotificationService(ExecutorService executorService,
-                               NotifyConfiguration notifyConfiguration,
+    public NotificationService(NotifyConfiguration notifyConfiguration,
                                NotifyDirectDebitConfiguration notifyDirectDebitConfiguration,
                                MetricRegistry metricRegistry) {
-        this.executorService = executorService;
         this.notifyConfiguration = notifyConfiguration;
         this.notifyDirectDebitConfiguration = notifyDirectDebitConfiguration;
 
@@ -49,63 +43,57 @@ public class NotificationService {
         this.metricRegistry = metricRegistry;
     }
 
-    NotifyConfiguration getNotifyConfiguration() {
-        return notifyConfiguration;
-    }
-
     NotifyDirectDebitConfiguration getNotifyDirectDebitConfiguration() {
         return notifyDirectDebitConfiguration;
     }
 
-    CompletableFuture<String> sendSecondFactorPasscodeSms(String phoneNumber, String passcode) {
-        return CompletableFuture.supplyAsync(() -> {
-            Stopwatch responseTimeStopwatch = Stopwatch.createStarted();
-            try {
-                SendSmsResponse response = notifyClientProvider.get(CARD).sendSms(secondFactorSmsTemplateId, TelephoneNumberUtility.formatToE164(phoneNumber), Map.of("code", passcode), null);
-                return response.getNotificationId().toString();
-            } catch (Exception e) {
-                metricRegistry.counter("notify-operations.sms.failures").inc();
-                throw AdminUsersExceptions.userNotificationError(e);
-            } finally {
-                responseTimeStopwatch.stop();
-                metricRegistry.histogram("notify-operations.sms.response_time").update(responseTimeStopwatch.elapsed(TimeUnit.MILLISECONDS));
-            }
-        }, executorService);
+    String sendSecondFactorPasscodeSms(String phoneNumber, String passcode) {
+        Stopwatch responseTimeStopwatch = Stopwatch.createStarted();
+        try {
+            SendSmsResponse response = notifyClientProvider.get(CARD).sendSms(secondFactorSmsTemplateId, TelephoneNumberUtility.formatToE164(phoneNumber), Map.of("code", passcode), null);
+            return response.getNotificationId().toString();
+        } catch (Exception e) {
+            metricRegistry.counter("notify-operations.sms.failures").inc();
+            throw AdminUsersExceptions.userNotificationError(e);
+        } finally {
+            responseTimeStopwatch.stop();
+            metricRegistry.histogram("notify-operations.sms.response_time").update(responseTimeStopwatch.elapsed(TimeUnit.MILLISECONDS));
+        }
     }
 
-    CompletableFuture<String> sendInviteEmail(String sender, String email, String inviteUrl) {
+    String sendInviteEmail(String sender, String email, String inviteUrl) {
         Map<String, String> personalisation = Map.of(
                 "username", sender,
                 "link", inviteUrl);
-        return sendEmailAsync(CARD, inviteEmailTemplateId, email, personalisation);
+        return sendEmail(CARD, inviteEmailTemplateId, email, personalisation);
     }
 
-    CompletableFuture<String> sendServiceInviteEmail(String email, String inviteUrl) {
+    String sendServiceInviteEmail(String email, String inviteUrl) {
         Map<String, String> personalisation = Map.of(
                 "name", email,
                 "link", inviteUrl);
-        return sendEmailAsync(CARD, notifyConfiguration.getInviteServiceEmailTemplateId(), email, personalisation);
+        return sendEmail(CARD, notifyConfiguration.getInviteServiceEmailTemplateId(), email, personalisation);
     }
 
-    CompletableFuture<String> sendForgottenPasswordEmail(String email, String forgottenPasswordUrl) {
+    String sendForgottenPasswordEmail(String email, String forgottenPasswordUrl) {
         Map<String, String> personalisation = Map.of("code", forgottenPasswordUrl);
-        return sendEmailAsync(CARD, forgottenPasswordEmailTemplateId, email, personalisation);
+        return sendEmail(CARD, forgottenPasswordEmailTemplateId, email, personalisation);
     }
 
-    CompletionStage<String> sendServiceInviteUserExistsEmail(String email, String signInLink, String forgottenPasswordLink, String feedbackLink) {
+    String sendServiceInviteUserExistsEmail(String email, String signInLink, String forgottenPasswordLink, String feedbackLink) {
         Map<String, String> personalisation = Map.of(
                 "signin_link", signInLink,
                 "forgotten_password_link", forgottenPasswordLink,
                 "feedback_link", feedbackLink);
-        return sendEmailAsync(CARD, notifyConfiguration.getInviteServiceUserExistsEmailTemplateId(), email, personalisation);
+        return sendEmail(CARD, notifyConfiguration.getInviteServiceUserExistsEmailTemplateId(), email, personalisation);
     }
 
-    CompletableFuture<String> sendServiceInviteUserDisabledEmail(String email, String supportUrl) {
+    String sendServiceInviteUserDisabledEmail(String email, String supportUrl) {
         Map<String, String> personalisation = Map.of("feedback_link", supportUrl);
-        return sendEmailAsync(CARD, notifyConfiguration.getInviteServiceUserDisabledEmailTemplateId(), email, personalisation);
+        return sendEmail(CARD, notifyConfiguration.getInviteServiceUserDisabledEmailTemplateId(), email, personalisation);
     }
 
-    CompletableFuture<String> sendInviteExistingUserEmail(String sender, String email, String inviteUrl, String serviceName) {
+    String sendInviteExistingUserEmail(String sender, String email, String inviteUrl, String serviceName) {
         String collaborateServiceNamePart;
         String joinServiceNamePart;
 
@@ -124,27 +112,25 @@ public class NotificationService {
                 "joinServiceNamePart", joinServiceNamePart
         );
 
-        return sendEmailAsync(CARD, inviteExistingUserEmailTemplateId, email, personalisation);
+        return sendEmail(CARD, inviteExistingUserEmailTemplateId, email, personalisation);
     }
 
-    CompletableFuture<String> sendLiveAccountCreatedEmail(String email, String serviceLiveAccountLink) {
+    String sendLiveAccountCreatedEmail(String email, String serviceLiveAccountLink) {
         Map<String, String> personalisation = Map.of("service_live_account_link", serviceLiveAccountLink);
-        return sendEmailAsync(CARD, notifyConfiguration.getLiveAccountCreatedEmailTemplateId(), email, personalisation);
+        return sendEmail(CARD, notifyConfiguration.getLiveAccountCreatedEmailTemplateId(), email, personalisation);
     }
 
-    public CompletableFuture<String> sendEmailAsync(PaymentType paymentType, final String templateId, final String email, final Map<String, String> personalisation) {
-        return CompletableFuture.supplyAsync(() -> {
-            Stopwatch responseTimeStopwatch = Stopwatch.createStarted();
-            try {
-                SendEmailResponse response = notifyClientProvider.get(paymentType).sendEmail(templateId, email, personalisation, null);
-                return response.getNotificationId().toString();
-            } catch (Exception e) {
-                metricRegistry.counter("notify-operations.email.failures").inc();
-                throw AdminUsersExceptions.userNotificationError(e);
-            } finally {
-                responseTimeStopwatch.stop();
-                metricRegistry.histogram("notify-operations.email.response_time").update(responseTimeStopwatch.elapsed(TimeUnit.MILLISECONDS));
-            }
-        }, executorService);
+    public String sendEmail(PaymentType paymentType, final String templateId, final String email, final Map<String, String> personalisation) {
+        Stopwatch responseTimeStopwatch = Stopwatch.createStarted();
+        try {
+            SendEmailResponse response = notifyClientProvider.get(paymentType).sendEmail(templateId, email, personalisation, null);
+            return response.getNotificationId().toString();
+        } catch (Exception e) {
+            metricRegistry.counter("notify-operations.email.failures").inc();
+            throw AdminUsersExceptions.userNotificationError(e);
+        } finally {
+            responseTimeStopwatch.stop();
+            metricRegistry.histogram("notify-operations.email.response_time").update(responseTimeStopwatch.elapsed(TimeUnit.MILLISECONDS));
+        }
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
@@ -43,11 +43,11 @@ public class NotificationService {
         this.metricRegistry = metricRegistry;
     }
 
-    NotifyDirectDebitConfiguration getNotifyDirectDebitConfiguration() {
+    public NotifyDirectDebitConfiguration getNotifyDirectDebitConfiguration() {
         return notifyDirectDebitConfiguration;
     }
 
-    String sendSecondFactorPasscodeSms(String phoneNumber, String passcode) {
+    public String sendSecondFactorPasscodeSms(String phoneNumber, String passcode) {
         Stopwatch responseTimeStopwatch = Stopwatch.createStarted();
         try {
             SendSmsResponse response = notifyClientProvider.get(CARD).sendSms(secondFactorSmsTemplateId, TelephoneNumberUtility.formatToE164(phoneNumber), Map.of("code", passcode), null);
@@ -61,26 +61,26 @@ public class NotificationService {
         }
     }
 
-    String sendInviteEmail(String sender, String email, String inviteUrl) {
+    public String sendInviteEmail(String sender, String email, String inviteUrl) {
         Map<String, String> personalisation = Map.of(
                 "username", sender,
                 "link", inviteUrl);
         return sendEmail(CARD, inviteEmailTemplateId, email, personalisation);
     }
 
-    String sendServiceInviteEmail(String email, String inviteUrl) {
+    public String sendServiceInviteEmail(String email, String inviteUrl) {
         Map<String, String> personalisation = Map.of(
                 "name", email,
                 "link", inviteUrl);
         return sendEmail(CARD, notifyConfiguration.getInviteServiceEmailTemplateId(), email, personalisation);
     }
 
-    String sendForgottenPasswordEmail(String email, String forgottenPasswordUrl) {
+    public String sendForgottenPasswordEmail(String email, String forgottenPasswordUrl) {
         Map<String, String> personalisation = Map.of("code", forgottenPasswordUrl);
         return sendEmail(CARD, forgottenPasswordEmailTemplateId, email, personalisation);
     }
 
-    String sendServiceInviteUserExistsEmail(String email, String signInLink, String forgottenPasswordLink, String feedbackLink) {
+    public String sendServiceInviteUserExistsEmail(String email, String signInLink, String forgottenPasswordLink, String feedbackLink) {
         Map<String, String> personalisation = Map.of(
                 "signin_link", signInLink,
                 "forgotten_password_link", forgottenPasswordLink,
@@ -88,12 +88,12 @@ public class NotificationService {
         return sendEmail(CARD, notifyConfiguration.getInviteServiceUserExistsEmailTemplateId(), email, personalisation);
     }
 
-    String sendServiceInviteUserDisabledEmail(String email, String supportUrl) {
+    public String sendServiceInviteUserDisabledEmail(String email, String supportUrl) {
         Map<String, String> personalisation = Map.of("feedback_link", supportUrl);
         return sendEmail(CARD, notifyConfiguration.getInviteServiceUserDisabledEmailTemplateId(), email, personalisation);
     }
 
-    String sendInviteExistingUserEmail(String sender, String email, String inviteUrl, String serviceName) {
+    public String sendInviteExistingUserEmail(String sender, String email, String inviteUrl, String serviceName) {
         String collaborateServiceNamePart;
         String joinServiceNamePart;
 
@@ -115,7 +115,7 @@ public class NotificationService {
         return sendEmail(CARD, inviteExistingUserEmailTemplateId, email, personalisation);
     }
 
-    String sendLiveAccountCreatedEmail(String email, String serviceLiveAccountLink) {
+    public String sendLiveAccountCreatedEmail(String email, String serviceLiveAccountLink) {
         Map<String, String> personalisation = Map.of("service_live_account_link", serviceLiveAccountLink);
         return sendEmail(CARD, notifyConfiguration.getLiveAccountCreatedEmailTemplateId(), email, personalisation);
     }

--- a/src/main/java/uk/gov/pay/adminusers/service/SendLiveAccountCreatedEmailService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/SendLiveAccountCreatedEmailService.java
@@ -38,11 +38,11 @@ public class SendLiveAccountCreatedEmailService {
                 .build()
                 .toString();
 
-        notificationService.sendLiveAccountCreatedEmail(agreement.getEmail(), serviceLiveAccountUrl)
-                .thenAcceptAsync(notificationId -> LOGGER.info("Sent service is live email successfully, notification id [{}]", notificationId))
-                .exceptionally(exception -> {
-                    LOGGER.error("Error sending service is live email", exception);
-                    return null;
-                });
+        try {
+            String notificationId = notificationService.sendLiveAccountCreatedEmail(agreement.getEmail(), serviceLiveAccountUrl);
+            LOGGER.info("Sent service is live email successfully, notification id [{}]", notificationId);
+        } catch(Exception e) {
+            LOGGER.error("Error sending service is live email", e);
+        }
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceInviteCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceInviteCreator.java
@@ -100,32 +100,32 @@ public class ServiceInviteCreator {
     }
 
     private void sendServiceInviteNotification(InviteEntity invite, String targetUrl) {
-        notificationService.sendServiceInviteEmail(invite.getEmail(), targetUrl)
-                .thenAcceptAsync(notificationId -> LOGGER.info("sent create service invitation email successfully, notification id [{}]", notificationId))
-                .exceptionally(exception -> {
-                    LOGGER.error("error sending create service invitation", exception);
-                    return null;
-                });
         LOGGER.info("New service creation invitation created");
+        try {
+            String notificationId = notificationService.sendServiceInviteEmail(invite.getEmail(), targetUrl);
+            LOGGER.info("sent create service invitation email successfully, notification id [{}]", notificationId);
+        } catch(Exception e) {
+            LOGGER.error("error sending create service invitation", e);
+        }
     }
 
     private void sendUserDisabledNotification(String email, String userExternalId) {
-        notificationService.sendServiceInviteUserDisabledEmail(email, linksConfig.getSupportUrl())
-                .thenAcceptAsync(notificationId -> LOGGER.info("sent create service, user account disabled email successfully, notification id [{}]", notificationId))
-                .exceptionally(exception -> {
-                    LOGGER.error("error sending service creation, user account disabled email", exception);
-                    return null;
-                });
         LOGGER.info("Disabled existing user tried to create a service - user_id={}", userExternalId);
+        try {
+            String notificationId = notificationService.sendServiceInviteUserDisabledEmail(email, linksConfig.getSupportUrl());
+            LOGGER.info("sent create service, user account disabled email successfully, notification id [{}]", notificationId);
+        } catch (Exception e) {
+            LOGGER.error("error sending service creation, user account disabled email", e);
+        }
     }
 
     private void sendUserExistsNotification(String email, String userExternalId) {
-        notificationService.sendServiceInviteUserExistsEmail(email, linksConfig.getSelfserviceLoginUrl(), linksConfig.getSelfserviceForgottenPasswordUrl(), linksConfig.getSupportUrl())
-                .thenAcceptAsync(notificationId -> LOGGER.info("sent create service, user exists email successfully, notification id [{}]", notificationId))
-                .exceptionally(exception -> {
-                    LOGGER.error("error sending service creation, users exists email", exception);
-                    return null;
-                });
         LOGGER.info("Existing user tried to create a service - user_id={}", userExternalId);
+        try {
+            String notificationId = notificationService.sendServiceInviteUserExistsEmail(email, linksConfig.getSelfserviceLoginUrl(), linksConfig.getSelfserviceForgottenPasswordUrl(), linksConfig.getSupportUrl());
+            LOGGER.info("sent create service, user exists email successfully, notification id [{}]", notificationId);
+        } catch (Exception e) {
+            LOGGER.error("error sending service creation, users exists email", e);
+        }
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/UserInviteCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserInviteCreator.java
@@ -108,22 +108,20 @@ public class UserInviteCreator {
 
     private void sendUserInviteNotification(InviteEntity inviteEntity, String inviteUrl, ServiceEntity serviceEntity, Optional<UserEntity> existingUser) {
         UserEntity sender = inviteEntity.getSender();
-        if (existingUser.isPresent()) {
-            String serviceName = serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName();
-            notificationService.sendInviteExistingUserEmail(inviteEntity.getSender().getEmail(), inviteEntity.getEmail(), inviteUrl, serviceName)
-                    .thenAcceptAsync(notificationId -> LOGGER.info("sent invite email successfully by user [{}], notification id [{}]", sender.getExternalId(), notificationId))
-                    .exceptionally(exception -> {
-                        LOGGER.error(format("error sending email by user [%s]", sender.getExternalId()), exception);
-                        return null;
-                    });
-        } else {
-            notificationService.sendInviteEmail(inviteEntity.getSender().getEmail(), inviteEntity.getEmail(), inviteUrl)
-                    .thenAcceptAsync(notificationId -> LOGGER.info("sent invite email successfully by user [{}], notification id [{}]", sender.getExternalId(), notificationId))
-                    .exceptionally(exception -> {
-                        LOGGER.error(format("error sending email by user [%s]", sender.getExternalId()), exception);
-                        return null;
-                    });
-        }
         LOGGER.info("New invite created by User [{}]", sender.getExternalId());
+        try {
+            String notificationId;
+            
+            if (existingUser.isPresent()) {
+                String serviceName = serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName();
+                notificationId = notificationService.sendInviteExistingUserEmail(inviteEntity.getSender().getEmail(), inviteEntity.getEmail(), inviteUrl, serviceName);
+            } else {
+                notificationId = notificationService.sendInviteEmail(inviteEntity.getSender().getEmail(), inviteEntity.getEmail(), inviteUrl);
+            }
+
+            LOGGER.info("sent invite email successfully by user [{}], notification id [{}]", sender.getExternalId(), notificationId);
+        } catch(Exception e) {
+            LOGGER.error(format("error sending email by user [%s]", sender.getExternalId()), e);
+        }
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/UserOtpDispatcher.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserOtpDispatcher.java
@@ -37,14 +37,15 @@ public class UserOtpDispatcher extends InviteOtpDispatcher {
                     inviteDao.merge(inviteEntity);
                     int newPassCode = secondFactorAuthenticator.newPassCode(inviteEntity.getOtpKey());
                     String passcode = format(Locale.ENGLISH, SIX_DIGITS_WITH_LEADING_ZEROS, newPassCode);
-                    notificationService.sendSecondFactorPasscodeSms(inviteOtpRequest.getTelephoneNumber(), passcode)
-                            .thenAcceptAsync(notificationId -> LOGGER.info("sent 2FA token successfully for invite code [{}], notification id [{}]",
-                                    inviteCode, notificationId))
-                            .exceptionally(exception -> {
-                                LOGGER.error(format("error sending 2FA token for invite code [%s]", inviteCode), exception);
-                                return null;
-                            });
                     LOGGER.info("New 2FA token generated for invite code [{}]", inviteCode);
+                    
+                    try {
+                        String notificationId = notificationService.sendSecondFactorPasscodeSms(inviteOtpRequest.getTelephoneNumber(), passcode);
+                        LOGGER.info("sent 2FA token successfully for invite code [{}], notification id [{}]", inviteCode, notificationId);
+                    } catch (Exception e) {
+                        LOGGER.error(format("error sending 2FA token for invite code [%s]", inviteCode), e);
+                    }
+                    
                     return true;
                 }).orElseGet(() -> {
                     LOGGER.info("New 2FA token generated for invite code [{}]", inviteCode);

--- a/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
@@ -137,13 +137,14 @@ public class UserServices {
                         int newPassCode = secondFactorAuthenticator.newPassCode(otpKey);
                         SecondFactorToken token = SecondFactorToken.from(externalId, newPassCode);
                         final String userExternalId = userEntity.getExternalId();
-                        notificationService.sendSecondFactorPasscodeSms(userEntity.getTelephoneNumber(), token.getPasscode())
-                                .thenAcceptAsync(notificationId -> logger.info("sent 2FA token successfully to user [{}], notification id [{}]",
-                                        userExternalId, notificationId))
-                                .exceptionally(exception -> {
-                                    logger.error("error sending 2FA token to user [{}]", userExternalId, exception);
-                                    return null;
-                                });
+                        
+                        try {
+                            String notificationId = notificationService.sendSecondFactorPasscodeSms(userEntity.getTelephoneNumber(), token.getPasscode());
+                            logger.info("sent 2FA token successfully to user [{}], notification id [{}]", userExternalId, notificationId);
+                        } catch (Exception e) {
+                            logger.error("error sending 2FA token to user [{}]", userExternalId, e);
+                        }
+                        
                         if (useProvisionalOtpKey) {
                             logger.info("New 2FA token generated for User [{}] from provisional OTP key", userExternalId);
                         } else {

--- a/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
@@ -48,6 +48,9 @@ public class IntegrationTest {
     @ClassRule
     public static final DropwizardClientRule notify;
 
+    protected DatabaseTestHelper databaseHelper;
+    protected ObjectMapper mapper;
+
     @Path("/v2/notifications")
     public static class NotifyResource {
         @Path("/email")
@@ -66,9 +69,6 @@ public class IntegrationTest {
                 ConfigOverride.config("notify.notificationBaseURL", () -> notify.baseUri().toString())
         );
     }
-
-    protected DatabaseTestHelper databaseHelper;
-    protected ObjectMapper mapper;
 
     @Before
     public void setUp() {

--- a/src/test/java/uk/gov/pay/adminusers/service/EmailServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/EmailServiceTest.java
@@ -98,7 +98,7 @@ public class EmailServiceTest {
         ArgumentCaptor<Map<String, String>> personalisationCaptor = forClass(Map.class);
         emailService.sendEmail(EMAIL_ADDRESS, GATEWAY_ACCOUNT_ID, template, personalisation);
 
-        verify(mockNotificationService).sendEmailAsync(eq(PaymentType.DIRECT_DEBIT), eq("NOTIFY_ONE_OFF_MANDATE_AND_PAYMENT_CREATED_EMAIL_TEMPLATE_ID_VALUE"), eq(EMAIL_ADDRESS), personalisationCaptor.capture());
+        verify(mockNotificationService).sendEmail(eq(PaymentType.DIRECT_DEBIT), eq("NOTIFY_ONE_OFF_MANDATE_AND_PAYMENT_CREATED_EMAIL_TEMPLATE_ID_VALUE"), eq(EMAIL_ADDRESS), personalisationCaptor.capture());
         Map<String, String> allContent = personalisationCaptor.getValue();
         assertThat(allContent.get("field 1"), is("theValueOfField1"));
         assertThat(allContent.get("field 2"), is("theValueOfField2"));
@@ -130,7 +130,7 @@ public class EmailServiceTest {
         ArgumentCaptor<Map<String, String>> personalisationCaptor = forClass(Map.class);
         emailService.sendEmail(EMAIL_ADDRESS, GATEWAY_ACCOUNT_ID, template, personalisation);
 
-        verify(mockNotificationService).sendEmailAsync(eq(PaymentType.DIRECT_DEBIT), eq("NOTIFY_ON_DEMAND_PAYMENT_CONFIRMED_EMAIL_TEMPLATE_ID_VALUE"), eq(EMAIL_ADDRESS), personalisationCaptor.capture());
+        verify(mockNotificationService).sendEmail(eq(PaymentType.DIRECT_DEBIT), eq("NOTIFY_ON_DEMAND_PAYMENT_CONFIRMED_EMAIL_TEMPLATE_ID_VALUE"), eq(EMAIL_ADDRESS), personalisationCaptor.capture());
         Map<String, String> allContent = personalisationCaptor.getValue();
         assertThat(allContent.get("field 1"), is("theValueOfField1"));
         assertThat(allContent.get("field 2"), is("theValueOfField2"));
@@ -163,7 +163,7 @@ public class EmailServiceTest {
 
         emailService.sendEmail(EMAIL_ADDRESS, GATEWAY_ACCOUNT_ID, template, personalisation);
 
-        verify(mockNotificationService).sendEmailAsync(eq(PaymentType.DIRECT_DEBIT), eq("NOTIFY_PAYMENT_FAILED_EMAIL_TEMPLATE_ID_VALUE"), eq(EMAIL_ADDRESS), personalisationCaptor.capture());
+        verify(mockNotificationService).sendEmail(eq(PaymentType.DIRECT_DEBIT), eq("NOTIFY_PAYMENT_FAILED_EMAIL_TEMPLATE_ID_VALUE"), eq(EMAIL_ADDRESS), personalisationCaptor.capture());
         Map<String, String> allContent = personalisationCaptor.getValue();
         assertThat(allContent.get("field 1"), is("theValueOfField1"));
         assertThat(allContent.get("field 2"), is("theValueOfField2"));
@@ -194,7 +194,7 @@ public class EmailServiceTest {
 
         emailService.sendEmail(EMAIL_ADDRESS, GATEWAY_ACCOUNT_ID, template, personalisation);
 
-        verify(mockNotificationService).sendEmailAsync(eq(PaymentType.DIRECT_DEBIT), eq("NOTIFY_MANDATE_FAILED_EMAIL_TEMPLATE_ID_VALUE"), eq(EMAIL_ADDRESS), personalisationCaptor.capture());
+        verify(mockNotificationService).sendEmail(eq(PaymentType.DIRECT_DEBIT), eq("NOTIFY_MANDATE_FAILED_EMAIL_TEMPLATE_ID_VALUE"), eq(EMAIL_ADDRESS), personalisationCaptor.capture());
         Map<String, String> allContent = personalisationCaptor.getValue();
         assertThat(allContent.get("field 1"), is("theValueOfField1"));
         assertThat(allContent.get("field 2"), is("theValueOfField2"));
@@ -226,7 +226,7 @@ public class EmailServiceTest {
 
         emailService.sendEmail(EMAIL_ADDRESS, GATEWAY_ACCOUNT_ID, template, personalisation);
 
-        verify(mockNotificationService).sendEmailAsync(eq(PaymentType.DIRECT_DEBIT), eq("NOTIFY_ON_DEMAND_MANDATE_CREATED_EMAIL_TEMPLATE_ID_VALUE"), eq(EMAIL_ADDRESS), personalisationCaptor.capture());
+        verify(mockNotificationService).sendEmail(eq(PaymentType.DIRECT_DEBIT), eq("NOTIFY_ON_DEMAND_MANDATE_CREATED_EMAIL_TEMPLATE_ID_VALUE"), eq(EMAIL_ADDRESS), personalisationCaptor.capture());
         Map<String, String> allContent = personalisationCaptor.getValue();
         assertThat(allContent.get("field 1"), is("theValueOfField1"));
         assertThat(allContent.get("field 2"), is("theValueOfField2"));
@@ -258,7 +258,7 @@ public class EmailServiceTest {
 
         emailService.sendEmail(EMAIL_ADDRESS, GATEWAY_ACCOUNT_ID, template, personalisation);
 
-        verify(mockNotificationService).sendEmailAsync(eq(PaymentType.DIRECT_DEBIT), eq("NOTIFY_ONE_OFF_MANDATE_AND_PAYMENT_CREATED_EMAIL_TEMPLATE_ID_VALUE"), eq(EMAIL_ADDRESS), personalisationCaptor.capture());
+        verify(mockNotificationService).sendEmail(eq(PaymentType.DIRECT_DEBIT), eq("NOTIFY_ONE_OFF_MANDATE_AND_PAYMENT_CREATED_EMAIL_TEMPLATE_ID_VALUE"), eq(EMAIL_ADDRESS), personalisationCaptor.capture());
         Map<String, String> allContent = personalisationCaptor.getValue();
         assertThat(allContent.get("field 1"), is("theValueOfField1"));
         assertThat(allContent.get("field 2"), is("theValueOfField2"));
@@ -315,7 +315,7 @@ public class EmailServiceTest {
         ArgumentCaptor<Map<String, String>> personalisationCaptor = forClass(Map.class);
         emailService.sendEmail(EMAIL_ADDRESS, GATEWAY_ACCOUNT_ID, template, personalisation);
 
-        verify(mockNotificationService).sendEmailAsync(eq(PaymentType.DIRECT_DEBIT), eq("NOTIFY_ONE_OFF_MANDATE_AND_PAYMENT_CREATED_EMAIL_TEMPLATE_ID_VALUE"), eq(EMAIL_ADDRESS), personalisationCaptor.capture());
+        verify(mockNotificationService).sendEmail(eq(PaymentType.DIRECT_DEBIT), eq("NOTIFY_ONE_OFF_MANDATE_AND_PAYMENT_CREATED_EMAIL_TEMPLATE_ID_VALUE"), eq(EMAIL_ADDRESS), personalisationCaptor.capture());
         Map<String, String> allContent = personalisationCaptor.getValue();
         assertThat(allContent.get("field 1"), is("theValueOfField1"));
         assertThat(allContent.get("field 2"), is("theValueOfField2"));

--- a/src/test/java/uk/gov/pay/adminusers/service/SendLiveAccountCreatedEmailServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/SendLiveAccountCreatedEmailServiceTest.java
@@ -15,7 +15,6 @@ import uk.gov.pay.adminusers.persistence.dao.GovUkPayAgreementDao;
 import uk.gov.pay.adminusers.persistence.entity.GovUkPayAgreementEntity;
 
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -57,15 +56,13 @@ public class SendLiveAccountCreatedEmailServiceTest {
         when(mockAgreement.getEmail()).thenReturn(email);
         when(mockGovUkPayAgreementDao.findByExternalServiceId(serviceExternalId)).thenReturn(Optional.of(mockAgreement));
 
-        CompletableFuture<String> notifyPromise = CompletableFuture.completedFuture("random-notify-id");
         ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
         when(mockNotificationService.sendLiveAccountCreatedEmail(eq(email), urlCaptor.capture()))
-                .thenReturn(notifyPromise);
+                .thenReturn("random-notify-id");
         
         sendLiveAccountCreatedEmailService.sendEmail(serviceExternalId);
 
         assertThat(urlCaptor.getValue(), is(SELFSERVICE_SERVICES_URL + '/' + serviceExternalId + "/live-account"));
-        assertThat(notifyPromise.isDone(), is(true));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCreatorTest.java
@@ -21,7 +21,6 @@ import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 import javax.ws.rs.WebApplicationException;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -60,7 +59,7 @@ public class ServiceInviteCreatorTest {
         when(userDao.findByEmail(email)).thenReturn(Optional.empty());
         when(inviteDao.findByEmail(email)).thenReturn(emptyList());
         when(roleDao.findByRoleName("admin")).thenReturn(Optional.of(roleEntity));
-        when(notificationService.sendServiceInviteEmail(eq(email), anyString())).thenReturn(CompletableFuture.completedFuture("done"));
+        when(notificationService.sendServiceInviteEmail(eq(email), anyString())).thenReturn("done");
         when(linksConfig.getSelfserviceInvitesUrl()).thenReturn("http://selfservice/invites");
         when(linksConfig.getSelfserviceUrl()).thenReturn("http://selfservice");
         when(passwordHasher.hash("password")).thenReturn("encrypted-password");
@@ -84,9 +83,7 @@ public class ServiceInviteCreatorTest {
         when(userDao.findByEmail(email)).thenReturn(Optional.empty());
         when(inviteDao.findByEmail(email)).thenReturn(emptyList());
         when(roleDao.findByRoleName("admin")).thenReturn(Optional.of(roleEntity));
-        when(notificationService.sendServiceInviteEmail(eq(email), anyString())).thenReturn(CompletableFuture.supplyAsync(() -> {
-            throw new RuntimeException("done");
-        }));
+        when(notificationService.sendServiceInviteEmail(eq(email), anyString())).thenThrow(AdminUsersExceptions.userNotificationError(new RuntimeException("failed")));
         when(linksConfig.getSelfserviceUrl()).thenReturn("http://selfservice");
         when(linksConfig.getSelfserviceInvitesUrl()).thenReturn("http://selfservice/invites");
         Invite invite = serviceInviteCreator.doInvite(request);
@@ -117,7 +114,7 @@ public class ServiceInviteCreatorTest {
         when(inviteDao.findByEmail(email)).thenReturn(List.of(validInvite));
         when(linksConfig.getSelfserviceInvitesUrl()).thenReturn("http://selfservice/invites");
         when(notificationService.sendServiceInviteEmail(eq(email), anyString()))
-                .thenReturn(CompletableFuture.completedFuture("done"));
+                .thenReturn("done");
 
         Invite invite = serviceInviteCreator.doInvite(request);
 
@@ -146,7 +143,7 @@ public class ServiceInviteCreatorTest {
         when(inviteDao.findByEmail(email)).thenReturn(List.of(validInvite));
         when(linksConfig.getSelfserviceInvitesUrl()).thenReturn("http://selfservice/invites");
         when(notificationService.sendServiceInviteEmail(eq(email), matches("^http://selfservice/invites/[0-9a-z]{32}$")))
-                .thenReturn(CompletableFuture.completedFuture("done"));
+                .thenReturn("done");
 
         Invite invite = serviceInviteCreator.doInvite(request);
 
@@ -167,7 +164,7 @@ public class ServiceInviteCreatorTest {
         when(linksConfig.getSelfserviceLoginUrl()).thenReturn("http://selfservice/login");
         when(linksConfig.getSelfserviceUrl()).thenReturn("http://selfservice");
         when(notificationService.sendServiceInviteUserExistsEmail(eq(email), anyString(), anyString(), anyString()))
-                .thenReturn(CompletableFuture.completedFuture("done"));
+                .thenReturn("done");
 
         thrown.expect(WebApplicationException.class);
         thrown.expectMessage("HTTP 409 Conflict");
@@ -185,7 +182,7 @@ public class ServiceInviteCreatorTest {
         when(userDao.findByEmail(email)).thenReturn(Optional.of(existingUserEntity));
         when(linksConfig.getSupportUrl()).thenReturn("http://frontend");
         when(notificationService.sendServiceInviteUserDisabledEmail(eq(email), anyString()))
-                .thenReturn(CompletableFuture.completedFuture("done"));
+                .thenReturn("done");
 
         thrown.expect(WebApplicationException.class);
         thrown.expectMessage("HTTP 409 Conflict");

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcherTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcherTest.java
@@ -10,7 +10,6 @@ import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
 
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -45,7 +44,7 @@ public class ServiceOtpDispatcherTest {
 
         when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
         when(secondFactorAuthenticator.newPassCode("otp-key")).thenReturn(123456);
-        when(notificationService.sendSecondFactorPasscodeSms(telephone,"123456")).thenReturn(CompletableFuture.completedFuture("success code from notify"));
+        when(notificationService.sendSecondFactorPasscodeSms(telephone,"123456")).thenReturn("success code from notify");
         boolean dispatched = serviceOtpDispatcher.dispatchOtp(inviteCode);
 
         assertThat(dispatched,is(true));

--- a/src/test/java/uk/gov/pay/adminusers/service/UserOtpDispatcherTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserOtpDispatcherTest.java
@@ -15,7 +15,6 @@ import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -56,7 +55,7 @@ public class UserOtpDispatcherTest {
 
         when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
         when(secondFactorAuthenticator.newPassCode("otp-key")).thenReturn(123456);
-        when(notificationService.sendSecondFactorPasscodeSms(telephone, "123456")).thenReturn(CompletableFuture.completedFuture("success code from notify"));
+        when(notificationService.sendSecondFactorPasscodeSms(telephone, "123456")).thenReturn("success code from notify");
         boolean dispatched = userOtpDispatcher.dispatchOtp(inviteCode);
 
         verify(inviteDao).merge(expectedInvite.capture());


### PR DESCRIPTION
The `NotificationService` was returning things as `CompletableFuture` in
some hopes of making the calls to Notify's API asynchronous. However the
status of the calls was never checked and it looks like adminusers
doesn't reallu care whether the API call was successful or not and
carries on regardless. 

## WHAT YOU DID
I've not changed this behaviour but instead
explicitly catch the `Exception`s thrown by `NotificationService` and
avoided the mess introduced by `CompletableFuture`.

Error logging behaviour should be the same.


## How to test

- Run unit and integration tests and check the build is successful

## Code review checklist

### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [x] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition