### PR TITLE
Introduce ShellCheck

### DIFF
--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -5,13 +5,17 @@ set -eu
 : "${RUN_MIGRATION:=false}"
 : "${RUN_APP:=true}"
 
-java $JAVA_OPTS -jar *-allinone.jar waitOnDependencies *.yaml
+# shellcheck disable=SC2086
+java $JAVA_OPTS -jar ./*-allinone.jar waitOnDependencies ./*.yaml
 
 if [ "$RUN_MIGRATION" == "true" ]; then
-  java $JAVA_OPTS -jar *-allinone.jar migrateToInitialDbState *.yaml
-  java $JAVA_OPTS -jar *-allinone.jar db migrate *.yaml
+  # shellcheck disable=SC2086
+  java $JAVA_OPTS -jar ./*-allinone.jar migrateToInitialDbState ./*.yaml
+  # shellcheck disable=SC2086
+  java $JAVA_OPTS -jar ./*-allinone.jar db migrate ./*.yaml
 fi
 
 if [ "$RUN_APP" == "true" ]; then
-  exec java $JAVA_OPTS -jar *-allinone.jar server *.yaml
+  # shellcheck disable=SC2086
+  exec java $JAVA_OPTS -jar ./*-allinone.jar server ./*.yaml
 fi

--- a/env.sh
+++ b/env.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 ENV_FILE="$WORKSPACE/pay-scripts/services/adminusers.env"
-if [ -f $ENV_FILE ]
+if [ -f "$ENV_FILE" ]
 then
   set -a
-  source $ENV_FILE
+  # shellcheck source=/dev/null
+  source "$ENV_FILE"
   set +a  
 fi
 

--- a/shellcheckrc
+++ b/shellcheckrc
@@ -1,0 +1,1 @@
+# GOV.UK Pay ShellCheck directives, primarily for use by Codacy


### PR DESCRIPTION
Fix or ignore errors in shell scripts found by ShellCheck.

ShellCheck reads a shellcheckrc file in the project directory, which can contain directives like `disable=SC2059` to ignore certain errors.

Add a `shellcheckrc` file with no directives (so far, everything we’ve wanted to ignore has been best dealt with on a case-by-case basis) for the benefit of Codacy.