### PR TITLE
PP-6000 Allow choosing the Notify template for sending OTP via SMS

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersModule.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersModule.java
@@ -16,6 +16,7 @@ import uk.gov.pay.adminusers.service.ForgottenPasswordServices;
 import uk.gov.pay.adminusers.service.InviteServiceFactory;
 import uk.gov.pay.adminusers.service.LinksBuilder;
 import uk.gov.pay.adminusers.service.NotificationService;
+import uk.gov.pay.adminusers.service.NotifyClientProvider;
 import uk.gov.pay.adminusers.service.PasswordHasher;
 import uk.gov.pay.adminusers.service.ResetPasswordService;
 import uk.gov.pay.adminusers.service.SecondFactorAuthenticator;
@@ -99,6 +100,7 @@ public class AdminUsersModule extends AbstractModule {
     @Provides
     public NotificationService provideUserNotificationService() {
         return new NotificationService(
+                new NotifyClientProvider(configuration.getNotifyConfiguration()),
                 configuration.getNotifyConfiguration(),
                 configuration.getNotifyDirectDebitConfiguration(),
                 environment.metrics());

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteService.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.invalidOtpAuthCodeInviteException;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.inviteLockedException;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.notFoundInviteException;
+import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.LEGACY;
 
 public class InviteService {
 
@@ -65,7 +66,7 @@ public class InviteService {
             LOGGER.info("New 2FA token generated for invite code [{}]", inviteOtpRequest.getCode());
             
             try {
-                String notificationId = notificationService.sendSecondFactorPasscodeSms(inviteOtpRequest.getTelephoneNumber(), passcode);
+                String notificationId = notificationService.sendSecondFactorPasscodeSms(inviteOtpRequest.getTelephoneNumber(), passcode, LEGACY);
                 LOGGER.info("sent 2FA token successfully for invite code [{}], notification id [{}]", inviteOtpRequest.getCode(), notificationId);
             } catch (Exception e) {
                 LOGGER.error(String.format("error sending 2FA token for invite code [%s]", inviteOtpRequest.getCode()), e);

--- a/src/main/java/uk/gov/pay/adminusers/service/NotifyClientProvider.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NotifyClientProvider.java
@@ -10,7 +10,7 @@ public class NotifyClientProvider {
 
     private NotifyConfiguration configuration;
 
-    /* default */ NotifyClientProvider(NotifyConfiguration configuration) {
+    public NotifyClientProvider(NotifyConfiguration configuration) {
         this.configuration = configuration;
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcher.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcher.java
@@ -8,6 +8,7 @@ import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import java.util.Locale;
 
 import static java.lang.String.format;
+import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.LEGACY;
 
 public class ServiceOtpDispatcher extends InviteOtpDispatcher {
 
@@ -35,7 +36,7 @@ public class ServiceOtpDispatcher extends InviteOtpDispatcher {
                     LOGGER.info("New 2FA token generated for invite code [{}]", inviteEntity.getCode());
                     
                     try {
-                        String notificationId = notificationService.sendSecondFactorPasscodeSms(inviteEntity.getTelephoneNumber(), passcode);
+                        String notificationId = notificationService.sendSecondFactorPasscodeSms(inviteEntity.getTelephoneNumber(), passcode, LEGACY);
                         LOGGER.info("sent 2FA token successfully for invite code [{}], notification id [{}]", inviteEntity.getCode(), notificationId);
                     } catch (Exception e) {
                         LOGGER.error(format("error sending 2FA token for invite code [%s]", inviteEntity.getCode()), e);

--- a/src/main/java/uk/gov/pay/adminusers/service/UserOtpDispatcher.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserOtpDispatcher.java
@@ -10,6 +10,7 @@ import uk.gov.pay.adminusers.utils.telephonenumber.TelephoneNumberUtility;
 import java.util.Locale;
 
 import static java.lang.String.format;
+import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.LEGACY;
 
 public class UserOtpDispatcher extends InviteOtpDispatcher {
 
@@ -43,7 +44,7 @@ public class UserOtpDispatcher extends InviteOtpDispatcher {
                     LOGGER.info("New 2FA token generated for invite code [{}]", inviteCode);
                     
                     try {
-                        String notificationId = notificationService.sendSecondFactorPasscodeSms(inviteOtpRequest.getTelephoneNumber(), passcode);
+                        String notificationId = notificationService.sendSecondFactorPasscodeSms(inviteOtpRequest.getTelephoneNumber(), passcode, LEGACY);
                         LOGGER.info("sent 2FA token successfully for invite code [{}], notification id [{}]", inviteCode, notificationId);
                     } catch (Exception e) {
                         LOGGER.info(format("error sending 2FA token for invite code [%s]", inviteCode), e);

--- a/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
@@ -28,6 +28,7 @@ import static uk.gov.pay.adminusers.model.PatchRequest.PATH_FEATURES;
 import static uk.gov.pay.adminusers.model.PatchRequest.PATH_SESSION_VERSION;
 import static uk.gov.pay.adminusers.model.PatchRequest.PATH_TELEPHONE_NUMBER;
 import static uk.gov.pay.adminusers.model.SecondFactorMethod.SMS;
+import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.LEGACY;
 
 public class UserServices {
 
@@ -140,7 +141,8 @@ public class UserServices {
                         final String userExternalId = userEntity.getExternalId();
 
                         try {
-                            String notificationId = notificationService.sendSecondFactorPasscodeSms(userEntity.getTelephoneNumber(), token.getPasscode());
+                            String notificationId = notificationService.sendSecondFactorPasscodeSms(userEntity.getTelephoneNumber(), token.getPasscode(),
+                                    LEGACY);
                             logger.info("sent 2FA token successfully to user [{}], notification id [{}]", userExternalId, notificationId);
                         } catch (Exception e) {
                             logger.error("error sending 2FA token to user [{}]", userExternalId, e);

--- a/src/test/java/uk/gov/pay/adminusers/service/InviteServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/InviteServiceTest.java
@@ -36,6 +36,7 @@ import static uk.gov.pay.adminusers.model.InviteOtpRequest.FIELD_PASSWORD;
 import static uk.gov.pay.adminusers.model.InviteOtpRequest.FIELD_TELEPHONE_NUMBER;
 import static uk.gov.pay.adminusers.model.Role.role;
 import static uk.gov.pay.adminusers.persistence.entity.Role.ADMIN;
+import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.LEGACY;
 
 @RunWith(MockitoJUnitRunner.class)
 public class InviteServiceTest {
@@ -220,7 +221,7 @@ public class InviteServiceTest {
         when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
         when(mockSecondFactorAuthenticator.newPassCode(otpKey)).thenReturn(passCode);
         when(mockInviteDao.merge(any(InviteEntity.class))).thenReturn(inviteEntity);
-        when(mockNotificationService.sendSecondFactorPasscodeSms(eq(telephoneNumber), eq(valueOf(passCode))))
+        when(mockNotificationService.sendSecondFactorPasscodeSms(eq(telephoneNumber), eq(valueOf(passCode)), eq(LEGACY)))
                 .thenThrow(AdminUsersExceptions.userNotificationError());
 
         inviteService.reGenerateOtp(inviteOtpRequestFrom(inviteCode, telephoneNumber, plainPassword));
@@ -241,7 +242,7 @@ public class InviteServiceTest {
         when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
         when(mockSecondFactorAuthenticator.newPassCode(otpKey)).thenReturn(passCode);
         when(mockInviteDao.merge(any(InviteEntity.class))).thenReturn(inviteEntity);
-        when(mockNotificationService.sendSecondFactorPasscodeSms(eq(telephoneNumber), eq(valueOf(passCode))))
+        when(mockNotificationService.sendSecondFactorPasscodeSms(eq(telephoneNumber), eq(valueOf(passCode)), eq(LEGACY)))
                 .thenReturn("random-notify-id");
 
         inviteService.reGenerateOtp(inviteOtpRequestFrom(inviteCode, telephoneNumber, plainPassword));

--- a/src/test/java/uk/gov/pay/adminusers/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/NotificationServiceTest.java
@@ -1,0 +1,119 @@
+package uk.gov.pay.adminusers.service;
+
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.adminusers.app.config.NotifyConfiguration;
+import uk.gov.pay.adminusers.app.config.NotifyDirectDebitConfiguration;
+import uk.gov.service.notify.NotificationClient;
+import uk.gov.service.notify.NotificationClientException;
+import uk.gov.service.notify.SendSmsResponse;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static uk.gov.pay.adminusers.model.PaymentType.CARD;
+import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NotificationServiceTest {
+    
+    private static final String OTP = "123456";
+    private static final String PHONE_NUMBER = "07700900000";
+    private static final String PHONE_NUMBER_E164 = "+447700900000";
+    private static final UUID NOTIFICATION_ID = UUID.fromString("0E56AABE-E026-4478-8B82-C03D3B31CFC1");
+
+    private static final String SECOND_FACTOR_SMS_TEMPLATE_ID = "second-factor-sms-template-id";
+    private static final String SIGN_IN_OTP_SMS_TEMPLATE_ID = "sign-in-otp-sms-template-id";
+    private static final String CHANGE_SIGN_IN_2FA_TO_SMS_OTP_SMS_TEMPLATE_ID = "change-sign-in-2fa-to-sms-otp-sms-template-id";
+    private static final String SELF_INITIATED_CREATE_USER_AND_SERVICE_OTP_SMS_TEMPLATE_ID = "self-initiated-create-user-and-service-otp-sms-template-id";
+    private static final String CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE_OTP_SMS_TEMPLATE_ID
+            = "create-user-in-response-to-invitation-to-service-otp-sms-template-id";
+    
+    private static final String INVITE_USER_EMAIL_TEMPLATE_ID = "invite-user-email-template-id";
+    private static final String INVITE_USER_EXISTING_EMAIL_TEMPLATE_ID = "invite-user-existing-email-template-id";
+    private static final String FORGOTTEN_PASSWORD_EMAIL_TEMPLATE_ID = "forgotten-password-email-template-id";
+    
+    @Mock private NotifyClientProvider mockNotifyClientProvider;
+    @Mock private NotifyConfiguration mockNotifyConfiguration;
+    @Mock private NotifyDirectDebitConfiguration mockNotifyDirectDebitConfiguration;
+    @Mock private MetricRegistry mockMetricRegistry;
+
+    @Mock private NotificationClient mockNotificationClient;
+    @Mock private SendSmsResponse mockSendSmsResponse;
+
+    private NotificationService notificationService;
+
+    @Before
+    public void setUp() throws NotificationClientException {
+        given(mockNotifyConfiguration.getSecondFactorSmsTemplateId()).willReturn(SECOND_FACTOR_SMS_TEMPLATE_ID);
+        given(mockNotifyConfiguration.getSignInOtpSmsTemplateId()).willReturn(SIGN_IN_OTP_SMS_TEMPLATE_ID);
+        given(mockNotifyConfiguration.getChangeSignIn2faToSmsOtpSmsTemplateId()).willReturn(CHANGE_SIGN_IN_2FA_TO_SMS_OTP_SMS_TEMPLATE_ID);
+        given(mockNotifyConfiguration.getSelfInitiatedCreateUserAndServiceOtpSmsTemplateId())
+                .willReturn(SELF_INITIATED_CREATE_USER_AND_SERVICE_OTP_SMS_TEMPLATE_ID);
+        given(mockNotifyConfiguration.getCreateUserInResponseToInvitationToServiceOtpSmsTemplateId())
+                .willReturn(CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE_OTP_SMS_TEMPLATE_ID);
+
+        given(mockNotifyConfiguration.getInviteUserEmailTemplateId()).willReturn(INVITE_USER_EMAIL_TEMPLATE_ID);
+        given(mockNotifyConfiguration.getInviteUserExistingEmailTemplateId()).willReturn(INVITE_USER_EXISTING_EMAIL_TEMPLATE_ID);
+        given(mockNotifyConfiguration.getForgottenPasswordEmailTemplateId()).willReturn(FORGOTTEN_PASSWORD_EMAIL_TEMPLATE_ID);
+        
+        given(mockNotifyClientProvider.get(CARD)).willReturn(mockNotificationClient);
+
+        given(mockMetricRegistry.histogram("notify-operations.sms.response_time")).willReturn(mock(Histogram.class));
+
+        given(mockNotificationClient.sendSms(anyString(), anyString(), anyMap(), isNull())).willReturn(mockSendSmsResponse);
+        given(mockSendSmsResponse.getNotificationId()).willReturn(NOTIFICATION_ID);
+
+        notificationService = new NotificationService(mockNotifyClientProvider, mockNotifyConfiguration, mockNotifyDirectDebitConfiguration,
+                mockMetricRegistry);
+    }
+
+    @Test
+    public void sendSecondFactorPasscodeSmsWithSignInTemplate() throws NotificationClientException {
+        notificationService.sendSecondFactorPasscodeSms(PHONE_NUMBER, OTP, OtpNotifySmsTemplateId.SIGN_IN);
+
+        verify(mockNotificationClient).sendSms(SIGN_IN_OTP_SMS_TEMPLATE_ID, PHONE_NUMBER_E164, Map.of("code", OTP), null);
+    }
+
+    @Test
+    public void sendSecondFactorPasscodeSmsWithChangeSignIn2faToSmsTemplate() throws NotificationClientException {
+        notificationService.sendSecondFactorPasscodeSms(PHONE_NUMBER, OTP, OtpNotifySmsTemplateId.CHANGE_SIGN_IN_2FA_TO_SMS);
+
+        verify(mockNotificationClient).sendSms(CHANGE_SIGN_IN_2FA_TO_SMS_OTP_SMS_TEMPLATE_ID, PHONE_NUMBER_E164, Map.of("code", OTP), null);
+    }
+
+    @Test
+    public void sendSecondFactorPasscodeSmsWithSelfInitiatedCreateNewUserAndServiceTemplate() throws NotificationClientException {
+        notificationService.sendSecondFactorPasscodeSms(PHONE_NUMBER, OTP, OtpNotifySmsTemplateId.SELF_INITIATED_CREATE_NEW_USER_AND_SERVICE);
+
+        verify(mockNotificationClient).sendSms(SELF_INITIATED_CREATE_USER_AND_SERVICE_OTP_SMS_TEMPLATE_ID, PHONE_NUMBER_E164, Map.of("code", OTP),
+                null);    
+    }
+
+    @Test
+    public void sendSecondFactorPasscodeSmsWithCreateUserInResponseToInvitationToServiceTemplate() throws NotificationClientException {
+        notificationService.sendSecondFactorPasscodeSms(PHONE_NUMBER, OTP, OtpNotifySmsTemplateId.CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE);
+
+        verify(mockNotificationClient).sendSms(CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE_OTP_SMS_TEMPLATE_ID, PHONE_NUMBER_E164, Map.of("code", OTP),
+                null);    
+    }
+
+    @Test
+    public void sendSecondFactorPasscodeSmsWithLegacyTemplate() throws NotificationClientException {
+        notificationService.sendSecondFactorPasscodeSms(PHONE_NUMBER, OTP, OtpNotifySmsTemplateId.LEGACY);
+
+        verify(mockNotificationClient).sendSms(SECOND_FACTOR_SMS_TEMPLATE_ID, PHONE_NUMBER_E164, Map.of("code", OTP), null);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcherTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcherTest.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.LEGACY;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ServiceOtpDispatcherTest {
@@ -44,7 +45,7 @@ public class ServiceOtpDispatcherTest {
 
         when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
         when(secondFactorAuthenticator.newPassCode("otp-key")).thenReturn(123456);
-        when(notificationService.sendSecondFactorPasscodeSms(telephone,"123456")).thenReturn("success code from notify");
+        when(notificationService.sendSecondFactorPasscodeSms(telephone, "123456", LEGACY)).thenReturn("success code from notify");
         boolean dispatched = serviceOtpDispatcher.dispatchOtp(inviteCode);
 
         assertThat(dispatched,is(true));

--- a/src/test/java/uk/gov/pay/adminusers/service/UserOtpDispatcherTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserOtpDispatcherTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.LEGACY;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UserOtpDispatcherTest {
@@ -55,7 +56,7 @@ public class UserOtpDispatcherTest {
 
         when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
         when(secondFactorAuthenticator.newPassCode("otp-key")).thenReturn(123456);
-        when(notificationService.sendSecondFactorPasscodeSms(telephone, "123456")).thenReturn("success code from notify");
+        when(notificationService.sendSecondFactorPasscodeSms(telephone, "123456", LEGACY)).thenReturn("success code from notify");
         boolean dispatched = userOtpDispatcher.dispatchOtp(inviteCode);
 
         verify(inviteDao).merge(expectedInvite.capture());

--- a/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
@@ -55,6 +55,7 @@ import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.model.Permission.permission;
 import static uk.gov.pay.adminusers.model.Role.role;
+import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.LEGACY;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UserServicesTest {
@@ -339,7 +340,7 @@ public class UserServicesTest {
         UserEntity userEntity = UserEntity.from(user);
         when(userDao.findByExternalId(user.getExternalId())).thenReturn(Optional.of(userEntity));
         when(secondFactorAuthenticator.newPassCode(user.getOtpKey())).thenReturn(123456);
-        when(notificationService.sendSecondFactorPasscodeSms(any(String.class), eq("123456")))
+        when(notificationService.sendSecondFactorPasscodeSms(any(String.class), eq("123456"), eq(LEGACY)))
                 .thenReturn("random-notify-id");
 
         Optional<SecondFactorToken> tokenOptional = userServices.newSecondFactorPasscode(user.getExternalId(), false);
@@ -354,7 +355,7 @@ public class UserServicesTest {
         UserEntity userEntity = UserEntity.from(user);
         when(userDao.findByExternalId(user.getExternalId())).thenReturn(Optional.of(userEntity));
         when(secondFactorAuthenticator.newPassCode(user.getOtpKey())).thenReturn(12345);
-        when(notificationService.sendSecondFactorPasscodeSms(any(String.class), eq("012345")))
+        when(notificationService.sendSecondFactorPasscodeSms(any(String.class), eq("012345"), eq(LEGACY)))
                 .thenReturn("random-notify-id");
 
         Optional<SecondFactorToken> tokenOptional = userServices.newSecondFactorPasscode(user.getExternalId(), false);
@@ -370,7 +371,7 @@ public class UserServicesTest {
         when(userDao.findByExternalId(user.getExternalId())).thenReturn(Optional.of(userEntity));
         when(secondFactorAuthenticator.newPassCode(user.getOtpKey())).thenReturn(123456);
 
-        when(notificationService.sendSecondFactorPasscodeSms(any(String.class), eq("123456")))
+        when(notificationService.sendSecondFactorPasscodeSms(any(String.class), eq("123456"), eq(LEGACY)))
                 .thenThrow(AdminUsersExceptions.userNotificationError());
 
         Optional<SecondFactorToken> tokenOptional = userServices.newSecondFactorPasscode(user.getExternalId(), false);
@@ -396,7 +397,7 @@ public class UserServicesTest {
         UserEntity userEntity = UserEntity.from(user);
         when(userDao.findByExternalId(user.getExternalId())).thenReturn(Optional.of(userEntity));
         when(secondFactorAuthenticator.newPassCode(user.getProvisionalOtpKey())).thenReturn(654321);
-        when(notificationService.sendSecondFactorPasscodeSms(any(String.class), eq("654321")))
+        when(notificationService.sendSecondFactorPasscodeSms(any(String.class), eq("654321"), eq(LEGACY)))
                 .thenReturn("random-notify-id");
 
         Optional<SecondFactorToken> tokenOptional = userServices.newSecondFactorPasscode(user.getExternalId(), true);
@@ -404,7 +405,7 @@ public class UserServicesTest {
         assertTrue(tokenOptional.isPresent());
         assertThat(tokenOptional.get().getPasscode(), is("654321"));
 
-        verify(notificationService, never()).sendSecondFactorPasscodeSms(any(String.class), eq(user.getOtpKey()));
+        verify(notificationService, never()).sendSecondFactorPasscodeSms(any(String.class), eq(user.getOtpKey()), eq(LEGACY));
     }
 
     @Test


### PR DESCRIPTION
Change `NotificationService` so that when the `sendSecondFactorPasscodeSms(…)` method is called, an enum constant from the new `OtpNotifySmsTemplateId` enum type is passed in to indicate which Notify template ID to use.

For now, all callers of this method pass in the `LEGACY` enum constant, which maps to the long-serving Notify template ID, so there’s no behaviour change yet.

In subsequent commits, different templates will be chosen for different types of messages and `LEGACY` will be removed.

Also add unit tests for `NotificationService` because there weren’t any and the logic is becoming a bit more complex now. This required some tweaks to how `NotificationService` is instantiated to make it easier to inject mock dependencies.