### PR TITLE
PP-6001 Upgrade Dropwizard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,13 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dropwizard.version>1.3.17</dropwizard.version>
+        <dropwizard.version>2.0.0</dropwizard.version>
         <hamcrest.version>2.2</hamcrest.version>
         <eclipselink.version>2.7.5</eclipselink.version>
         <guice.version>4.2.2</guice.version>
         <guava.version>28.2-jre</guava.version>
         <jackson.version>2.10.2</jackson.version>
-        <pay-java-commons.version>1.0.20191224120315</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20200107160358</pay-java-commons.version>
     </properties>
     <repositories>
         <repository>
@@ -206,7 +206,7 @@
         <dependency>
             <groupId>org.dhatim</groupId>
             <artifactId>dropwizard-sentry</artifactId>
-            <version>1.3.9-2</version>
+            <version>2.0.0-4</version>
         </dependency>
 
         <!-- testing -->
@@ -248,7 +248,7 @@
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-jdbi</artifactId>
+            <artifactId>dropwizard-jdbi3</artifactId>
             <version>${dropwizard.version}</version>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
@@ -2,6 +2,7 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.inject.Inject;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.adminusers.model.Invite;
@@ -168,7 +169,7 @@ public class InviteResource {
                 .map(errors -> Response.status(BAD_REQUEST).entity(errors).build())
                 .orElseGet(() -> inviteServiceFactory.userInvite().doInvite(InviteUserRequest.from(payload))
                         .map(invite -> Response.status(CREATED).entity(invite).build())
-                        .orElseGet(() -> Response.status(NOT_FOUND).build())
+                        .orElseGet(() -> Response.status(NOT_FOUND).entity(StringUtils.EMPTY).build())
                 );
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/infra/DropwizardAppWithPostgresRule.java
+++ b/src/test/java/uk/gov/pay/adminusers/infra/DropwizardAppWithPostgresRule.java
@@ -9,11 +9,11 @@ import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.LiquibaseException;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import org.apache.commons.lang3.ArrayUtils;
+import org.jdbi.v3.core.Jdbi;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-import org.skife.jdbi.v2.DBI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.adminusers.app.AdminUsersApp;
@@ -77,7 +77,7 @@ public class DropwizardAppWithPostgresRule implements TestRule {
                 restoreDropwizardsLogging();
 
                 DataSourceFactory dataSourceFactory = app.getConfiguration().getDataSourceFactory();
-                databaseTestHelper = new DatabaseTestHelper(new DBI(dataSourceFactory.getUrl(), dataSourceFactory.getUser(), dataSourceFactory.getPassword()));
+                databaseTestHelper = new DatabaseTestHelper(Jdbi.create(dataSourceFactory.getUrl(), dataSourceFactory.getUser(), dataSourceFactory.getPassword()));
 
                 base.evaluate();
             }

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/DaoTestBase.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/DaoTestBase.java
@@ -4,10 +4,10 @@ import com.google.inject.persist.jpa.JpaPersistModule;
 import liquibase.Liquibase;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.resource.ClassLoaderResourceAccessor;
+import org.jdbi.v3.core.Jdbi;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.skife.jdbi.v2.DBI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.adminusers.infra.GuicedTestEnvironment;
@@ -43,7 +43,7 @@ public class DaoTestBase {
 
         JpaPersistModule jpaModule = new JpaPersistModule("AdminUsersUnit").properties(properties);
 
-        databaseHelper = new DatabaseTestHelper(new DBI(postgres.getConnectionUrl(), postgres.getUsername(), postgres.getPassword()));
+        databaseHelper = new DatabaseTestHelper(Jdbi.create(postgres.getConnectionUrl(), postgres.getUsername(), postgres.getPassword()));
 
         try (Connection connection = DriverManager.getConnection(postgres.getConnectionUrl(), postgres.getUsername(), postgres.getPassword())) {
 

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoIT.java
@@ -23,6 +23,7 @@ import static java.lang.String.valueOf;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.RandomUtils.nextInt;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
@@ -85,7 +86,7 @@ public class UserDaoIT extends DaoTestBase {
         assertThat(userEntity.getId(), is(notNullValue()));
         List<Map<String, Object>> savedUserData = databaseHelper.findUser(userEntity.getId());
         assertThat(savedUserData.size(), is(1));
-        assertThat((String) savedUserData.get(0).get("external_id"), not(isEmptyOrNullString()));
+        assertThat((String) savedUserData.get(0).get("external_id"), not(emptyOrNullString()));
         assertThat(((String) savedUserData.get(0).get("external_id")).length(), equalTo(32));
         assertThat(savedUserData.get(0).get("username"), is(userEntity.getUsername()));
         assertThat(savedUserData.get(0).get("password"), is(userEntity.getPassword()));
@@ -94,8 +95,8 @@ public class UserDaoIT extends DaoTestBase {
         assertThat(savedUserData.get(0).get("telephone_number"), is(userEntity.getTelephoneNumber()));
         assertThat(savedUserData.get(0).get("disabled"), is(Boolean.FALSE));
         assertThat(savedUserData.get(0).get("session_version"), is(0));
-        assertThat(savedUserData.get(0).get("createdAt"), is(java.sql.Timestamp.from(timeNow.toInstant())));
-        assertThat(savedUserData.get(0).get("updatedAt"), is(java.sql.Timestamp.from(timeNow.toInstant())));
+        assertThat(savedUserData.get(0).get("createdat"), is(java.sql.Timestamp.from(timeNow.toInstant())));
+        assertThat(savedUserData.get(0).get("updatedat"), is(java.sql.Timestamp.from(timeNow.toInstant())));
 
         List<Map<String, Object>> serviceRolesForUser = databaseHelper.findServiceRoleForUser(userEntity.getId());
         assertThat(serviceRolesForUser.size(), is(1));

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceStripeAgreementIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceStripeAgreementIT.java
@@ -110,7 +110,7 @@ public class ServiceResourceStripeAgreementIT extends IntegrationTest {
                 .then()
                 .statusCode(422)
                 .body("errors", hasSize(1))
-                .body("errors[0]", is("ipAddress may not be null"));
+                .body("errors[0]", is("ipAddress must not be null"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.adminusers.utils;
 
+import org.jdbi.v3.core.Jdbi;
 import org.postgresql.util.PGobject;
-import org.skife.jdbi.v2.DBI;
 import uk.gov.pay.adminusers.model.ForgottenPassword;
 import uk.gov.pay.adminusers.model.MerchantDetails;
 import uk.gov.pay.adminusers.model.Permission;
@@ -21,12 +21,13 @@ import java.util.List;
 import java.util.Map;
 
 import static java.sql.Timestamp.from;
+import static java.sql.Types.OTHER;
 
 public class DatabaseTestHelper {
 
-    private DBI jdbi;
+    private Jdbi jdbi;
 
-    public DatabaseTestHelper(DBI jdbi) {
+    public DatabaseTestHelper(Jdbi jdbi) {
         this.jdbi = jdbi;
     }
 
@@ -36,7 +37,7 @@ public class DatabaseTestHelper {
                         "FROM users " +
                         "WHERE external_id = :externalId")
                         .bind("externalId", externalId)
-                        .list());
+                        .mapToMap().list());
     }
 
     public List<Map<String, Object>> findUserByUsername(String username) {
@@ -45,7 +46,7 @@ public class DatabaseTestHelper {
                         "FROM users " +
                         "WHERE username = :username")
                         .bind("username", username)
-                        .list());
+                        .mapToMap().list());
     }
 
     public List<Map<String, Object>> findUser(long userId) {
@@ -54,7 +55,7 @@ public class DatabaseTestHelper {
                         "FROM users " +
                         "WHERE id = :userId")
                         .bind("userId", userId)
-                        .list());
+                        .mapToMap().list());
     }
 
     public List<Map<String, Object>> findServiceRoleForUser(long userId) {
@@ -63,7 +64,7 @@ public class DatabaseTestHelper {
                         "FROM roles r INNER JOIN user_services_roles ur " +
                         "ON ur.user_id = :userId AND ur.role_id = r.id")
                         .bind("userId", userId)
-                        .list());
+                        .mapToMap().list());
     }
 
     public List<Map<String, Object>> findForgottenPasswordById(Integer forgottenPasswordId) {
@@ -72,7 +73,7 @@ public class DatabaseTestHelper {
                         "FROM forgotten_passwords " +
                         "WHERE id = :id")
                         .bind("id", forgottenPasswordId)
-                        .list());
+                        .mapToMap().list());
     }
 
     public List<Map<String, Object>> findInviteById(Integer inviteId) {
@@ -81,13 +82,13 @@ public class DatabaseTestHelper {
                         "FROM invites " +
                         "WHERE id = :id")
                         .bind("id", inviteId)
-                        .list());
+                        .mapToMap().list());
     }
 
     public DatabaseTestHelper updateLoginCount(String username, int loginCount) {
         jdbi.withHandle(handle ->
                 handle
-                        .createStatement("UPDATE users SET login_counter = :loginCount " +
+                        .createUpdate("UPDATE users SET login_counter = :loginCount " +
                                 "WHERE username = :username")
                         .bind("loginCount", loginCount)
                         .bind("username", username)
@@ -99,7 +100,7 @@ public class DatabaseTestHelper {
     public DatabaseTestHelper updateProvisionalOtpKey(String username, String provisionalOtpKey) {
         jdbi.withHandle(handle ->
                 handle
-                        .createStatement("UPDATE users SET provisional_otp_key = :provisionalOtpKey, " +
+                        .createUpdate("UPDATE users SET provisional_otp_key = :provisionalOtpKey, " +
                                 "provisional_otp_key_created_at = NOW() " +
                                 "WHERE username = :username")
                         .bind("provisionalOtpKey", provisionalOtpKey)
@@ -113,7 +114,7 @@ public class DatabaseTestHelper {
         Timestamp now = from(ZonedDateTime.now(ZoneId.of("UTC")).toInstant());
         jdbi.withHandle(handle ->
                 handle
-                        .createStatement("INSERT INTO users(" +
+                        .createUpdate("INSERT INTO users(" +
                                 "id, external_id, username, password, email, otp_key, telephone_number, " +
                                 "second_factor, disabled, login_counter, version, " +
                                 "\"createdAt\", \"updatedAt\", session_version, provisional_otp_key) " +
@@ -143,7 +144,7 @@ public class DatabaseTestHelper {
     public DatabaseTestHelper add(Role role) {
         jdbi.withHandle(handle ->
                 handle
-                        .createStatement("INSERT INTO roles(id, name, description) " +
+                        .createUpdate("INSERT INTO roles(id, name, description) " +
                                 "SELECT :id, :name, :description " +
                                 "WHERE NOT EXISTS (SELECT id FROM roles WHERE id = :id) " +
                                 "RETURNING id")
@@ -153,7 +154,7 @@ public class DatabaseTestHelper {
                         .execute()
         );
         role.getPermissions().forEach(permission -> jdbi.withHandle(handle ->
-                handle.createStatement("INSERT INTO role_permission(role_id, permission_id) VALUES (:roleId, :permissionId)")
+                handle.createUpdate("INSERT INTO role_permission(role_id, permission_id) VALUES (:roleId, :permissionId)")
                         .bind("roleId", role.getId())
                         .bind("permissionId", permission.getId())
                         .execute()
@@ -164,7 +165,7 @@ public class DatabaseTestHelper {
     public DatabaseTestHelper add(Permission permission) {
         jdbi.withHandle(handle ->
                 handle
-                        .createStatement("INSERT INTO permissions(id, name, description) " +
+                        .createUpdate("INSERT INTO permissions(id, name, description) " +
                                 "VALUES (:id, :name, :description)")
                         .bind("id", permission.getId())
                         .bind("name", permission.getName())
@@ -177,7 +178,7 @@ public class DatabaseTestHelper {
     public DatabaseTestHelper add(ForgottenPassword forgottenPassword, Integer userId) {
         jdbi.withHandle(handle ->
                 handle
-                        .createStatement("INSERT INTO forgotten_passwords(id, date, code, \"userId\") " +
+                        .createUpdate("INSERT INTO forgotten_passwords(id, date, code, \"userId\") " +
                                 "VALUES (:id, :date, :code, :userId)")
                         .bind("id", forgottenPassword.getId())
                         .bind("date", from(forgottenPassword.getDate().toInstant()))
@@ -194,7 +195,7 @@ public class DatabaseTestHelper {
                 h.createQuery("SELECT service_id FROM user_services_roles " +
                         "WHERE user_id = :userId")
                         .bind("userId", userId)
-                        .list());
+                        .mapToMap().list());
     }
 
     public DatabaseTestHelper addService(Service service, String... gatewayAccountIds) {
@@ -206,14 +207,14 @@ public class DatabaseTestHelper {
             if (merchantDetails == null) {
                 merchantDetails = new MerchantDetails();
             }
-            return handle.createStatement("INSERT INTO services(" +
+            return handle.createUpdate("INSERT INTO services(" +
                     "id, custom_branding, " +
                     "merchant_name, merchant_telephone_number, merchant_address_line1, merchant_address_line2, merchant_address_city, " +
                     "merchant_address_postcode, merchant_address_country, merchant_email, external_id) " +
                     "VALUES (:id, :customBranding, :merchantName, :merchantTelephoneNumber, :merchantAddressLine1, :merchantAddressLine2, " +
                     ":merchantAddressCity, :merchantAddressPostcode, :merchantAddressCountry, :merchantEmail, :externalId)")
                     .bind("id", service.getId())
-                    .bind("customBranding", customBranding)
+                    .bindBySqlType("customBranding", customBranding, OTHER)
                     .bind("merchantName", merchantDetails.getName())
                     .bind("merchantTelephoneNumber", merchantDetails.getTelephoneNumber())
                     .bind("merchantAddressLine1", merchantDetails.getAddressLine1())
@@ -230,7 +231,7 @@ public class DatabaseTestHelper {
         
         for (String gatewayAccountId : gatewayAccountIds) {
             jdbi.withHandle(handle ->
-                    handle.createStatement("INSERT INTO service_gateway_accounts(service_id, gateway_account_id) VALUES (:serviceId, :gatewayAccountId)")
+                    handle.createUpdate("INSERT INTO service_gateway_accounts(service_id, gateway_account_id) VALUES (:serviceId, :gatewayAccountId)")
                             .bind("serviceId", service.getId())
                             .bind("gatewayAccountId", gatewayAccountId)
                             .execute()
@@ -241,7 +242,7 @@ public class DatabaseTestHelper {
 
     public DatabaseTestHelper addUserServiceRole(Integer userId, Integer serviceId, Integer roleId) {
         jdbi.withHandle(handle -> handle
-                .createStatement("INSERT INTO user_services_roles(user_id, service_id, role_id) VALUES(:userId, :serviceId, :roleId)")
+                .createUpdate("INSERT INTO user_services_roles(user_id, service_id, role_id) VALUES(:userId, :serviceId, :roleId)")
                 .bind("userId", userId)
                 .bind("serviceId", serviceId)
                 .bind("roleId", roleId)
@@ -257,7 +258,7 @@ public class DatabaseTestHelper {
                                         Integer loginCounter) {
         jdbi.withHandle(handle ->
                 handle
-                        .createStatement("INSERT INTO invites(id, sender_id, service_id, role_id, email, code, otp_key, date, expiry_date, telephone_number, password, disabled, login_counter) " +
+                        .createUpdate("INSERT INTO invites(id, sender_id, service_id, role_id, email, code, otp_key, date, expiry_date, telephone_number, password, disabled, login_counter) " +
                                 "VALUES (:id, :senderId, :serviceId, :roleId, :email, :code, :otpKey, :date, :expiryDate, :telephoneNumber, :password, :disabled, :loginCounter)")
                         .bind("id", id)
                         .bind("senderId", senderId)
@@ -285,7 +286,7 @@ public class DatabaseTestHelper {
                                                Integer loginCounter) {
         jdbi.withHandle(handle ->
                 handle
-                        .createStatement("INSERT INTO invites(id, sender_id, role_id, email, code, otp_key, date, expiry_date, telephone_number, password, disabled, login_counter, type) " +
+                        .createUpdate("INSERT INTO invites(id, sender_id, role_id, email, code, otp_key, date, expiry_date, telephone_number, password, disabled, login_counter, type) " +
                                 "VALUES (:id, :senderId, :roleId, :email, :code, :otpKey, :date, :expiryDate, :telephoneNumber, :password, :disabled, :loginCounter, :type)")
                         .bind("id", id)
                         .bind("senderId", senderId)
@@ -310,7 +311,7 @@ public class DatabaseTestHelper {
                 h.createQuery("SELECT id, sender_id, service_id, role_id, email, code, otp_key, date, telephone_number, disabled, login_counter FROM invites " +
                         "WHERE code = :code")
                         .bind("code", code)
-                        .list());
+                        .mapToMap().list());
     }
 
     public List<Map<String, Object>> findServiceByExternalId(String serviceExternalId) {
@@ -318,32 +319,32 @@ public class DatabaseTestHelper {
                 h.createQuery("SELECT * FROM services " +
                         "WHERE external_id = :external_id")
                         .bind("external_id", serviceExternalId)
-                        .list());
+                        .mapToMap().list());
     }
 
     public List<Map<String, Object>> findServiceNameByServiceId(Integer serviceId) {
         return jdbi.withHandle(h ->
                 h.createQuery("SELECT * FROM service_names WHERE service_id = :serviceId")
                         .bind("serviceId", serviceId)
-                        .list());
+                        .mapToMap().list());
     }
 
     public List<Map<String, Object>> findStripeAgreementById(int id) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("SELECT * FROM stripe_agreements WHERE id = :id")
                         .bind("id", id)
-                        .list());
+                        .mapToMap().list());
     }
     
     public List<Map<String, Object>> findGovUkPayAgreementEntity(Integer serviceId) {
         return jdbi.withHandle(handle -> 
                 handle.createQuery("SELECT * FROM govuk_pay_agreements WHERE service_id = :id")
                 .bind("id", serviceId)
-                .list());
+                        .mapToMap().list());
     }
     
     public DatabaseTestHelper insertGovUkPayAgreementEntity(int serviceId, String email, ZonedDateTime agreementTime) {
-        jdbi.withHandle(handle -> handle.createStatement("INSERT INTO govuk_pay_agreements(service_id, agreement_time, email) VALUES (:serviceId, :agreementTime, :email)")
+        jdbi.withHandle(handle -> handle.createUpdate("INSERT INTO govuk_pay_agreements(service_id, agreement_time, email) VALUES (:serviceId, :agreementTime, :email)")
                 .bind("serviceId", serviceId)
                 .bind("email", email)
                 .bind("agreementTime", from(agreementTime.toInstant()))
@@ -353,7 +354,7 @@ public class DatabaseTestHelper {
 
     public DatabaseTestHelper insertStripeAgreementEntity(int serviceId, ZonedDateTime agreementTime, String ipAddress) {
         jdbi.withHandle(handle -> handle
-                .createStatement("INSERT INTO stripe_agreements(service_id, agreement_time, ip_address) VALUES (:serviceId, :agreementTime, :ipAddress)")
+                .createUpdate("INSERT INTO stripe_agreements(service_id, agreement_time, ip_address) VALUES (:serviceId, :agreementTime, :ipAddress)")
                 .bind("serviceId", serviceId)
                 .bind("agreementTime", from(agreementTime.toInstant()))
                 .bind("ipAddress", ipAddress)
@@ -363,7 +364,7 @@ public class DatabaseTestHelper {
 
     private DatabaseTestHelper addServiceName(ServiceNameEntity entity, Integer serviceId) {
         jdbi.withHandle(handle -> handle
-                .createStatement("INSERT INTO service_names(service_id, language, name) VALUES (:serviceId, :language, :name)")
+                .createUpdate("INSERT INTO service_names(service_id, language, name) VALUES (:serviceId, :language, :name)")
                 .bind("serviceId", serviceId)
                 .bind("language", entity.getLanguage().toString())
                 .bind("name", entity.getName())
@@ -378,14 +379,14 @@ public class DatabaseTestHelper {
                     new CustomBrandingConverter().convertToDatabaseColumn(serviceEntity.getCustomBranding());
             MerchantDetailsEntity merchantDetails = serviceEntity.getMerchantDetailsEntity();
 
-            return handle.createStatement("INSERT INTO services(" +
+            return handle.createUpdate("INSERT INTO services(" +
                     "id, custom_branding, " +
                     "merchant_name, merchant_telephone_number, merchant_address_line1, merchant_address_line2, merchant_address_city, " +
                     "merchant_address_postcode, merchant_address_country, merchant_email, external_id, redirect_to_service_immediately_on_terminal_state, current_go_live_stage) " +
                     "VALUES (:id, :customBranding, :merchantName, :merchantTelephoneNumber, :merchantAddressLine1, :merchantAddressLine2, " +
                     ":merchantAddressCity, :merchantAddressPostcode, :merchantAddressCountry, :merchantEmail, :externalId, :redirectToServiceImmediatelyOnTerminalState, :currentGoLiveStage)")
                     .bind("id", serviceEntity.getId())
-                    .bind("customBranding", customBranding)
+                    .bindBySqlType("customBranding", customBranding, OTHER)
                     .bind("merchantName", merchantDetails.getName())
                     .bind("merchantTelephoneNumber", merchantDetails.getTelephoneNumber())
                     .bind("merchantAddressLine1", merchantDetails.getAddressLine1())
@@ -401,7 +402,7 @@ public class DatabaseTestHelper {
         });
         serviceEntity.getGatewayAccountIds().forEach(gatewayAccount ->
                 jdbi.withHandle(handle ->
-                        handle.createStatement("INSERT INTO service_gateway_accounts(service_id, gateway_account_id) VALUES (:serviceId, :gatewayAccountId)")
+                        handle.createUpdate("INSERT INTO service_gateway_accounts(service_id, gateway_account_id) VALUES (:serviceId, :gatewayAccountId)")
                                 .bind("serviceId", serviceEntity.getId())
                                 .bind("gatewayAccountId", gatewayAccount.getGatewayAccountId())
                                 .execute()
@@ -411,7 +412,7 @@ public class DatabaseTestHelper {
     }
 
     public void truncateAllData() {
-        jdbi.withHandle(handle -> handle.createStatement("TRUNCATE TABLE users CASCADE").execute());
-        jdbi.withHandle(handle -> handle.createStatement("TRUNCATE TABLE services CASCADE").execute());
+        jdbi.withHandle(handle -> handle.createUpdate("TRUNCATE TABLE users CASCADE").execute());
+        jdbi.withHandle(handle -> handle.createUpdate("TRUNCATE TABLE services CASCADE").execute());
     }
 }


### PR DESCRIPTION
## WHAT 
- Upgrades dropwizard to v2.0.0
- Added `dropwizard-dependencies` as parent as v2.0.0 upgrade doesn't specify transitive dependency versions anymore https://www.dropwizard.io/en/release-2.0.x/manual/upgrade-notes/upgrade-notes-2_0_x.html

      We can also include BOM for transitive dependency versions but versions can't be overridden and we may end up with multiple revisions of same library. For example, `jackson-version` current used is `2.10.2` but dropwizard uses `2.10.1`

- Upgraded dropwizard-sentry library too without which builds are failing with error `java.lang.NoSuchMethodError: 'com.google.common.collect.ImmutableList org.dhatim.dropwizard.sentry.logging.SentryAppenderFactory.getFilterFactories()'`

- Upgrade pay-java-commons library which is on dropwizard v2.0.0 and defines required library `org.glassfish.jersey.bundles.repackaged`

- Return empty response explictly for /v1/api/invites/user resource as Jersey default response is being returned

    ```
    "servlet":"io.dropwizard.jersey.setup.JerseyServletContainer-6dff6ce",
    "message":"Not Found",
    "url":"/v1/api/invites/user",
    "status":"404"
    ```

- Fixed tests DB setup