### PR TITLE
PP-6085 Lookup DB creds using the service name within env-map.yml

### DIFF
--- a/src/main/resources/env-map.yml
+++ b/src/main/resources/env-map.yml
@@ -1,8 +1,8 @@
 env_vars:
-  BASE_URL: '."user-provided"[0].credentials.adminusers_url'
+  BASE_URL:        '."user-provided"[0].credentials.adminusers_url'
   SELFSERVICE_URL: '."user-provided"[0].credentials.selfservice_url'
-  DB_HOST: ".postgres[0].credentials.host"
-  DB_NAME:  ".postgres[0].credentials.name"
-  DB_PASSWORD: ".postgres[0].credentials.password"
-  DB_USER: ".postgres[0].credentials.username"
-
+  DB_HOST:         '.[][] | select(.name == "adminusers-db") | .credentials.host                    '
+  DB_NAME:         '.[][] | select(.name == "adminusers-db") | .credentials.name                    '
+  DB_PASSWORD:     '.[][] | select(.name == "adminusers-db") | .credentials.password                '
+  DB_USER:         '.[][] | select(.name == "adminusers-db") | .credentials.username                '
+  DB_SSL_OPTION:   '.[][] | select(.name == "adminusers-db") | .credentials.ssl_option // "ssl=true"'


### PR DESCRIPTION
The location of the DB credentials will change within VCAP_SERVICES if
the database is a postgres rds instance provided as a cf service
(under 'postgres'), or a container which we use in dev spaces (under
'user-provided').

'env-map.yml' should use the service name which should always be 'adminusers-db'
regardless of the environment.

## How to test
```
gds5062 > cf push -f manifest.yml --vars-file /Users/danworth/projects/gds/pay-omnibus/paas/env_variables/staging.yml

gds5062 > cf ssh adminusers -c "/tmp/lifecycle/shell /home/vcap/app 'env | sort'" | grep DB
```
The above queries return the correctly set env vars.
