### PR TITLE
Remove Apache commons collections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,11 +158,6 @@
             <version>3.10</version>
         </dependency>
         <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-            <version>3.2.2</version>
-        </dependency>
-        <dependency>
             <groupId>org.mindrot</groupId>
             <artifactId>jbcrypt</artifactId>
             <version>0.4</version>
@@ -186,12 +181,6 @@
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
             <version>1.6</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-collections</groupId>
-                    <artifactId>commons-collections</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.googlecode.libphonenumber</groupId>

--- a/src/main/java/uk/gov/pay/adminusers/model/Role.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Role.java
@@ -8,8 +8,6 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.commons.collections.CollectionUtils.isEqualCollection;
-
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class Role {
 
@@ -73,7 +71,7 @@ public class Role {
             return false;
         }
 
-        return isEqualCollection(permissions, role.permissions);
+        return permissions == null && role.permissions == null || permissions.equals(role.permissions);
     }
 
     @Override


### PR DESCRIPTION
Commons collections is only used in one place, and can be replaced by `List.equals()`