### PR TITLE
Introduce Hadolint

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,4 @@
+# GOV.UK Pay Hadolint configuration, primarily for use by Codacy
+
+ignored:
+  - DL3017

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,9 @@ EXPOSE 8081
 
 WORKDIR /app
 
-ADD docker-startup.sh /app/docker-startup.sh
-ADD target/*.yaml /app/
-ADD target/pay-*-allinone.jar /app/
+COPY docker-startup.sh /app/docker-startup.sh
+COPY target/*.yaml /app/
+COPY target/pay-*-allinone.jar /app/
 
 ENTRYPOINT ["tini", "-e", "143", "--"]
 


### PR DESCRIPTION
Use `COPY` rather than `ADD` in `Dockerfile` and add Hadolint (Haskell Dockerfile Linter) configuration to ignore some rules we don’t want to to bother us.