### PR TITLE
PP-6000 Make InviteEntity type field an InviteType not String

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
@@ -68,7 +68,8 @@ public class InviteEntity extends AbstractEntity {
     private Integer loginCounter = 0;
 
     @Column(name = "type")
-    private String type = USER.getType();
+    @Convert(converter = InviteTypeConverter.class)
+    private InviteType type = USER;
 
     /**
      * For JPA
@@ -201,20 +202,20 @@ public class InviteEntity extends AbstractEntity {
         this.loginCounter = loginCount;
     }
 
-    public String getType() {
+    public InviteType getType() {
         return type;
     }
 
     public void setType(InviteType type) {
-        this.type = type.getType();
+        this.type = type;
     }
 
     public boolean isServiceType() {
-        return InviteType.SERVICE.equals(InviteType.from(type));
+        return InviteType.SERVICE.equals(type);
     }
 
     public boolean isUserType() {
-        return InviteType.USER.equals(InviteType.from(type));
+        return InviteType.USER.equals(type);
     }
 
     @Deprecated //use toInvite() instead
@@ -225,7 +226,7 @@ public class InviteEntity extends AbstractEntity {
     }
 
     public Invite toInvite() {
-        return new Invite(code, email, telephoneNumber, disabled, loginCounter, type, role.getName(), isExpired());
+        return new Invite(code, email, telephoneNumber, disabled, loginCounter, type.getType(), role.getName(), isExpired());
     }
 
     public boolean isExpired() {

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteTypeConverter.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteTypeConverter.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.adminusers.persistence.entity;
+
+import uk.gov.pay.adminusers.model.InviteType;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter
+public class InviteTypeConverter implements AttributeConverter<InviteType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(InviteType inviteType) {
+        return inviteType.getType();
+    }
+
+    @Override
+    public InviteType convertToEntityAttribute(String string) {
+        return InviteType.from(string);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteRouter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteRouter.java
@@ -2,7 +2,6 @@ package uk.gov.pay.adminusers.service;
 
 import com.google.inject.Inject;
 import org.apache.commons.lang3.tuple.Pair;
-import uk.gov.pay.adminusers.model.InviteType;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
 
@@ -23,7 +22,7 @@ public class InviteRouter {
     public Optional<Pair<InviteCompleter, Boolean>> routeComplete(String inviteCode) {
         return routeIfExist(inviteCode,
                 inviteEntity -> {
-                    boolean isServiceType = InviteType.SERVICE.getType().equals(inviteEntity.getType());
+                    boolean isServiceType = inviteEntity.isServiceType();
                     InviteCompleter inviteCompleter = isServiceType ? inviteServiceFactory.completeServiceInvite() : inviteServiceFactory.completeUserInvite();
                     return Optional.of(Pair.of(inviteCompleter, isServiceType));
                 });
@@ -32,7 +31,7 @@ public class InviteRouter {
     public Optional<Pair<InviteOtpDispatcher, Boolean>> routeOtpDispatch(String inviteCode) {
         return routeIfExist(inviteCode,
                 inviteEntity -> {
-                    boolean isUserType = InviteType.USER.getType().equals(inviteEntity.getType());
+                    boolean isUserType = inviteEntity.isUserType();
                     InviteOtpDispatcher inviteOtpDispatcher = isUserType ? inviteServiceFactory.dispatchUserOtp() : inviteServiceFactory.dispatchServiceOtp();
                     return Optional.of(Pair.of(inviteOtpDispatcher, isUserType));
                 });

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceInviteCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceInviteCreator.java
@@ -65,7 +65,7 @@ public class ServiceInviteCreator {
         List<InviteEntity> exitingInvites = inviteDao.findByEmail(requestEmail);
         List<InviteEntity> existingValidServiceInvitesForSameEmail =  exitingInvites.stream()
                 .filter(inviteEntity -> !inviteEntity.isDisabled() && !inviteEntity.isExpired())
-                .filter(inviteEntity -> SERVICE.getType().equals(inviteEntity.getType())).collect(Collectors.toList());
+                .filter(InviteEntity::isServiceType).collect(Collectors.toList());
 
         if(!existingValidServiceInvitesForSameEmail.isEmpty()) {
             InviteEntity foundInvite = existingValidServiceInvitesForSameEmail.get(0);

--- a/src/test/java/uk/gov/pay/adminusers/persistence/entity/InviteTypeConverterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/entity/InviteTypeConverterTest.java
@@ -1,0 +1,42 @@
+package uk.gov.pay.adminusers.persistence.entity;
+
+import org.junit.Test;
+import uk.gov.pay.adminusers.model.InviteType;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class InviteTypeConverterTest {
+
+    private final InviteTypeConverter inviteTypeConverter = new InviteTypeConverter();
+
+    @Test
+    public void userEnumConstantConvertToDatabaseColumnReturnsUserString() {
+        String databaseColumnValue = inviteTypeConverter.convertToDatabaseColumn(InviteType.USER);
+        assertThat(databaseColumnValue, is("user"));
+    }
+
+    @Test
+    public void serviceEnumConstantConvertToDatabaseColumnReturnsServiceString() {
+        String databaseColumnValue = inviteTypeConverter.convertToDatabaseColumn(InviteType.SERVICE);
+        assertThat(databaseColumnValue, is("service"));
+    }
+
+    @Test
+    public void userStringConvertToEntityAttributeReturnsUserEnumConstant() {
+        InviteType entityAttribute = inviteTypeConverter.convertToEntityAttribute("user");
+        assertThat(entityAttribute, is(InviteType.USER));
+    }   
+
+    @Test
+    public void serviceStringConvertToEntityAttributeReturnsServiceEnumConstant() {
+        InviteType entityAttribute = inviteTypeConverter.convertToEntityAttribute("service");
+        assertThat(entityAttribute, is(InviteType.SERVICE));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void unhandledStringConvertToEntityAttributeThrowsException() {
+        inviteTypeConverter.convertToEntityAttribute("Someone went wild in the DB!");
+    }
+
+}


### PR DESCRIPTION
Make the `InviteEntity` type field an `InviteType` and not a `String.` Also make its the `InviteEntity` `getType()` method return an `InviteType` not a `String`. Use `InviteEntity`’s existing `isUserInvite()` and `isServiceInvite()` methods rather than `getType()` in some places.

This means that any `InviteEntity` that is loaded from the database and has a type that isn’t “user” or “service” will blow up during deserialisation but there are no such entities in the production database and other things would probably break if there were.