### PR TITLE
PP-6000 Move newSecondFactorPasscode from UserServices to new class

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersModule.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersModule.java
@@ -12,6 +12,7 @@ import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.setup.Environment;
 import uk.gov.pay.adminusers.resources.ResetPasswordValidator;
 import uk.gov.pay.adminusers.resources.UserRequestValidator;
+import uk.gov.pay.adminusers.service.ExistingUserOtpDispatcher;
 import uk.gov.pay.adminusers.service.ForgottenPasswordServices;
 import uk.gov.pay.adminusers.service.InviteServiceFactory;
 import uk.gov.pay.adminusers.service.LinksBuilder;
@@ -62,6 +63,7 @@ public class AdminUsersModule extends AbstractModule {
         bind(Integer.class).annotatedWith(Names.named("LOGIN_ATTEMPT_CAP")).toInstance(configuration.getLoginAttemptCap());
         bind(SecondFactorAuthenticator.class).in(Singleton.class);
         bind(UserServices.class).in(Singleton.class);
+        bind(ExistingUserOtpDispatcher.class).in(Singleton.class);
         bind(ForgottenPasswordServices.class).in(Singleton.class);
         bind(ResetPasswordService.class).in(Singleton.class);
 

--- a/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
@@ -10,6 +10,7 @@ import uk.gov.pay.adminusers.model.CreateUserRequest;
 import uk.gov.pay.adminusers.model.PatchRequest;
 import uk.gov.pay.adminusers.model.SecondFactorMethod;
 import uk.gov.pay.adminusers.model.User;
+import uk.gov.pay.adminusers.service.ExistingUserOtpDispatcher;
 import uk.gov.pay.adminusers.service.UserServices;
 import uk.gov.pay.adminusers.service.UserServicesFactory;
 
@@ -51,13 +52,17 @@ public class UserResource {
     private final UserServices userServices;
     private final UserServicesFactory userServicesFactory;
 
+    private final ExistingUserOtpDispatcher existingUserOtpDispatcher;
+
     private final UserRequestValidator validator;
 
     @Inject
-    public UserResource(UserServices userServices, UserRequestValidator validator, UserServicesFactory userServicesFactory) {
+    public UserResource(UserServices userServices, UserRequestValidator validator, UserServicesFactory userServicesFactory,
+                        ExistingUserOtpDispatcher existingUserOtpDispatcher) {
         this.userServices = userServices;
         this.validator = validator;
         this.userServicesFactory = userServicesFactory;
+        this.existingUserOtpDispatcher = existingUserOtpDispatcher;
     }
 
 
@@ -150,7 +155,7 @@ public class UserResource {
                 .map(errors -> Response.status(BAD_REQUEST).entity(errors).build())
                 .orElseGet(() -> {
                     boolean provisional = payload != null && payload.get("provisional") != null && payload.get("provisional").asBoolean();
-                    return userServices.newSecondFactorPasscode(externalId, provisional)
+                    return existingUserOtpDispatcher.newSecondFactorPasscode(externalId, provisional)
                             .map(twoFAToken -> Response.status(OK).type(APPLICATION_JSON).build())
                             .orElseGet(() -> Response.status(NOT_FOUND).build());
                 });

--- a/src/main/java/uk/gov/pay/adminusers/service/ExistingUserOtpDispatcher.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ExistingUserOtpDispatcher.java
@@ -1,0 +1,70 @@
+package uk.gov.pay.adminusers.service;
+
+import com.google.inject.Provider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.adminusers.model.SecondFactorToken;
+import uk.gov.pay.adminusers.persistence.dao.UserDao;
+
+import javax.inject.Inject;
+import java.util.Optional;
+
+import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.LEGACY;
+
+public class ExistingUserOtpDispatcher {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserServices.class);
+
+    private final NotificationService notificationService;
+    private final SecondFactorAuthenticator secondFactorAuthenticator;
+    private final UserDao userDao;
+
+    @Inject
+    public ExistingUserOtpDispatcher(Provider<NotificationService> notificationService, SecondFactorAuthenticator secondFactorAuthenticator,
+                                     UserDao userDao) {
+        this.notificationService = notificationService.get();
+        this.secondFactorAuthenticator = secondFactorAuthenticator;
+        this.userDao = userDao;
+    }
+
+    public Optional<SecondFactorToken> newSecondFactorPasscode(String externalId, boolean useProvisionalOtpKey) {
+        return userDao.findByExternalId(externalId)
+                .map(userEntity -> {
+                    String otpKeyOrProvisionalOtpKey = useProvisionalOtpKey ? userEntity.getProvisionalOtpKey() : userEntity.getOtpKey();
+                    return Optional.ofNullable(otpKeyOrProvisionalOtpKey).map(otpKey -> {
+                        int newPassCode = secondFactorAuthenticator.newPassCode(otpKey);
+                        SecondFactorToken token = SecondFactorToken.from(externalId, newPassCode);
+                        final String userExternalId = userEntity.getExternalId();
+
+                        try {
+                            String notificationId = notificationService.sendSecondFactorPasscodeSms(userEntity.getTelephoneNumber(), token.getPasscode(),
+                                    LEGACY);
+                            LOGGER.info("sent 2FA token successfully to user [{}], notification id [{}]", userExternalId, notificationId);
+                        } catch (Exception e) {
+                            LOGGER.error("error sending 2FA token to user [{}]", userExternalId, e);
+                        }
+
+                        if (useProvisionalOtpKey) {
+                            LOGGER.info("New 2FA token generated for User [{}] from provisional OTP key", userExternalId);
+                        } else {
+                            LOGGER.info("New 2FA token generated for User [{}]", userExternalId);
+                        }
+                        return Optional.of(token);
+                    }).orElseGet(() -> {
+                        if (useProvisionalOtpKey) {
+                            LOGGER.error("New provisional 2FA token attempted for user without a provisional OTP key [{}]", externalId);
+                        } else {
+                            // Realistically, this will never happen
+                            LOGGER.error("New 2FA token attempted for user without an OTP key [{}]", externalId);
+                        }
+                        return Optional.empty();
+                    });
+                })
+                .orElseGet(() -> {
+                    //this cannot happen unless a bug in selfservice
+                    LOGGER.error("New 2FA token attempted for non-existent User [{}]", externalId);
+                    return Optional.empty();
+                });
+    }
+
+}

--- a/src/test/java/uk/gov/pay/adminusers/service/ExistingUserOtpDispatcherTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ExistingUserOtpDispatcherTest.java
@@ -1,0 +1,150 @@
+package uk.gov.pay.adminusers.service;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.adminusers.model.SecondFactorMethod;
+import uk.gov.pay.adminusers.model.SecondFactorToken;
+import uk.gov.pay.adminusers.model.User;
+import uk.gov.pay.adminusers.persistence.dao.UserDao;
+import uk.gov.pay.adminusers.persistence.entity.UserEntity;
+
+import java.util.Optional;
+
+import static java.util.Collections.emptyList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
+import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.LEGACY;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ExistingUserOtpDispatcherTest {
+
+    private static final String USER_EXTERNAL_ID = "7d19aff33f8948deb97ed16b2912dcd3";
+    private static final String USER_USERNAME = "random-name";
+
+    @Mock
+    private UserDao userDao;
+    @Mock
+    private PasswordHasher passwordHasher;
+    @Mock
+    private NotificationService notificationService;
+    @Mock
+    private SecondFactorAuthenticator secondFactorAuthenticator;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private ExistingUserOtpDispatcher existingUserOtpDispatcher;
+
+    @Before
+    public void before() {
+        existingUserOtpDispatcher = new ExistingUserOtpDispatcher(() -> notificationService, secondFactorAuthenticator, userDao);
+    }
+
+    @Test
+    public void shouldReturn2FAToken_whenCreate2FA_ifUserFound() {
+        User user = aUser();
+        UserEntity userEntity = UserEntity.from(user);
+        when(userDao.findByExternalId(user.getExternalId())).thenReturn(Optional.of(userEntity));
+        when(secondFactorAuthenticator.newPassCode(user.getOtpKey())).thenReturn(123456);
+        when(notificationService.sendSecondFactorPasscodeSms(any(String.class), eq("123456"), eq(LEGACY)))
+                .thenReturn("random-notify-id");
+
+        Optional<SecondFactorToken> tokenOptional = existingUserOtpDispatcher.newSecondFactorPasscode(user.getExternalId(), false);
+
+        assertTrue(tokenOptional.isPresent());
+        assertThat(tokenOptional.get().getPasscode(), is("123456"));
+    }
+
+    @Test
+    public void shouldZeroPad2FATokenTo6Digits_whenCreate2FA() {
+        User user = aUser();
+        UserEntity userEntity = UserEntity.from(user);
+        when(userDao.findByExternalId(user.getExternalId())).thenReturn(Optional.of(userEntity));
+        when(secondFactorAuthenticator.newPassCode(user.getOtpKey())).thenReturn(12345);
+        when(notificationService.sendSecondFactorPasscodeSms(any(String.class), eq("012345"), eq(LEGACY)))
+                .thenReturn("random-notify-id");
+
+        Optional<SecondFactorToken> tokenOptional = existingUserOtpDispatcher.newSecondFactorPasscode(user.getExternalId(), false);
+
+        assertTrue(tokenOptional.isPresent());
+        assertThat(tokenOptional.get().getPasscode(), is("012345"));
+    }
+
+    @Test
+    public void shouldReturn2FAToken_whenCreate2FA_evenIfNotifyThrowsAnError() {
+        User user = aUser();
+        UserEntity userEntity = UserEntity.from(user);
+        when(userDao.findByExternalId(user.getExternalId())).thenReturn(Optional.of(userEntity));
+        when(secondFactorAuthenticator.newPassCode(user.getOtpKey())).thenReturn(123456);
+
+        when(notificationService.sendSecondFactorPasscodeSms(any(String.class), eq("123456"), eq(LEGACY)))
+                .thenThrow(AdminUsersExceptions.userNotificationError());
+
+        Optional<SecondFactorToken> tokenOptional = existingUserOtpDispatcher.newSecondFactorPasscode(user.getExternalId(), false);
+
+        assertTrue(tokenOptional.isPresent());
+        assertThat(tokenOptional.get().getPasscode(), is("123456"));
+    }
+
+    @Test
+    public void shouldReturnEmpty_whenCreate2FA_ifUserNotFound() {
+        String nonExistentExternalId = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+        when(userDao.findByExternalId(nonExistentExternalId)).thenReturn(Optional.empty());
+
+        Optional<SecondFactorToken> tokenOptional = existingUserOtpDispatcher.newSecondFactorPasscode(nonExistentExternalId, false);
+
+        assertFalse(tokenOptional.isPresent());
+    }
+
+    @Test
+    public void shouldReturn2FAToken_whenCreate2FA_withProvisionalOtpKey_ifUserFound() {
+        User user = aUser();
+        user.setProvisionalOtpKey("provisional OTP key");
+        UserEntity userEntity = UserEntity.from(user);
+        when(userDao.findByExternalId(user.getExternalId())).thenReturn(Optional.of(userEntity));
+        when(secondFactorAuthenticator.newPassCode(user.getProvisionalOtpKey())).thenReturn(654321);
+        when(notificationService.sendSecondFactorPasscodeSms(any(String.class), eq("654321"), eq(LEGACY)))
+                .thenReturn("random-notify-id");
+
+        Optional<SecondFactorToken> tokenOptional = existingUserOtpDispatcher.newSecondFactorPasscode(user.getExternalId(), true);
+
+        assertTrue(tokenOptional.isPresent());
+        assertThat(tokenOptional.get().getPasscode(), is("654321"));
+
+        verify(notificationService, never()).sendSecondFactorPasscodeSms(any(String.class), eq(user.getOtpKey()), eq(LEGACY));
+    }
+
+    @Test
+    public void shouldReturn2FAToken_whenCreate2FA_withProvisionalOtpKey_ifProvisionalOtpKeyNotSet() {
+        User user = aUser();
+        UserEntity userEntity = UserEntity.from(user);
+        when(userDao.findByExternalId(user.getExternalId())).thenReturn(Optional.of(userEntity));
+
+        Optional<SecondFactorToken> tokenOptional = existingUserOtpDispatcher.newSecondFactorPasscode(user.getExternalId(), true);
+
+        assertFalse(tokenOptional.isPresent());
+
+        verifyNoInteractions(secondFactorAuthenticator);
+    }
+
+    private User aUser() {
+        return User.from(randomInt(), USER_EXTERNAL_ID, USER_USERNAME, "random-password",
+                "email@example.com","784rh", "8948924", emptyList(),
+                null, SecondFactorMethod.SMS,null, null, null);
+    }
+
+}


### PR DESCRIPTION
Move the `newSecondFactorPasscode(…)` method from `UserServices` to the new `ExistingUserOtpDispatcher` class. No functionality changes.