### PR TITLE
PP-6254: Add Carbon Relay metrics config

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -40,6 +40,8 @@ applications:
       BASE_URL: ""
       SELFSERVICE_URL: ""
       SUPPORT_URL: ""
+      METRICS_HOST: ""
+      METRICS_PORT: ""
 
       # Provide via adminusers-db service, see env-map.yml
       DB_HOST: ""

--- a/src/main/resources/env-map.yml
+++ b/src/main/resources/env-map.yml
@@ -10,3 +10,5 @@ env_vars:
   NOTIFY_API_KEY:              '.[][] | select(.name == "adminusers-secret-service") | .credentials.notify_api_key'
   NOTIFY_DIRECT_DEBIT_API_KEY: '.[][] | select(.name == "adminusers-secret-service") | .credentials.notify_direct_debit_api_key'
   SENTRY_DSN:                  '.[][] | select(.name == "adminusers-secret-service") | .credentials.sentry_dsn'
+  METRICS_HOST:                '.[][] | select(.name == "app-catalog")               | .credentials.carbon_relay_route'
+  METRICS_PORT:                '.[][] | select(.name == "app-catalog")               | .credentials.carbon_relay_port'


### PR DESCRIPTION
Set the `METRICS_HOST` and `METRICS_PORT` from the app-catalog to send
metrics to the carbon-relay app.