### PR TITLE
PP-6257 Add reporting columns to services table

### DIFF
--- a/src/main/resources/migrations/00062_add_services_reporting_columns.sql
+++ b/src/main/resources/migrations/00062_add_services_reporting_columns.sql
@@ -1,0 +1,19 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_services_column_internal
+ALTER TABLE services ADD COLUMN internal BOOLEAN NULL;
+--rollback ALTER TABLE services DROP COLUMN internal;
+
+--changeset uk.gov.pay:add_services_column_archived
+ALTER TABLE services ADD COLUMN archived BOOLEAN NULL;
+ALTER TABLE services ALTER COLUMN archived SET DEFAULT false;
+--rollback ALTER TABLE services DROP COLUMN archived;
+
+--changeset uk.gov.pay:add_services_column_created_date
+ALTER TABLE services ADD COLUMN created_date TIMESTAMP WITH TIME ZONE;
+ALTER TABLE services ALTER COLUMN created_date SET DEFAULT (now() at time zone 'utc');
+--rollback ALTER TABLE services DROP COLUMN created_date;
+
+--changeset uk.gov.pay:add_services_column_went_live_date
+ALTER TABLE services ADD COLUMN went_live_date TIMESTAMP WITH TIME ZONE;
+--rollback ALTER TABLE services DROP COLUMN went_live_date;


### PR DESCRIPTION
- Add `internal` column to indicate whether the service was created for internal testing purposes.
- Add `archived` column to indicate that a service is not in use. Currently this is just for reporting purposes but we could use this in future to affect visibility of a service.
- Add `created_date` column to record the date when the service was created.
- Add `went_live_date` column to record the date when the service was made live.