### PR TITLE
PP-6000 Remove legacy Notify OTP SMS template ID

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/app/config/NotifyConfiguration.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/NotifyConfiguration.java
@@ -21,10 +21,6 @@ public class NotifyConfiguration extends Configuration {
 
     @Valid
     @NotNull
-    private String secondFactorSmsTemplateId;
-
-    @Valid
-    @NotNull
     private String signInOtpSmsTemplateId;
 
     @Valid
@@ -77,10 +73,6 @@ public class NotifyConfiguration extends Configuration {
 
     public String getNotificationBaseURL() {
         return notificationBaseURL;
-    }
-
-    public String getSecondFactorSmsTemplateId() {
-        return secondFactorSmsTemplateId;
     }
 
     public String getSignInOtpSmsTemplateId() {

--- a/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
@@ -24,7 +24,6 @@ public class NotificationService {
     private final NotifyConfiguration notifyConfiguration;
     private final NotifyDirectDebitConfiguration notifyDirectDebitConfiguration;
 
-    private final String secondFactorSmsTemplateId;
     private final String signInOtpSmsTemplateId;
     private final String changeSignIn2faToSmsOtpSmsTemplateId;
     private final String selfInitiatedCreateUserAndServiceOtpSmsTemplateId;
@@ -42,7 +41,6 @@ public class NotificationService {
         this.notifyConfiguration = notifyConfiguration;
         this.notifyDirectDebitConfiguration = notifyDirectDebitConfiguration;
 
-        this.secondFactorSmsTemplateId = notifyConfiguration.getSecondFactorSmsTemplateId();
         this.signInOtpSmsTemplateId = notifyConfiguration.getSignInOtpSmsTemplateId();
         this.changeSignIn2faToSmsOtpSmsTemplateId = notifyConfiguration.getChangeSignIn2faToSmsOtpSmsTemplateId();
         this.selfInitiatedCreateUserAndServiceOtpSmsTemplateId = notifyConfiguration.getSelfInitiatedCreateUserAndServiceOtpSmsTemplateId();
@@ -158,12 +156,12 @@ public class NotificationService {
             case CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE:
                 return createUserInResponseToInvitationToServiceOtpSmsTemplateId;
             default:
-                return secondFactorSmsTemplateId;
+                throw new IllegalArgumentException("Unrecognised OtpNotifySmsTemplateId: " + otpNotifySmsTemplateId.name());
         }
     }
 
     public enum OtpNotifySmsTemplateId {
-        LEGACY, SIGN_IN, CHANGE_SIGN_IN_2FA_TO_SMS, SELF_INITIATED_CREATE_NEW_USER_AND_SERVICE, CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE;
+        SIGN_IN, CHANGE_SIGN_IN_2FA_TO_SMS, SELF_INITIATED_CREATE_NEW_USER_AND_SERVICE, CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE;
     }
 
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -72,7 +72,6 @@ notify:
   cardApiKey: ${NOTIFY_API_KEY:-api_key-pay-notify-service-id-pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs}
   directDebitApiKey: ${NOTIFY_DIRECT_DEBIT_API_KEY:-api_key-pay-notify-service-id-pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs}
   notificationBaseURL: ${NOTIFY_BASE_URL:-https://stubs.pymnt.localdomain/notify}
-  secondFactorSmsTemplateId: ${NOTIFY_2FA_TEMPLATE_ID:-pay-notify-two-factor-template-id}
   signInOtpSmsTemplateId: ${NOTIFY_SIGN_IN_OTP_SMS_TEMPLATE_ID:-pay-notify-sign-in-otp-sms-template-id}
   changeSignIn2faToSmsOtpSmsTemplateId: ${NOTIFY_CHANGE_SIGN_IN_2FA_TO_SMS_OTP_SMS_TEMPLATE_ID:-pay-notify-change-sign-in-2fa-to-sms-otp-sms-template-id}
   selfInitiatedCreateUserAndServiceOtpSmsTemplateId: ${NOTIFY_SELF_INITIATED_CREATE_USER_AND_SERVICE_OTP_SMS_TEMPLATE_ID:-pay-notify-self-initiated-create-user-and-service-otp-sms-template-id}

--- a/src/test/java/uk/gov/pay/adminusers/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/NotificationServiceTest.java
@@ -56,7 +56,6 @@ public class NotificationServiceTest {
 
     @Before
     public void setUp() throws NotificationClientException {
-        given(mockNotifyConfiguration.getSecondFactorSmsTemplateId()).willReturn(SECOND_FACTOR_SMS_TEMPLATE_ID);
         given(mockNotifyConfiguration.getSignInOtpSmsTemplateId()).willReturn(SIGN_IN_OTP_SMS_TEMPLATE_ID);
         given(mockNotifyConfiguration.getChangeSignIn2faToSmsOtpSmsTemplateId()).willReturn(CHANGE_SIGN_IN_2FA_TO_SMS_OTP_SMS_TEMPLATE_ID);
         given(mockNotifyConfiguration.getSelfInitiatedCreateUserAndServiceOtpSmsTemplateId())
@@ -107,13 +106,6 @@ public class NotificationServiceTest {
 
         verify(mockNotificationClient).sendSms(CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE_OTP_SMS_TEMPLATE_ID, PHONE_NUMBER_E164, Map.of("code", OTP),
                 null);    
-    }
-
-    @Test
-    public void sendSecondFactorPasscodeSmsWithLegacyTemplate() throws NotificationClientException {
-        notificationService.sendSecondFactorPasscodeSms(PHONE_NUMBER, OTP, OtpNotifySmsTemplateId.LEGACY);
-
-        verify(mockNotificationClient).sendSms(SECOND_FACTOR_SMS_TEMPLATE_ID, PHONE_NUMBER_E164, Map.of("code", OTP), null);
     }
 
 }

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -59,7 +59,6 @@ notify:
   directDebitApiKey: ${NOTIFY_DIRECT_DEBIT_API_KEY:-api_key-pay-notify-service-id-pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs}
   cardApiKey: ${NOTIFY_API_KEY:-api_key-pay-notify-service-id-pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs}
   notificationBaseURL: ${NOTIFY_BASE_URL:-https://stubs.pymnt.localdomain/notify}
-  secondFactorSmsTemplateId: ${NOTIFY_2FA_TEMPLATE_ID:-pay-notify-two-factor-template-id}
   signInOtpSmsTemplateId: ${NOTIFY_SIGN_IN_OTP_SMS_TEMPLATE_ID:-pay-notify-sign-in-otp-sms-template-id}
   changeSignIn2faToSmsOtpSmsTemplateId: ${NOTIFY_CHANGE_SIGN_IN_2FA_TO_SMS_OTP_SMS_TEMPLATE_ID:-pay-notify-change-sign-in-2fa-to-sms-otp-sms-template-id}
   selfInitiatedCreateUserAndServiceOtpSmsTemplateId: ${NOTIFY_SELF_INITIATED_CREATE_USER_AND_SERVICE_OTP_SMS_TEMPLATE_ID:-pay-notify-self-initiated-create-user-and-service-otp-sms-template-id}


### PR DESCRIPTION
Remove the legacy Notify OTP SMS template ID now that we have specific ones for specific circumstances.