### PR TITLE
PP-6029: Add PaaS manifest

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,19 @@
+memory: 500M
+disk_quota: 500M
+disable_internal_https: 'true'
+run_migration: 'true'
+support_url: https://example.com
+
+# Stub services
+db_password: mysecretpassword
+db_user: connector
+db_name: connector
+db_ssl_option: ssl=none
+
+metrics_host: localhost
+metrics_port: '8092'
+
+notify_api_key: api_key-pay-notify-service-id-pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs
+notify_base_url: https://example.com/notify
+notify_receipt_email_template_id: email-template-id
+notify_refund_email_template_id: email-refund-issued-template-id

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,47 @@
+---
+applications:
+  - name: adminusers
+    buildpacks:
+      - java_buildpack
+    path: target/pay-adminusers-0.1-SNAPSHOT-allinone.jar
+    health-check-type: http
+    health-check-http-endpoint: '/healthcheck'
+    health-check-invocation-timeout: 5
+    memory: ((memory))
+    disk_quota: ((disk_quota))
+    env:
+      ADMIN_PORT: '9301'
+      BASE_URL: ((adminusers_url))
+      ENVIRONMENT: ((space))
+      FORGOTTEN_PASSWORD_EXPIRY_MINUTES: '90'
+      JAVA_OPTS: -Xms512m -Xmx1G
+      JBP_CONFIG_JAVA_MAIN: '{ arguments: "server /home/vcap/app/config/config.yaml" }'
+      JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 11.+ } }'
+      JPA_LOG_LEVEL: 'INFO'
+      JPA_SQL_LOG_LEVEL: 'INFO'
+      LOGIN_ATTEMPT_CAP: '10'
+      RUN_APP: 'true'
+      RUN_MIGRATION: ((run_migration))
+      SELFSERVICE_URL: ((selfservice_url))
+      SUPPORT_URL: ((support_url))
+
+      # Provided via metrics service
+      METRICS_HOST: ((metrics_host))
+      METRICS_PORT: ((metrics_port))
+
+      # Provide via connector-db service
+      DB_HOST: postgres-((space)).apps.internal
+      DB_NAME: ((db_name))
+      DB_PASSWORD: ((db_password))
+      DB_USER: ((db_user))
+      DB_SSL_OPTION: ((db_ssl_option))
+
+      # Provide via notify service
+      NOTIFY_API_KEY: ((notify_api_key))
+      NOTIFY_BASE_URL: ((notify_base_url))
+
+      # Provide via notify-direct-debit service
+      NOTIFY_DIRECT_DEBIT_API_KEY: ((notify_api_key))
+
+    routes:
+      - route: ((adminusers_route))


### PR DESCRIPTION
## WHAT YOU DID

This adds a PaaS `manifest.yml` and a `dev.yml` suitable for pushing the
app to dev environments.

## How to test

Usage:

    cf push --vars-file dev.yml \
      --var adminusers_url=http://adminusers-dev-<you>.apps.internal:8080 \
      --var adminusers_route=adminusers-dev-<you>.apps.internal \
      --var selfservice_url=https://pay-selfservice-dev-<you>.london.cloudapps.digital \
      --var space=dev-<you>


- Push adminusers to your own PaaS dev environment
- Check adminusers starts and runs successfully

## Code review checklist

### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [x] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition