### PR TITLE
Add PMD Java “Error Prone” rules

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -96,4 +96,28 @@
         </properties>
     </rule>
 
+    <rule ref="category/java/errorprone.xml">
+        <exclude name="AvoidDuplicateLiterals"/>
+
+        <exclude name="AvoidFieldNameMatchingMethodName"/>
+
+        <exclude name="AvoidFieldNameMatchingTypeName"/>
+
+        <!-- Would flag fields that store injected dependencies etc. -->
+        <exclude name="BeanMembersShouldSerialize"/>
+
+        <exclude name="DataflowAnomalyAnalysis"/>
+
+        <!-- We never use Java serialisation -->
+        <exclude name="MissingSerialVersionUID"/>
+
+        <exclude name="NullAssignment"/>
+
+        <!-- Would flag some Pact tests -->
+        <exclude name="TestClassWithoutTestCases"/>
+
+        <!-- Deprecated rules -->
+        <exclude name="LoggerIsNotStaticFinal"/>
+    </rule>
+
 </ruleset>

--- a/src/main/java/uk/gov/pay/adminusers/app/util/RandomIdGenerator.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/util/RandomIdGenerator.java
@@ -2,6 +2,7 @@ package uk.gov.pay.adminusers.app.util;
 
 import java.math.BigInteger;
 import java.security.SecureRandom;
+import java.util.Locale;
 import java.util.Random;
 import java.util.UUID;
 
@@ -30,6 +31,6 @@ public class RandomIdGenerator {
     }
 
     public static String randomUuid() {
-        return UUID.randomUUID().toString().replace("-", "").toLowerCase();
+        return UUID.randomUUID().toString().replace("-", "").toLowerCase(Locale.ENGLISH);
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/exception/ValidationException.java
+++ b/src/main/java/uk/gov/pay/adminusers/exception/ValidationException.java
@@ -2,7 +2,7 @@ package uk.gov.pay.adminusers.exception;
 
 import uk.gov.pay.adminusers.utils.Errors;
 
-public class ValidationException extends Throwable {
+public class ValidationException extends Exception {
 
     private Errors errors;
 

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
@@ -14,6 +14,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Locale;
 
 import static java.time.temporal.ChronoUnit.DAYS;
 import static uk.gov.pay.adminusers.model.InviteType.USER;
@@ -82,7 +83,7 @@ public class InviteEntity extends AbstractEntity {
         initializeExpiry();
         this.code = code;
         this.otpKey = otpKey;
-        this.email = email.toLowerCase();
+        this.email = email.toLowerCase(Locale.ENGLISH);
         this.role = role;
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.adminusers.utils.email;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -87,7 +88,7 @@ public class EmailValidator {
      * @return <b>boolean</b> whether or not it is from a public sector domain
      */
     public static boolean isPublicSectorEmail(String email) {
-        String lowerCaseEmail = email.toLowerCase();
+        String lowerCaseEmail = email.toLowerCase(Locale.ENGLISH);
         String[] emailParts = lowerCaseEmail.split("@");
         if (emailParts.length != 2 || emailParts[0].isEmpty() || emailParts[1].isEmpty()) {
             return false;

--- a/src/main/java/uk/gov/pay/adminusers/utils/telephonenumber/TelephoneNumberUtility.java
+++ b/src/main/java/uk/gov/pay/adminusers/utils/telephonenumber/TelephoneNumberUtility.java
@@ -17,10 +17,10 @@ public class TelephoneNumberUtility {
                 PhoneNumber phoneNumber = PHONE_NUMBER_UTIL.parseAndKeepRawInput(telephoneNumber, DEFAULT_COUNTRY);
                 return PHONE_NUMBER_UTIL.isValidNumber(phoneNumber);
             }
+            return false;
         } catch (NumberParseException e) {
-            // do nothing
+            return false;
         }
-        return false;
     }
 
     public static String formatToE164(String telephoneNumber) {

--- a/src/main/java/uk/gov/pay/adminusers/validations/RequestValidations.java
+++ b/src/main/java/uk/gov/pay/adminusers/validations/RequestValidations.java
@@ -9,6 +9,7 @@ import uk.gov.pay.adminusers.utils.telephonenumber.TelephoneNumberUtility;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -118,7 +119,7 @@ public class RequestValidations {
     }
 
     /* default */ static Function<JsonNode, Boolean> isNotBoolean() {
-        return jsonNode -> !List.of("true", "false").contains(jsonNode.asText().toLowerCase());
+        return jsonNode -> !List.of("true", "false").contains(jsonNode.asText().toLowerCase(Locale.ENGLISH));
     }
 
     /* default */ static Function<JsonNode, Boolean> isNotStrictBoolean() {

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoIT.java
@@ -15,6 +15,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
@@ -217,7 +218,7 @@ public class UserDaoIT extends DaoTestBase {
 
         String otpKey = user.getOtpKey();
 
-        Optional<UserEntity> userEntityMaybe = userDao.findByUsername(username.toUpperCase());
+        Optional<UserEntity> userEntityMaybe = userDao.findByUsername(username.toUpperCase(Locale.ENGLISH));
         assertTrue(userEntityMaybe.isPresent());
 
         UserEntity foundUser = userEntityMaybe.get();

--- a/src/test/java/uk/gov/pay/adminusers/persistence/entity/InviteExpiryTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/entity/InviteExpiryTest.java
@@ -15,7 +15,7 @@ public class InviteExpiryTest {
     private InviteEntity inviteEntity;
 
     @Before
-    public void setup() {
+    public void setUp() {
         inviteEntity = anInvite();
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/HealthCheckResourceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/HealthCheckResourceTest.java
@@ -33,7 +33,7 @@ public class HealthCheckResourceTest {
     private HealthCheckResource resource;
 
     @Before
-    public void setup() {
+    public void setUp() {
         when(environment.healthChecks()).thenReturn(healthCheckRegistry);
         resource = new HealthCheckResource(environment);
     }

--- a/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
@@ -71,7 +71,7 @@ public class IntegrationTest {
     }
 
     @Before
-    public void setUp() {
+    public void initialise() {
         databaseHelper = APP.getDatabaseTestHelper();
         mapper = new ObjectMapper();
     }

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateServiceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateServiceIT.java
@@ -5,6 +5,7 @@ import io.restassured.http.ContentType;
 import org.junit.Test;
 import uk.gov.pay.adminusers.fixtures.UserDbFixture;
 
+import java.util.Locale;
 import java.util.Map;
 
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
@@ -34,7 +35,7 @@ public class InviteResourceCreateServiceIT extends IntegrationTest {
                 .post(SERVICE_INVITES_CREATE_URL)
                 .then()
                 .statusCode(CREATED.getStatusCode())
-                .body("email", is(email.toLowerCase()))
+                .body("email", is(email.toLowerCase(Locale.ENGLISH)))
                 .body("telephone_number", is("+441134960000"))
                 .body("_links", hasSize(2))
                 .body("_links[0].href", matchesPattern("^https://selfservice.pymnt.localdomain/invites/[0-9a-z]{32}$"))

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateUserIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateUserIT.java
@@ -7,6 +7,7 @@ import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.ServiceName;
 import uk.gov.pay.adminusers.model.User;
 
+import java.util.Locale;
 import java.util.Map;
 
 import static java.lang.String.format;
@@ -73,7 +74,7 @@ public class InviteResourceCreateUserIT extends IntegrationTest {
                 .post(INVITE_USER_RESOURCE_URL)
                 .then()
                 .statusCode(CREATED.getStatusCode())
-                .body("email", is(email.toLowerCase()))
+                .body("email", is(email.toLowerCase(Locale.ENGLISH)))
                 .body("telephone_number", is(nullValue()))
                 .body("_links", hasSize(1))
                 .body("_links[0].href", matchesPattern("^https://selfservice.pymnt.localdomain/invites/[0-9a-z]{32}$"))

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceGovUkPayAgreementResourceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceGovUkPayAgreementResourceIT.java
@@ -28,7 +28,7 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
     private String email = randomUuid() + "@example.org";
 
     @Before
-    public void setup() {
+    public void setUp() {
         service = serviceDbFixture(databaseHelper).insertService();
         user = userDbFixture(databaseHelper)
                 .withServiceRole(service, 1)

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceIT.java
@@ -28,7 +28,7 @@ public class ServiceResourceIT extends IntegrationTest {
     private User user1WithRoleViewInService1;
 
     @Before
-    public void setup() {
+    public void setUp() {
         Role roleAdmin = roleDbFixture(databaseHelper).insertAdmin();
         Role roleView = roleDbFixture(databaseHelper)
                 .withName("roleView")

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceStripeAgreementIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceStripeAgreementIT.java
@@ -25,7 +25,7 @@ public class ServiceResourceStripeAgreementIT extends IntegrationTest {
     private Service service;
 
     @Before
-    public void setup() {
+    public void setUp() {
         service = serviceDbFixture(databaseHelper).insertService();
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateNameIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateNameIT.java
@@ -18,7 +18,7 @@ public class ServiceResourceUpdateNameIT extends IntegrationTest {
     private String serviceExternalId;
 
     @Before
-    public void setup() {
+    public void setUp() {
         Service service = serviceDbFixture(databaseHelper).insertService();
         serviceExternalId = service.getExternalId();
     }

--- a/src/test/java/uk/gov/pay/adminusers/service/InviteServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/InviteServiceTest.java
@@ -61,7 +61,7 @@ public class InviteServiceTest {
     private String senderExternalId = "12345";
 
     @Before
-    public void setup() {
+    public void setUp() {
         inviteService = new InviteService(
                 mockUserDao,
                 mockInviteDao,

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCompleterTest.java
@@ -66,7 +66,7 @@ public class ServiceInviteCompleterTest {
     private String baseUrl = "http://localhost";
 
     @Before
-    public void setup() {
+    public void setUp() {
         serviceInviteCompleter = new ServiceInviteCompleter(
                 mockInviteDao,
                 mockUserDao,

--- a/src/test/java/uk/gov/pay/adminusers/service/UserInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserInviteCompleterTest.java
@@ -59,7 +59,7 @@ public class UserInviteCompleterTest {
     private String senderExternalId = "12345";
 
     @Before
-    public void setup() {
+    public void setUp() {
         userInviteCompleter = new UserInviteCompleter(
                 mockInviteDao,
                 mockUserDao

--- a/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
@@ -80,7 +80,7 @@ public class UserInviteCreatorTest {
     private String roleName = "view-only";
 
     @Before
-    public void setup() {
+    public void setUp() {
         LinksConfig mockLinks = mock(LinksConfig.class);
         when(mockLinks.getSelfserviceUrl()).thenReturn(SELFSERVICE_URL);
         when(mockConfig.getLinks()).thenReturn(mockLinks);


### PR DESCRIPTION
Add PMD’s Java “Error prone” rules, less the ones we don’t want to bother us (some comments in the rule set explaining why).

Modify code so it doesn’t violate the PMD rules (see individual commits for details).

Some of the rules introduced are broken by our existing code but have not been fixed (and will thus make Codacy complain about this PR). They’re real problems we want to fix but too complicated to tackle in this PR.