### PR TITLE
BAU — Use sets rather than lists for permissions on roles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,11 +158,6 @@
             <version>3.10</version>
         </dependency>
         <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-            <version>3.2.2</version>
-        </dependency>
-        <dependency>
             <groupId>org.mindrot</groupId>
             <artifactId>jbcrypt</artifactId>
             <version>0.4</version>
@@ -186,12 +181,6 @@
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
             <version>1.6</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-collections</groupId>
-                    <artifactId>commons-collections</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.googlecode.libphonenumber</groupId>

--- a/src/main/java/uk/gov/pay/adminusers/model/Role.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Role.java
@@ -5,10 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.apache.commons.collections.CollectionUtils.isEqualCollection;
+import java.util.HashSet;
+import java.util.Set;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class Role {
@@ -17,7 +15,7 @@ public class Role {
     private Integer id;
     private String name;
     private String description;
-    private List<Permission> permissions = new ArrayList<>();
+    private Set<Permission> permissions = new HashSet<>();
 
     public static Role role(Integer roleId, String name, String description) {
         return new Role(roleId, name, description);
@@ -41,11 +39,11 @@ public class Role {
         return description;
     }
 
-    public void setPermissions(List<Permission> permissions) {
+    public void setPermissions(Set<Permission> permissions) {
         this.permissions = permissions;
     }
 
-    public List<Permission> getPermissions() {
+    public Set<Permission> getPermissions() {
         return permissions;
     }
 
@@ -73,7 +71,7 @@ public class Role {
             return false;
         }
 
-        return isEqualCollection(permissions, role.permissions);
+        return permissions.equals(role.permissions);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/RoleEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/RoleEntity.java
@@ -11,10 +11,10 @@ import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.HashSet;
+import java.util.Set;
 
+import static java.util.stream.Collectors.toUnmodifiableSet;
 import static uk.gov.pay.adminusers.persistence.entity.Role.ADMIN;
 
 /**
@@ -43,7 +43,7 @@ public class RoleEntity {
     @ManyToMany(fetch = FetchType.EAGER, targetEntity = PermissionEntity.class)
     @JoinTable(name = "role_permission", joinColumns = @JoinColumn(name = "role_id", referencedColumnName = "id"),
             inverseJoinColumns = @JoinColumn(name = "permission_id", referencedColumnName = "id"))
-    private List<PermissionEntity> permissions = new ArrayList<>();
+    private Set<PermissionEntity> permissions = new HashSet<>();
 
     public RoleEntity() {
         //for jpa
@@ -53,8 +53,7 @@ public class RoleEntity {
         this.id = role.getId();
         this.name = role.getName();
         this.description = role.getDescription();
-        this.permissions = role.getPermissions().stream()
-                .map(PermissionEntity::new).collect(Collectors.toList());
+        this.permissions = role.getPermissions().stream().map(PermissionEntity::new).collect(toUnmodifiableSet());
     }
 
     public Integer getId() {
@@ -81,17 +80,17 @@ public class RoleEntity {
         this.description = description;
     }
 
-    public List<PermissionEntity> getPermissions() {
+    public Set<PermissionEntity> getPermissions() {
         return permissions;
     }
 
-    public void setPermissions(List<PermissionEntity> permissions) {
+    public void setPermissions(Set<PermissionEntity> permissions) {
         this.permissions = permissions;
     }
 
     public Role toRole() {
         Role role = Role.role(id, name, description);
-        role.setPermissions(permissions.stream().map(PermissionEntity::toPermission).collect(Collectors.toList()));
+        role.setPermissions(permissions.stream().map(PermissionEntity::toPermission).collect(toUnmodifiableSet()));
         return role;
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/RoleDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/RoleDbFixture.java
@@ -4,7 +4,7 @@ import uk.gov.pay.adminusers.model.Permission;
 import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.utils.DatabaseTestHelper;
 
-import java.util.List;
+import java.util.Set;
 
 import static org.apache.commons.lang3.RandomStringUtils.random;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
@@ -42,7 +42,7 @@ public class RoleDbFixture {
         for (Permission permission : permissions) {
             databaseHelper.add(permission);
         }
-        role.setPermissions(List.of(permissions));
+        role.setPermissions(Set.of(permissions));
         databaseHelper.add(role);
         return role;
     }

--- a/src/test/java/uk/gov/pay/adminusers/model/UserEntityTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/UserEntityTest.java
@@ -9,6 +9,7 @@ import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -50,7 +51,7 @@ public class UserEntityTest {
         String gatewayAccountId = "1";
         ServiceEntity service = new ServiceEntity(List.of(gatewayAccountId));
         Role role = role(1, "role", "hey");
-        role.setPermissions(List.of(permission(1, "perm1", "perm1 desc"), permission(2, "perm2", "perm2 desc")));
+        role.setPermissions(Set.of(permission(1, "perm1", "perm1 desc"), permission(2, "perm2", "perm2 desc")));
         RoleEntity roleEntity = new RoleEntity(role);
         ServiceRoleEntity serviceRole = new ServiceRoleEntity(service, roleEntity);
 

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoIT.java
@@ -274,7 +274,7 @@ public class ServiceDaoIT extends DaoTestBase {
         databaseHelper.add(perm1).add(perm2);
 
         Role role = role(roleId, "role-" + roleId, "role-desc-" + roleId);
-        role.setPermissions(List.of(perm1, perm2));
+        role.setPermissions(Set.of(perm1, perm2));
         databaseHelper.add(role);
 
         String gatewayAccountId1 = randomInt().toString();

--- a/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
@@ -29,10 +29,10 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static java.util.Collections.emptyList;
@@ -685,7 +685,7 @@ public class UserServicesTest {
         serviceEntity.setId(randomInt());
 
         Role role = aRole();
-        role.setPermissions(Collections.singletonList(aPermission()));
+        role.setPermissions(Set.of(aPermission()));
 
         ServiceRoleEntity serviceRoleEntity = new ServiceRoleEntity(serviceEntity, new RoleEntity(role));
         userEntity.addServiceRole(serviceRoleEntity);


### PR DESCRIPTION
Use sets rather than lists for permissions on roles. It doesn’t make sense to have the same permission more than once, so a set is a better fit than a list.

This also allows us to stop using Apache Commons Collections’ `isEqualCollection(…)` method, which allows us to remove the dependency on Commons Collections altogether.

We were explicitly overriding Commons Validator’s dependency on Commons Collections with our own but both Commons Validator and us were depending on the same 3.2.2 version so removing this exclusion will have no effect.

Inspired by https://github.com/alphagov/pay-adminusers/pull/775/commits/2fe336f99541c64503dabe624321ba408d859e3e by @rhowe.