### PR TITLE
PP-5809: Don't throw runtime exception on failure to send notification

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
@@ -99,8 +99,8 @@ public class AdminUsersExceptions {
         return buildWebApplicationException(error, CONFLICT.getStatusCode());
     }
 
-    public static RuntimeException userNotificationError(Exception e) {
-        return new RuntimeException("error sending user notification", e);
+    public static WebApplicationException userNotificationError() {
+        return buildWebApplicationException("error sending user notification", INTERNAL_SERVER_ERROR.getStatusCode());
     }
 
     private static WebApplicationException buildWebApplicationException(String error, int status) {

--- a/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
@@ -15,6 +15,7 @@ import java.util.concurrent.TimeUnit;
 import static java.lang.String.format;
 import static uk.gov.pay.adminusers.model.PaymentType.CARD;
 import static uk.gov.pay.adminusers.model.Service.DEFAULT_NAME_VALUE;
+import static uk.gov.pay.adminusers.service.AdminUsersExceptions.userNotificationError;
 
 public class NotificationService {
 
@@ -54,7 +55,7 @@ public class NotificationService {
             return response.getNotificationId().toString();
         } catch (Exception e) {
             metricRegistry.counter("notify-operations.sms.failures").inc();
-            throw AdminUsersExceptions.userNotificationError(e);
+            throw userNotificationError();
         } finally {
             responseTimeStopwatch.stop();
             metricRegistry.histogram("notify-operations.sms.response_time").update(responseTimeStopwatch.elapsed(TimeUnit.MILLISECONDS));
@@ -127,7 +128,7 @@ public class NotificationService {
             return response.getNotificationId().toString();
         } catch (Exception e) {
             metricRegistry.counter("notify-operations.email.failures").inc();
-            throw AdminUsersExceptions.userNotificationError(e);
+            throw userNotificationError();
         } finally {
             responseTimeStopwatch.stop();
             metricRegistry.histogram("notify-operations.email.response_time").update(responseTimeStopwatch.elapsed(TimeUnit.MILLISECONDS));

--- a/src/test/java/uk/gov/pay/adminusers/service/ForgottenPasswordServicesTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ForgottenPasswordServicesTest.java
@@ -94,7 +94,7 @@ public class ForgottenPasswordServicesTest {
         when(mockUser.getEmail()).thenReturn(email);
         when(userDao.findByUsername(username)).thenReturn(Optional.of(mockUser));
         when(mockNotificationService.sendForgottenPasswordEmail(eq(email), matches("^http://selfservice/reset-password/[0-9a-z]{32}$")))
-                .thenThrow(AdminUsersExceptions.userNotificationError(new RuntimeException("some error from notify")));
+                .thenThrow(AdminUsersExceptions.userNotificationError());
         doNothing().when(forgottenPasswordDao).persist(any(ForgottenPasswordEntity.class));
 
         forgottenPasswordServices.create(username);

--- a/src/test/java/uk/gov/pay/adminusers/service/InviteServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/InviteServiceTest.java
@@ -221,7 +221,7 @@ public class InviteServiceTest {
         when(mockSecondFactorAuthenticator.newPassCode(otpKey)).thenReturn(passCode);
         when(mockInviteDao.merge(any(InviteEntity.class))).thenReturn(inviteEntity);
         when(mockNotificationService.sendSecondFactorPasscodeSms(eq(telephoneNumber), eq(valueOf(passCode))))
-                .thenThrow(AdminUsersExceptions.userNotificationError(new RuntimeException("some error from notify")));
+                .thenThrow(AdminUsersExceptions.userNotificationError());
 
         inviteService.reGenerateOtp(inviteOtpRequestFrom(inviteCode, telephoneNumber, plainPassword));
 

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCreatorTest.java
@@ -83,7 +83,7 @@ public class ServiceInviteCreatorTest {
         when(userDao.findByEmail(email)).thenReturn(Optional.empty());
         when(inviteDao.findByEmail(email)).thenReturn(emptyList());
         when(roleDao.findByRoleName("admin")).thenReturn(Optional.of(roleEntity));
-        when(notificationService.sendServiceInviteEmail(eq(email), anyString())).thenThrow(AdminUsersExceptions.userNotificationError(new RuntimeException("failed")));
+        when(notificationService.sendServiceInviteEmail(eq(email), anyString())).thenThrow(AdminUsersExceptions.userNotificationError());
         when(linksConfig.getSelfserviceUrl()).thenReturn("http://selfservice");
         when(linksConfig.getSelfserviceInvitesUrl()).thenReturn("http://selfservice/invites");
         Invite invite = serviceInviteCreator.doInvite(request);

--- a/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
@@ -121,7 +121,7 @@ public class UserInviteCreatorTest {
         mockInviteSuccessForNonExistingUserNonExistingInvite();
 
         when(mockNotificationService.sendInviteEmail(eq(senderEmail), eq(email), matches("^http://selfservice/invites/[0-9a-z]{32}$")))
-                .thenThrow(AdminUsersExceptions.userNotificationError(new RuntimeException("some error from notify")));
+                .thenThrow(AdminUsersExceptions.userNotificationError());
 
         userInviteCreator.doInvite(inviteRequestFrom(senderExternalId, email, roleName));
 
@@ -241,7 +241,7 @@ public class UserInviteCreatorTest {
         InviteEntity anInvite = mockInviteSuccessExistingInvite();
         when(mockNotificationService.sendInviteExistingUserEmail(eq(senderEmail), eq(email), matches("^http://selfservice/invites/[0-9a-z]{32}$"),
                 eq(anInvite.getService().getServiceNames().get(SupportedLanguage.ENGLISH).getName())))
-                .thenThrow(AdminUsersExceptions.userNotificationError(new RuntimeException("some error from notify")));
+                .thenThrow(AdminUsersExceptions.userNotificationError());
 
         InviteUserRequest inviteUserRequest = inviteRequestFrom(senderExternalId, email, roleName);
         Optional<Invite> invite = userInviteCreator.doInvite(inviteUserRequest);

--- a/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
@@ -373,7 +373,7 @@ public class UserServicesTest {
         when(secondFactorAuthenticator.newPassCode(user.getOtpKey())).thenReturn(123456);
 
         when(notificationService.sendSecondFactorPasscodeSms(any(String.class), eq("123456")))
-                .thenThrow(AdminUsersExceptions.userNotificationError(new Exception("some error from notify")));
+                .thenThrow(AdminUsersExceptions.userNotificationError());
 
         Optional<SecondFactorToken> tokenOptional = userServices.newSecondFactorPasscode(user.getExternalId(), false);
 


### PR DESCRIPTION
When there is an exception sending a notification, the
`uk.gov.service.notify.NotificationClient` will log an error. So there is no
need for us to rethrow a RuntimeException which will also be logged. This is
causing duplicate issues in Sentry. For example,

https://pay-sentry.cloudapps.digital/sentry/adminusers/issues/299/ and
https://pay-sentry.cloudapps.digital/sentry/adminusers/issues/300/ are the same
error - they have the same sentry threadname dw-25. Similarly for
https://pay-sentry.cloudapps.digital/sentry/adminusers/issues/1242/ and
https://pay-sentry.cloudapps.digital/sentry/adminusers/issues/1241/.

## WHAT YOU DID
_A brief description of the pull request:_

## How to test

- How should it be reviewed? 
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

