### PR TITLE
PP-6085 Add env-map buildpack

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,6 +2,7 @@
 applications:
   - name: adminusers
     buildpacks:
+      - https://github.com/alphagov/env-map-buildpack.git#v2
       - java_buildpack
     path: target/pay-adminusers-0.1-SNAPSHOT-allinone.jar
     health-check-type: http
@@ -9,9 +10,12 @@ applications:
     health-check-invocation-timeout: 5
     memory: ((memory))
     disk_quota: ((disk_quota))
+    services:
+      - app-catalog
+      - adminusers-db
     env:
+      ENV_MAP_BP_USE_APP_PROFILE_DIR: true
       ADMIN_PORT: '9301'
-      BASE_URL: ((adminusers_url))
       ENVIRONMENT: ((space))
       FORGOTTEN_PASSWORD_EXPIRY_MINUTES: '90'
       JAVA_OPTS: -Xms512m -Xmx1G
@@ -22,26 +26,23 @@ applications:
       LOGIN_ATTEMPT_CAP: '10'
       RUN_APP: 'true'
       RUN_MIGRATION: ((run_migration))
-      SELFSERVICE_URL: ((selfservice_url))
+
       SUPPORT_URL: ((support_url))
 
-      # Provided via metrics service
       METRICS_HOST: ((metrics_host))
       METRICS_PORT: ((metrics_port))
 
-      # Provide via connector-db service
-      DB_HOST: postgres-((space)).apps.internal
-      DB_NAME: ((db_name))
-      DB_PASSWORD: ((db_password))
-      DB_USER: ((db_user))
-      DB_SSL_OPTION: ((db_ssl_option))
-
-      # Provide via notify service
       NOTIFY_API_KEY: ((notify_api_key))
       NOTIFY_BASE_URL: ((notify_base_url))
-
-      # Provide via notify-direct-debit service
       NOTIFY_DIRECT_DEBIT_API_KEY: ((notify_api_key))
 
-    routes:
-      - route: ((adminusers_route))
+      # Provided via app-catalog bound service, see env-map.yml
+      BASE_URL: ""
+      SELFSERVICE_URL: ""
+
+      # Provide via adminusers-db service, see env-map.yml
+      DB_HOST: ""
+      DB_NAME: ""
+      DB_PASSWORD: ""
+      DB_USER: ""
+      DB_SSL_OPTION: ""

--- a/src/main/resources/env-map.yml
+++ b/src/main/resources/env-map.yml
@@ -1,0 +1,8 @@
+env_vars:
+  BASE_URL: '."user-provided"[0].credentials.adminusers_url'
+  SELFSERVICE_URL: '."user-provided"[0].credentials.selfservice_url'
+  DB_HOST: ".postgres[0].credentials.host"
+  DB_NAME:  ".postgres[0].credentials.name"
+  DB_PASSWORD: ".postgres[0].credentials.password"
+  DB_USER: ".postgres[0].credentials.username"
+


### PR DESCRIPTION
Take app url and database connection details from the bound apps
app-catalog and adminusers-db respectively. Use the env-map buildpack to
extract these variables from within VCAP-SERVICES and into existing env
vars to avoid changing the app to work on PaaS.

## WHAT YOU DID
Tested by manually pushing, the app starts and the vars are set...
```
gds5062 > cf ssh adminusers -c "/tmp/lifecycle/shell /home/vcap/app 'env | sort'" | grep URL
BASE_URL=http://adminusers-stg.apps.internal:8080
DATABASE_URL=postgres://ugswmvg7c22zbny7:cHjYJSnHua6BfosAcLOuk1rtYVx7zDDJ@rdsbroker-a5572787-5d99-45a2-8bcf-b9bbe0185f7e.c7uewwm9qebj.eu-west-1.rds.amazonaws.com:5432/rdsbroker_a5572787_5d99_45a2_8bcf_b9bbe0185f7e
SELFSERVICE_URL=https://selfservice.staging.gdspay.uk
```