### PR TITLE
PP-5809: Lower log level when 2fa token could not be sent

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/service/UserOtpDispatcher.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserOtpDispatcher.java
@@ -46,7 +46,7 @@ public class UserOtpDispatcher extends InviteOtpDispatcher {
                         String notificationId = notificationService.sendSecondFactorPasscodeSms(inviteOtpRequest.getTelephoneNumber(), passcode);
                         LOGGER.info("sent 2FA token successfully for invite code [{}], notification id [{}]", inviteCode, notificationId);
                     } catch (Exception e) {
-                        LOGGER.error(format("error sending 2FA token for invite code [%s]", inviteCode), e);
+                        LOGGER.info(format("error sending 2FA token for invite code [%s]", inviteCode), e);
                     }
                     
                     return true;


### PR DESCRIPTION
Lowering the level here as there's nothing we can do when a 2fa token can't be
sent. This will already be logged at ERROR level by the notify client as well.

