### PR TITLE
PP-6633 Add Stripe account update permissions

### DIFF
--- a/src/main/resources/migrations/00061_add_stripe_account_details_permission.sql
+++ b/src/main/resources/migrations/00061_add_stripe_account_details_permission.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:stripe_account_details_update_permission
+INSERT INTO  permissions(id, name, description) VALUES (48, 'stripe-account-details:update', 'UpdateStripeAccountDetails');
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'super-admin'), (SELECT id FROM permissions WHERE name = 'stripe-account-details:update'), NOW(), NOW());
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'admin'), (SELECT id FROM permissions WHERE name = 'stripe-account-details:update'), NOW(), NOW());

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationIT.java
@@ -49,7 +49,7 @@ public class UserResourceAuthenticationIT extends IntegrationTest {
                 .body("disabled", is(false))
                 .body("_links", hasSize(1))
                 .body("service_roles[0].role.name", is("admin"))
-                .body("service_roles[0].role.permissions", hasSize(46));
+                .body("service_roles[0].role.permissions", hasSize(47));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateIT.java
@@ -109,7 +109,7 @@ public class UserResourceCreateIT extends IntegrationTest {
                 .body("disabled", is(false))
                 .body("service_roles[0].role.name", is("admin"))
                 .body("service_roles[0].role.description", is("Administrator"))
-                .body("service_roles[0].role.permissions", hasSize(46));
+                .body("service_roles[0].role.permissions", hasSize(47));
 
         response
                 .body("_links", hasSize(1))


### PR DESCRIPTION
## WHAT YOU DID
- Added new permission `stripe-account-details:update` so users with this permission can be shown Stripe account status in selfservice

