### PR TITLE
Replace Apache commons-lang with commons-lang3

### DIFF
--- a/src/test/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntityBuilder.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntityBuilder.java
@@ -1,12 +1,12 @@
 package uk.gov.pay.adminusers.persistence.entity;
 
-import org.apache.commons.lang.math.RandomUtils;
 import uk.gov.pay.adminusers.app.util.RandomIdGenerator;
 import uk.gov.pay.adminusers.model.GoLiveStage;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
+import static org.apache.commons.lang3.RandomUtils.nextInt;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -14,7 +14,7 @@ import java.util.Map;
 import java.util.Set;
 
 public final class ServiceEntityBuilder {
-    private Integer id = RandomUtils.nextInt();
+    private Integer id = nextInt();
     private String externalId = RandomIdGenerator.randomUuid();
     private String name = Service.DEFAULT_NAME_VALUE;
     private MerchantDetailsEntity merchantDetailsEntity = MerchantDetailsEntityBuilder.aMerchantDetailsEntity().build();

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceRequestValidatorTest.java
@@ -3,7 +3,6 @@ package uk.gov.pay.adminusers.resources;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,6 +17,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -166,7 +166,7 @@ public class ServiceRequestValidatorTest {
 
     @Test(expected = ValidationException.class)
     public void shouldFail_updatingMerchantDetails_whenEmailOver255() throws ValidationException {
-        String longEmail = RandomStringUtils.randomAlphanumeric(256);
+        String longEmail = randomAlphanumeric(256);
         ObjectNode payload = createMerchantDetailsJsonPayload(DEFAULT_MERCHANT_DETAILS_NAME, longEmail);
 
         try {
@@ -179,7 +179,7 @@ public class ServiceRequestValidatorTest {
 
     @Test(expected = ValidationException.class)
     public void shouldFail_updatingMerchantDetails_whenNameOver255() throws ValidationException {
-        String longName = RandomStringUtils.randomAlphanumeric(256);
+        String longName = randomAlphanumeric(256);
         ObjectNode payload = createMerchantDetailsJsonPayload(longName, DEFAULT_MERCHANT_DETAILS_EMAIL);
 
         try {

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Test;
 import uk.gov.pay.adminusers.validations.RequestValidations;
 
@@ -10,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -571,7 +571,7 @@ public class ServiceUpdateOperationValidatorTest {
         ObjectNode payload = mapper.createObjectNode();
         payload.put("path", path);
         payload.put("op", "replace");
-        payload.put("value", RandomStringUtils.randomAlphanumeric(expectedMaxLength + 1));
+        payload.put("value", randomAlphanumeric(expectedMaxLength + 1));
         List<String> errors = serviceUpdateOperationValidator.validate(payload);
         assertThat(errors.size(), is(1));
         assertThat(errors, hasItem(String.format("Field [value] must have a maximum length of %s characters", expectedMaxLength)));

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceGetIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceGetIT.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.adminusers.resources;
 
-import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Test;
 import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.model.Service;
@@ -9,6 +8,7 @@ import uk.gov.pay.adminusers.model.User;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static java.lang.String.valueOf;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.apache.commons.lang3.RandomUtils.nextInt;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
@@ -74,7 +74,7 @@ public class UserResourceGetIT extends IntegrationTest {
         givenSetup()
                 .when()
                 .accept(JSON)
-                .get(format(USER_RESOURCE_URL, RandomStringUtils.randomAlphanumeric(256)))
+                .get(format(USER_RESOURCE_URL, randomAlphanumeric(256)))
                 .then()
                 .statusCode(404);
     }


### PR DESCRIPTION
commons-lang isn't actually declared as a dependency so it's a bit naughty to rely on it being there. Switch to commons-lang3, which we do depend on.

Originally contributed by @rhowe in https://github.com/alphagov/pay-adminusers/pull/776.