### PR TITLE
PP-5313 Add reset second factor endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
@@ -197,6 +197,15 @@ public class UserResource {
                             .orElseGet(() -> Response.status(UNAUTHORIZED).build());
                 });
     }
+    
+    @Path("/{userExternalId}/reset-second-factor")
+    @POST
+    @Produces(APPLICATION_JSON)
+    public Response resetSecondFactor(@PathParam("userExternalId") String externalId) {
+        return userServices.resetSecondFactor(externalId)
+                .map(user -> Response.status(OK).entity(user).build())
+                .orElseGet(() -> Response.status(NOT_FOUND).build());
+    }
 
     @PATCH
     @Path("/{userExternalId}")

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
@@ -29,6 +29,7 @@ public class UserDbFixture {
     private String telephoneNumber = "+447700900000";
     private String features = "FEATURE_1, FEATURE_2";
     private String provisionalOtpKey;
+    private SecondFactorMethod secondFactorMethod = SecondFactorMethod.SMS;
 
     private UserDbFixture(DatabaseTestHelper databaseTestHelper) {
         this.databaseTestHelper = databaseTestHelper;
@@ -41,7 +42,7 @@ public class UserDbFixture {
     public User insertUser() {
         List<ServiceRole> serviceRoles = serviceRolePairs.stream().map(servicePair -> ServiceRole.from(servicePair.getLeft(), servicePair.getRight())).collect(Collectors.toList());
         User user = User.from(randomInt(), externalId, username, password, email, otpKey, telephoneNumber,
-                serviceRoles, features, SecondFactorMethod.SMS, provisionalOtpKey, null, null);
+                serviceRoles, features, secondFactorMethod, provisionalOtpKey, null, null);
 
         databaseTestHelper.add(user);
         serviceRoles.forEach(serviceRole -> databaseTestHelper.addUserServiceRole(user.getId(), serviceRole.getService().getId(), serviceRole.getRole().getId()));
@@ -94,9 +95,14 @@ public class UserDbFixture {
         this.otpKey = otpKey;
         return this;
     }
-
+    
     public UserDbFixture withProvisionalOtpKey(String provisionalOtpKey) {
         this.provisionalOtpKey = provisionalOtpKey;
+        return this;
+    }
+
+    public UserDbFixture withSecondFactorMethod(SecondFactorMethod secondFactorMethod) {
+        this.secondFactorMethod = secondFactorMethod;
         return this;
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceResetSecondFactorIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceResetSecondFactorIT.java
@@ -1,0 +1,44 @@
+package uk.gov.pay.adminusers.resources;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.adminusers.model.SecondFactorMethod;
+import uk.gov.pay.adminusers.model.User;
+
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
+
+public class UserResourceResetSecondFactorIT extends IntegrationTest {
+
+    private static final String OTP_KEY = "34f34";
+    private String externalId;
+
+    @Before
+    public void createValidUser() {
+        User user = userDbFixture(databaseHelper)
+                .withSecondFactorMethod(SecondFactorMethod.APP)
+                .withOtpKey(OTP_KEY)
+                .insertUser();
+
+        this.externalId = user.getExternalId();
+    }
+
+    @Test
+    public void shouldResetSecondFactorMethod() {
+        givenSetup()
+                .when()
+                .post("v1/api/users/" + externalId + "/reset-second-factor")
+                .then()
+                .statusCode(200)
+                .body("second_factor", is("SMS"));
+    }
+
+    @Test
+    public void shouldReturnNotFound_whenUserNotFound() {
+        givenSetup()
+                .when()
+                .post("v1/api/users/not-found/reset-second-factor")
+                .then()
+                .statusCode(404);
+    }
+}


### PR DESCRIPTION
Adds an API endpoint for resetting the second factor method to SMS and
generating a new OTP key in the process.

For the case that the second factor method is already SMS, we do nothing
and return a success response.