### PR TITLE
Remove support for custom CA certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ The GOV.UK Pay Admin Users Module in Java (Dropwizard)
 | ----------------------- | ------------------------------------------------------------------------------ |
 | `ADMIN_PORT`                                                   | The port number to listen for Dropwizard admin requests on. Defaults to `8081`. |
 | `BASE_URL`                                                     | This is the publicly visible URL for the pay admin users root. Defaults to `http://localhost:8080`. |
-| `CERTS_PATH`                                                   | If set, add all certificates in this directory to the default Java truststore. |
 | `DB_HOST`                                                      | The hostname of the database server. |
 | `DB_NAME`                                                      | The name of the database on `DB_HOST`. Defaults to `adminusers`. |
 | `DB_PASSWORD`                                                  | The password for the `DB_USER` user. |

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -5,16 +5,6 @@ set -eu
 : "${RUN_MIGRATION:=false}"
 : "${RUN_APP:=true}"
 
-if [ -n "${CERTS_PATH:-}" ]; then
-  i=0
-  truststore_pass=changeit
-  for cert in "$CERTS_PATH"/*; do
-    [ -f "$cert" ] || continue
-    echo "Adding $cert to default truststore"
-    keytool -importcert -noprompt -cacerts -storepass "$truststore_pass" -file "$cert" -alias custom$((i++))
-  done
-fi
-
 java $JAVA_OPTS -jar *-allinone.jar waitOnDependencies *.yaml
 
 if [ "$RUN_MIGRATION" == "true" ]; then

--- a/env.sh
+++ b/env.sh
@@ -7,6 +7,4 @@ then
   set +a  
 fi
 
-export CERTS_PATH=$WORKSPACE/pay-scripts/services/ssl/certs
-
 eval "$@"


### PR DESCRIPTION
We only needed to augment the default Java truststore for local testing with
selfsigned certificates, but this is no longer required.

Remove support for adding custom CA certificates.