### PR TITLE
PP-6152 Allow PATCH on experimental features flag

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
@@ -34,6 +34,7 @@ import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_MERCHANT_DETAIL
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_MERCHANT_DETAILS_TELEPHONE_NUMBER;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_REDIRECT_NAME;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_SERVICE_NAME_PREFIX;
+import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_EXPERIMENTAL_FEATURES_ENABLED;
 
 public class ServiceUpdateOperationValidator {
 
@@ -63,6 +64,7 @@ public class ServiceUpdateOperationValidator {
                 entry(FIELD_GATEWAY_ACCOUNT_IDS, singletonList(ADD)),
                 entry(FIELD_CUSTOM_BRANDING, singletonList(REPLACE)),
                 entry(FIELD_REDIRECT_NAME, singletonList(REPLACE)),
+                entry(FIELD_EXPERIMENTAL_FEATURES_ENABLED, singletonList(REPLACE)),
                 entry(FIELD_COLLECT_BILLING_ADDRESS, singletonList(REPLACE)),
                 entry(FIELD_CURRENT_GO_LIVE_STAGE, singletonList(REPLACE)),
                 entry(FIELD_MERCHANT_DETAILS_NAME, singletonList(REPLACE)),
@@ -112,6 +114,8 @@ public class ServiceUpdateOperationValidator {
         } else if (path.startsWith(FIELD_SERVICE_NAME_PREFIX)) {
             return validateServiceNameValue(operation, path);
         } else if (FIELD_REDIRECT_NAME.equals(path)) {
+            return validateMandatoryBooleanValue(operation);
+        } else if (FIELD_EXPERIMENTAL_FEATURES_ENABLED.equals(path)) {
             return validateMandatoryBooleanValue(operation);
         } else if (FIELD_COLLECT_BILLING_ADDRESS.equals(path)) {
             return validateMandatoryBooleanValue(operation);

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
@@ -30,6 +30,7 @@ public class ServiceUpdater {
     public static final String FIELD_CUSTOM_BRANDING = "custom_branding";
     public static final String FIELD_SERVICE_NAME_PREFIX = "service_name";
     public static final String FIELD_REDIRECT_NAME = "redirect_to_service_immediately_on_terminal_state";
+    public static final String FIELD_EXPERIMENTAL_FEATURES_ENABLED = "experimental_features_enabled";
     public static final String FIELD_COLLECT_BILLING_ADDRESS = "collect_billing_address";
     public static final String FIELD_CURRENT_GO_LIVE_STAGE = "current_go_live_stage";
     public static final String FIELD_MERCHANT_DETAILS_NAME = "merchant_details/name";
@@ -49,6 +50,7 @@ public class ServiceUpdater {
                 entry(FIELD_GATEWAY_ACCOUNT_IDS, assignGatewayAccounts()),
                 entry(FIELD_CUSTOM_BRANDING, updateCustomBranding()),
                 entry(FIELD_REDIRECT_NAME, updateRedirectImmediately()),
+                entry(FIELD_EXPERIMENTAL_FEATURES_ENABLED, updateExperimentalFeaturesEnabled()),
                 entry(FIELD_COLLECT_BILLING_ADDRESS, updateCollectBillingAddress()),
                 entry(FIELD_CURRENT_GO_LIVE_STAGE, updateCurrentGoLiveStage()),
                 entry(FIELD_MERCHANT_DETAILS_NAME, updateMerchantDetailsName()),
@@ -124,6 +126,10 @@ public class ServiceUpdater {
     private BiConsumer<ServiceUpdateRequest, ServiceEntity> updateRedirectImmediately() {
         return (serviceUpdateRequest, serviceEntity) ->
                 serviceEntity.setRedirectToServiceImmediatelyOnTerminalState(serviceUpdateRequest.valueAsBoolean());
+    }
+    
+    private BiConsumer<ServiceUpdateRequest, ServiceEntity> updateExperimentalFeaturesEnabled() {
+        return ((serviceUpdateRequest, serviceEntity) -> serviceEntity.setExperimentalFeaturesEnabled(serviceUpdateRequest.valueAsBoolean()));
     }
 
     private BiConsumer<ServiceUpdateRequest, ServiceEntity> updateCollectBillingAddress() {

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
@@ -115,6 +115,16 @@ public class ServiceUpdateOperationValidatorTest {
     }
 
     @Test
+    public void shouldSucceed_whenUpdateExperimentalFeaturesEnabled() {
+        replaceShouldSucceed("experimental_features_enabled", true);
+    }
+
+    @Test
+    public void shouldFail_whenUpdateExperimentalFeaturesEnabled_whenOpIsNotReplace() {
+        shouldFailForAddOperation("experimental_features_enabled", true);
+    }
+
+    @Test
     public void shouldFail_whenUpdateRedirectToService_whenOpIsNotReplace() {
         shouldFailForAddOperation("redirect_to_service_immediately_on_terminal_state", true);
     }

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceUpdateTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceUpdateTest.java
@@ -477,4 +477,29 @@ public class ServiceResourceUpdateTest extends ServiceResourceBaseTest {
 
         assertThat(json.get("errors"), is(Collections.singletonList("Field [value] must be a boolean")));
     }
+
+    @Test
+    public void shouldUpdateExperimentalFeaturesEnabled_toTrue() {
+        ServiceEntity thisServiceEntity = ServiceEntityBuilder
+                .aServiceEntity()
+                .withExperimentalFeaturesEnabled(false)
+                .build();
+        String externalId = thisServiceEntity.getExternalId();
+
+        String jsonPayload = fixture("fixtures/resource/service/patch/replace_experimental_features_enabled_to_true.json");
+
+        when(mockedServiceDao.findByExternalId(externalId)).thenReturn(Optional.of(thisServiceEntity));
+        when(mockedServiceDao.merge(thisServiceEntity)).thenReturn(thisServiceEntity);
+
+        Response response = RESOURCES.target(format(API_PATH, thisServiceEntity.getExternalId()))
+                .request()
+                .method("PATCH", Entity.json(jsonPayload));
+
+        assertThat(response.getStatus(), is(200));
+
+        String body = response.readEntity(String.class);
+        JsonPath json = JsonPath.from(body);
+
+        assertThat(json.get("experimental_features_enabled"), is(true));
+    }
 }

--- a/src/test/resources/fixtures/resource/service/patch/replace_experimental_features_enabled_to_true.json
+++ b/src/test/resources/fixtures/resource/service/patch/replace_experimental_features_enabled_to_true.json
@@ -1,0 +1,5 @@
+{
+  "op": "replace",
+  "path": "experimental_features_enabled",
+  "value": true
+}


### PR DESCRIPTION
Update service updater to allow `experimental_features_enabled` to
respond to the `update` PATCH request, enforcing a boolean value.