### PR TITLE
PP-6000 Specific templates for different types of user creation SMS

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcher.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcher.java
@@ -8,7 +8,7 @@ import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import java.util.Locale;
 
 import static java.lang.String.format;
-import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.LEGACY;
+import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.SELF_INITIATED_CREATE_NEW_USER_AND_SERVICE;
 
 public class ServiceOtpDispatcher extends InviteOtpDispatcher {
 
@@ -36,7 +36,8 @@ public class ServiceOtpDispatcher extends InviteOtpDispatcher {
                     LOGGER.info("New 2FA token generated for invite code [{}]", inviteEntity.getCode());
                     
                     try {
-                        String notificationId = notificationService.sendSecondFactorPasscodeSms(inviteEntity.getTelephoneNumber(), passcode, LEGACY);
+                        String notificationId = notificationService.sendSecondFactorPasscodeSms(inviteEntity.getTelephoneNumber(), passcode,
+                                SELF_INITIATED_CREATE_NEW_USER_AND_SERVICE);
                         LOGGER.info("sent 2FA token successfully for invite code [{}], notification id [{}]", inviteEntity.getCode(), notificationId);
                     } catch (Exception e) {
                         LOGGER.error(format("error sending 2FA token for invite code [%s]", inviteEntity.getCode()), e);

--- a/src/main/java/uk/gov/pay/adminusers/service/UserOtpDispatcher.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserOtpDispatcher.java
@@ -10,11 +10,11 @@ import uk.gov.pay.adminusers.utils.telephonenumber.TelephoneNumberUtility;
 import java.util.Locale;
 
 import static java.lang.String.format;
-import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.LEGACY;
+import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE;
 
 public class UserOtpDispatcher extends InviteOtpDispatcher {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ServiceOtpDispatcher.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserOtpDispatcher.class);
     private final InviteDao inviteDao;
     private final SecondFactorAuthenticator secondFactorAuthenticator;
     private final PasswordHasher passwordHasher;
@@ -44,7 +44,8 @@ public class UserOtpDispatcher extends InviteOtpDispatcher {
                     LOGGER.info("New 2FA token generated for invite code [{}]", inviteCode);
                     
                     try {
-                        String notificationId = notificationService.sendSecondFactorPasscodeSms(inviteOtpRequest.getTelephoneNumber(), passcode, LEGACY);
+                        String notificationId = notificationService.sendSecondFactorPasscodeSms(inviteOtpRequest.getTelephoneNumber(), passcode,
+                                CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE);
                         LOGGER.info("sent 2FA token successfully for invite code [{}], notification id [{}]", inviteCode, notificationId);
                     } catch (Exception e) {
                         LOGGER.info(format("error sending 2FA token for invite code [%s]", inviteCode), e);

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcherTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcherTest.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.LEGACY;
+import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.SELF_INITIATED_CREATE_NEW_USER_AND_SERVICE;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ServiceOtpDispatcherTest {
@@ -45,7 +45,8 @@ public class ServiceOtpDispatcherTest {
 
         when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
         when(secondFactorAuthenticator.newPassCode("otp-key")).thenReturn(123456);
-        when(notificationService.sendSecondFactorPasscodeSms(telephone, "123456", LEGACY)).thenReturn("success code from notify");
+        when(notificationService.sendSecondFactorPasscodeSms(telephone, "123456", SELF_INITIATED_CREATE_NEW_USER_AND_SERVICE))
+                .thenReturn("success code from notify");
         boolean dispatched = serviceOtpDispatcher.dispatchOtp(inviteCode);
 
         assertThat(dispatched,is(true));

--- a/src/test/java/uk/gov/pay/adminusers/service/UserOtpDispatcherTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserOtpDispatcherTest.java
@@ -21,7 +21,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.LEGACY;
+import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UserOtpDispatcherTest {
@@ -56,7 +56,8 @@ public class UserOtpDispatcherTest {
 
         when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
         when(secondFactorAuthenticator.newPassCode("otp-key")).thenReturn(123456);
-        when(notificationService.sendSecondFactorPasscodeSms(telephone, "123456", LEGACY)).thenReturn("success code from notify");
+        when(notificationService.sendSecondFactorPasscodeSms(telephone, "123456", CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE))
+                .thenReturn("success code from notify");
         boolean dispatched = userOtpDispatcher.dispatchOtp(inviteCode);
 
         verify(inviteDao).merge(expectedInvite.capture());


### PR DESCRIPTION
When sending an OTP code for user who is trying to create a new account (not a user who already has an account), use the new specific Notify template IDs for the two possible variations:
self-initiated user and service creation or creating a user in response to an invitation to join a service.

Note that the actual contents of the messages are the same for now but this allows them to diverge in the future (which we’ll do when nothing is using the legacy template ID).