### PR TITLE
PP-6000 Update README with OTP SMS changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ The GOV.UK Pay Admin Users Module in Java (Dropwizard)
 | `LOGIN_ATTEMPT_CAP`                                                           | The number of consecutive failed logins a user can have before their account is disabled. Defaults to `10`. |
 | `METRICS_HOST`                                                                | The hostname to send graphite metrics to. Defaults to `localhost`. |
 | `METRICS_PORT`                                                                | The port number to send graphite metrics to. Defaults to `8092`. |
-| `NOTIFY_2FA_TEMPLATE_ID`                                                      | The GOV.UK Notify template ID to use for sending MFA codes via SMS. Defaults to `pay-notify-two-factor-template-id`. |
 | `NOTIFY_SIGN_IN_OTP_SMS_TEMPLATE_ID`                                          | The GOV.UK Notify template ID to use for sending OTP codes via SMS for signing in. Defaults to `pay-notify-sign-in-otp-sms-template-id`. |
 | `NOTIFY_CHANGE_SIGN_IN_2FA_TO_SMS_OTP_SMS_TEMPLATE_ID`                        | The GOV.UK Notify template ID to use for sending OTP codes via SMS for changing the sign-in method to text messages. Defaults to `pay-notify-switch-sign-in-2fa-to-sms-otp-sms-template-id`. |
 | `NOTIFY_SELF_INITIATED_CREATE_USER_AND_SERVICE_OTP_SMS_TEMPLATE_ID`           | The GOV.UK Notify template ID to use for sending OTP codes via SMS for self-initiated user and service creation. Defaults to `pay-notify-self-initiated-create-user-and-service-otp-sms-template-id`. |
@@ -60,6 +59,7 @@ The GOV.UK Pay Admin Users Module in Java (Dropwizard)
 | [```/v1/api/users/{externalId}```](/docs/api_specification.md#patch-v1apiusersexternalid)              | PATCH    |  amend a specific user attribute            |
 | [```/v1/api/users/{externalId}/services/{serviceId}```](/docs/api_specification.md#put-v1apiusersexternalidservicesserviceid)  | PUT    |  update user's role for a service            |
 | [```/v1/api/users/{externalId}/services```](/docs/api_specification.md#post-v1apiusersexternalidservicesserviceid)  | POST    |  assign a new service along with role to a user        |
+| [```/v1/api/users/{externalId}/second-factor```](/docs/api_specification.md#post-v1apiusersexternalidsecondfactor)  | POST    | Send OTP via SMS for an existing user |
 | [```/v1/api/users/{externalId}/second-factor/provision```](/docs/api_specification.md#post-v1apiusersexternalidsecondfactorprovision)  | POST    | Create a new provisional OTP key for a user |
 | [```/v1/api/users/{externalId}/second-factor/activate```](/docs/api_specification.md#post-v1apiusersexternalidsecondfactoractivate)  | POST    | Activate a new OTP key and method for a user |
 | [```/v1/api/users/authenticate```](/docs/api_specification.md#post-v1apiusersauthenticate)              | POST    |  Authenticate a given username/password            |

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -529,11 +529,45 @@ Content-Type: application/json
 }
 ```
 
+## POST /v1/api/users/`{externalId}`/second-factor
+
+This endpoint sends an OTP to a user’s phone number via SMS.
+
+If the `provisional` field is `false` or not present, the message explains to the user that the code is for signing in.
+
+If the `provisional` field is `true`, the user’s provisional OTP key (see [```/v1/api/users/{externalId}/second-factor/provision```](#post-v1apiusersexternalidsecond-factorprovision)) is used and the message explains to the user that the code is for changing their sign-in method.
+
+### Notes
+
+Will return `404` if the external ID does not match a user or if `"provisional": true` is used but the user does not have a provisional OTP key.
+
+### Request example
+
+```
+POST /v1/api/users/7d19aff33f8948deb97ed16b2912dcd3/second-factor
+
+{
+    "provisional": true
+}
+```
+
+#### Request body description
+
+| Field         | Required | Description                                                                                   | Supported Values  |
+| --------------|:--------:| ----------------------------------------------------------------------------------------------|-------------------|
+| `provisional` |          | `true` if the user is changing their sign-in method; `false` (default) if they are signing in | `true` or `false` |
+
+### Response example
+
+```
+200 OK
+```
+
 ## POST /v1/api/users/`{externalId}`/second-factor/provision
 
 This endpoint provisions a new second-factor OTP key (secret used to generate OTP codes) for a user.
 
-Provisioning a new key does not change immediately change the user’s current key. Use the [```/v1/api/users/second-factor/activate```](#post-v1apiusersexternalidsecondfactoractivate) endpoint to replace the user’s current key with the newly-provisioned one.
+Provisioning a new key does not change immediately change the user’s current key. Use the [```/v1/api/users/{externalId}/second-factor/activate```](#post-v1apiusersexternalidsecond-factoractivate) endpoint to replace the user’s current key with the newly-provisioned one.
 
 ### Request example
 
@@ -556,7 +590,7 @@ See [The user object](#the-user-object)
 
 This endpoint activates the provisional OTP key for a user and configures their second-factor authentication method.
 
-The user should have already a provisional OTP key created by the [```/v1/api/users/second-factor/provision```](#post-v1apiusersexternalidsecondfactorprovision) endpoint before this endpoint is called.
+The user should have already a provisional OTP key created by the [```/v1/api/users/{externalId}/second-factor/provision```](#post-v1apiusersexternalidsecond-factorprovision) endpoint before this endpoint is called.
 
 ### Request example
 


### PR DESCRIPTION
Update README to reflect that `NOTIFY_2FA_TEMPLATE_ID` is no more and add some docs for `/v1/api/users/{externalId}/second-factor`, which had docs before.