### PR TITLE
Remove shellcheckrc file because Codacy doesn’t use it

### DIFF
--- a/shellcheckrc
+++ b/shellcheckrc
@@ -1,1 +1,0 @@
-# GOV.UK Pay ShellCheck directives, primarily for use by Codacy


### PR DESCRIPTION
Remove the `shellcheckrc` file, which provides directives to ShellCheck. It was mostly added for Codacy but it appears Codacy does not use this configuration file.