### PR TITLE
BAU Codacy clean up

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/model/Invite.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Invite.java
@@ -74,7 +74,7 @@ public class Invite {
     }
     
     public void setInviteLink(String targetUrl) {
-        Link inviteLink = Link.from(Link.Rel.invite, "GET", targetUrl);
+        Link inviteLink = Link.from(Link.Rel.INVITE, "GET", targetUrl);
         this.links.add(inviteLink);
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/model/Link.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Link.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-import java.util.Map;
+import java.util.Locale;
 import java.util.Objects;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
@@ -13,28 +13,28 @@ import java.util.Objects;
 public class Link {
 
     public enum Rel {
-        self,
-        invite,
-        user
+        SELF,
+        INVITE,
+        USER
     }
 
-    private Rel rel;
-    private String method;
-    private String href;
-    private String title;
-    private String type;
-    private Map<String, Object> params;
+    private final Rel rel;
+    private final String method;
+    private final String href;
 
     public static Link from(Rel rel, String method, String href) {
         return new Link(rel, method, href);
     }
 
-    private Link(@JsonProperty("rel") Rel rel,
-                 @JsonProperty("method") String method,
-                 @JsonProperty("href") String href) {
+    private Link(Rel rel, String method, String href) {
         this.rel = rel;
         this.method = method;
         this.href = href;
+    }
+
+    @JsonProperty("rel")
+    public String getRelAsLowerCase() {
+        return rel.name().toLowerCase(Locale.ENGLISH);
     }
 
     public Rel getRel() {
@@ -47,30 +47,6 @@ public class Link {
 
     public String getHref() {
         return href;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public Map<String, Object> getParams() {
-        return params;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    public void setParams(Map<String, Object> params) {
-        this.params = params;
-    }
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
     }
 
     @Override
@@ -87,20 +63,17 @@ public class Link {
 
         return Objects.equals(rel, link.rel)
                 && Objects.equals(method, link.method)
-                && Objects.equals(href, link.href)
-                && Objects.equals(title, link.title)
-                && Objects.equals(type, link.type)
-                && Objects.equals(params, link.params);
+                && Objects.equals(href, link.href);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(rel, method, href, title, type, params);
+        return Objects.hash(rel, method, href);
     }
 
     @Override
     public String toString() {
-        return String.format("Link{rel=%s, method='%s', href='%s', title='%s', type='%s', params=%s}",
-                rel, method, href, title, type, params);
+        return String.format("Link{rel=%s, method='%s', href='%s'}",
+                getRelAsLowerCase(), method, href);
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/LinksBuilder.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/LinksBuilder.java
@@ -27,7 +27,7 @@ public class LinksBuilder {
     public User decorate(User user) {
         URI uri = fromUri(baseUrl).path(USERS_RESOURCE).path(user.getExternalId())
                 .build();
-        Link selfLink = Link.from(Rel.self, "GET", uri.toString());
+        Link selfLink = Link.from(Rel.SELF, "GET", uri.toString());
         user.setLinks(List.of(selfLink));
         return user;
     }
@@ -35,7 +35,7 @@ public class LinksBuilder {
     public Service decorate(Service service) {
         URI uri = fromUri(baseUrl).path(SERVICES_RESOURCE).path(String.valueOf(service.getExternalId()))
                 .build();
-        Link selfLink = Link.from(Rel.self, "GET", uri.toString());
+        Link selfLink = Link.from(Rel.SELF, "GET", uri.toString());
         service.setLinks(List.of(selfLink));
         return service;
     }
@@ -43,7 +43,7 @@ public class LinksBuilder {
     public ForgottenPassword decorate(ForgottenPassword forgottenPassword) {
         URI uri = fromUri(baseUrl).path(FORGOTTEN_PASSWORDS_RESOURCE).path(forgottenPassword.getCode())
                 .build();
-        Link selfLink = Link.from(Rel.self, "GET", uri.toString());
+        Link selfLink = Link.from(Rel.SELF, "GET", uri.toString());
         forgottenPassword.setLinks(List.of(selfLink));
         return forgottenPassword;
     }
@@ -51,7 +51,7 @@ public class LinksBuilder {
     public Invite decorate(Invite invite) {
         URI uri = fromUri(baseUrl).path(INVITES_RESOURCE).path(invite.getCode())
                 .build();
-        Link selfLink = Link.from(Rel.self, "GET", uri.toString());
+        Link selfLink = Link.from(Rel.SELF, "GET", uri.toString());
         invite.getLinks().add(selfLink);
         return invite;
     }
@@ -59,7 +59,7 @@ public class LinksBuilder {
     public Invite addUserLink(User user, Invite invite) {
         URI uri = fromUri(baseUrl).path(USERS_RESOURCE).path(user.getExternalId())
                 .build();
-        Link userLink = Link.from(Rel.user, "GET", uri.toString());
+        Link userLink = Link.from(Rel.USER, "GET", uri.toString());
         invite.getLinks().add(userLink);
         return invite;
     }

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceCreatorTest.java
@@ -165,7 +165,7 @@ public class ServiceCreatorTest {
     private void assertSelfLink(Service service) {
         assertThat(service.getLinks(), hasSize(1));
         Link selfLink = service.getLinks().get(0);
-        assertThat(selfLink.getRel(), is(Link.Rel.self));
+        assertThat(selfLink.getRel(), is(Link.Rel.SELF));
         assertThat(selfLink.getMethod(), is(HttpMethod.GET));
         assertThat(selfLink.getHref(), is(BASE_URL + "/v1/api/services/" + service.getExternalId()));
     }

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCompleterTest.java
@@ -11,6 +11,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.adminusers.model.InviteCompleteRequest;
 import uk.gov.pay.adminusers.model.InviteCompleteResponse;
 import uk.gov.pay.adminusers.model.InviteType;
+import uk.gov.pay.adminusers.model.Link;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
@@ -103,7 +104,7 @@ public class ServiceInviteCompleterTest {
 
         assertThat(inviteResponse.getInvite().isDisabled(), is(true));
         assertThat(inviteResponse.getInvite().getLinks().size(), is(1));
-        assertThat(inviteResponse.getInvite().getLinks().get(0).getRel().toString(), is("user"));
+        assertThat(inviteResponse.getInvite().getLinks().get(0).getRel(), is(Link.Rel.USER));
         assertThat(inviteResponse.getInvite().getLinks().get(0).getHref(), matchesPattern("^" + baseUrl + "/v1/api/users/[0-9a-z]{32}$"));
     }
 
@@ -134,7 +135,7 @@ public class ServiceInviteCompleterTest {
 
         assertThat(inviteResponse.getInvite().isDisabled(), is(true));
         assertThat(inviteResponse.getInvite().getLinks().size(), is(1));
-        assertThat(inviteResponse.getInvite().getLinks().get(0).getRel().toString(), is("user"));
+        assertThat(inviteResponse.getInvite().getLinks().get(0).getRel(), is(Link.Rel.USER));
         assertThat(inviteResponse.getInvite().getLinks().get(0).getHref(), matchesPattern("^" + baseUrl + "/v1/api/users/[0-9a-z]{32}$"));
     }
 


### PR DESCRIPTION
- Change `Link.Rel` enum values to upper case as per convention.

## WHAT YOU DID
Ran PMD locally and fixed the final lint warning.