### PR TITLE
PP-6152 Add `experimental_features_enabled` flag to services

### DIFF
--- a/src/main/resources/migrations/00058_add_column_experimental_features_enabled.sql
+++ b/src/main/resources/migrations/00058_add_column_experimental_features_enabled.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_column_experimental_features_enabled
+ALTER TABLE services ADD COLUMN experimental_features_enabled boolean NULL;


### PR DESCRIPTION
Allow services to opt into features in development without making specific
flags each time. 

Database migration for, default false, experimental features flag. 

Future improvements may allow generic JSONB flags to be
set on a column.
