### PR TITLE
PP-6000 Specific templates for sign in v change sign-in method SMS

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/service/ExistingUserOtpDispatcher.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ExistingUserOtpDispatcher.java
@@ -9,11 +9,12 @@ import uk.gov.pay.adminusers.persistence.dao.UserDao;
 import javax.inject.Inject;
 import java.util.Optional;
 
-import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.LEGACY;
+import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.CHANGE_SIGN_IN_2FA_TO_SMS;
+import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.SIGN_IN;
 
 public class ExistingUserOtpDispatcher {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(UserServices.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExistingUserOtpDispatcher.class);
 
     private final NotificationService notificationService;
     private final SecondFactorAuthenticator secondFactorAuthenticator;
@@ -26,32 +27,41 @@ public class ExistingUserOtpDispatcher {
         this.secondFactorAuthenticator = secondFactorAuthenticator;
         this.userDao = userDao;
     }
+    
+    public Optional<SecondFactorToken> sendSignInOtp(String externalId) {
+        return sendOtp(externalId, false);
+    }
 
-    public Optional<SecondFactorToken> newSecondFactorPasscode(String externalId, boolean useProvisionalOtpKey) {
+    public Optional<SecondFactorToken> sendChangeSignMethodToSmsOtp(String externalId) {
+        return sendOtp(externalId, true);
+    }
+
+    private Optional<SecondFactorToken> sendOtp(String externalId, boolean changingSignInMethodToSms) {
         return userDao.findByExternalId(externalId)
                 .map(userEntity -> {
-                    String otpKeyOrProvisionalOtpKey = useProvisionalOtpKey ? userEntity.getProvisionalOtpKey() : userEntity.getOtpKey();
+                    String otpKeyOrProvisionalOtpKey = changingSignInMethodToSms ? userEntity.getProvisionalOtpKey() : userEntity.getOtpKey();
                     return Optional.ofNullable(otpKeyOrProvisionalOtpKey).map(otpKey -> {
                         int newPassCode = secondFactorAuthenticator.newPassCode(otpKey);
                         SecondFactorToken token = SecondFactorToken.from(externalId, newPassCode);
-                        final String userExternalId = userEntity.getExternalId();
+                        String userExternalId = userEntity.getExternalId();
+                        NotificationService.OtpNotifySmsTemplateId notifyTemplateId = changingSignInMethodToSms ? CHANGE_SIGN_IN_2FA_TO_SMS : SIGN_IN;
 
                         try {
                             String notificationId = notificationService.sendSecondFactorPasscodeSms(userEntity.getTelephoneNumber(), token.getPasscode(),
-                                    LEGACY);
+                                    notifyTemplateId);
                             LOGGER.info("sent 2FA token successfully to user [{}], notification id [{}]", userExternalId, notificationId);
                         } catch (Exception e) {
                             LOGGER.error("error sending 2FA token to user [{}]", userExternalId, e);
                         }
 
-                        if (useProvisionalOtpKey) {
+                        if (changingSignInMethodToSms) {
                             LOGGER.info("New 2FA token generated for User [{}] from provisional OTP key", userExternalId);
                         } else {
                             LOGGER.info("New 2FA token generated for User [{}]", userExternalId);
                         }
                         return Optional.of(token);
                     }).orElseGet(() -> {
-                        if (useProvisionalOtpKey) {
+                        if (changingSignInMethodToSms) {
                             LOGGER.error("New provisional 2FA token attempted for user without a provisional OTP key [{}]", externalId);
                         } else {
                             // Realistically, this will never happen


### PR DESCRIPTION
When sending an OTP code to an existing user (not a user who is in the process of creating their account), use the new specific Notify template IDs for the two possible activities: signing in or
changing the sign-in method to SMS.

Note that the actual contents of the messages are the same for now but this allows them to diverge in the future (which we’ll do when nothing is using the legacy template ID).

This change subtly changes the semantics of what it means to send an OTP for a user. Previously, the only difference was whether the provisional OTP key was used or not. Now this also implies whether the user is signing in or changing their sign-in method to SMS and affects the message content, so adjust some naming to clarify this.