### PR TITLE
PP-6257 Refactor service update validator tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,6 +281,12 @@
             <artifactId>jaxb-api</artifactId>
             <version>2.3.1</version>
         </dependency>
+        <dependency>
+            <groupId>pl.pragmatists</groupId>
+            <artifactId>JUnitParams</artifactId>
+            <version>1.1.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
@@ -142,8 +142,9 @@ public class ServiceUpdateOperationValidator {
         return Collections.emptyList();
     }
 
-    private List<String> validateCustomBrandingValue(JsonNode operation) {
-        return checkIfValidJson(operation.get(FIELD_VALUE), FIELD_CUSTOM_BRANDING);
+    private List<String> validateCustomBrandingValue(JsonNode operation) { ;
+        return requestValidations.checkExists(operation, FIELD_VALUE)
+                .orElseGet(() -> checkIfValidJson(operation.get(FIELD_VALUE), FIELD_CUSTOM_BRANDING));
     }
 
     private List<String> validateServiceNameValue(JsonNode operation, String path) {

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
@@ -2,7 +2,10 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import uk.gov.pay.adminusers.validations.RequestValidations;
 
 import java.util.List;
@@ -14,10 +17,11 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
+@RunWith(JUnitParamsRunner.class)
 public class ServiceUpdateOperationValidatorTest {
 
     private static final String GO_LIVE_STAGE_INVALID_ERROR_MESSAGE = "Field [value] must be one of [NOT_STARTED, ENTERED_ORGANISATION_NAME, ENTERED_ORGANISATION_ADDRESS, CHOSEN_PSP_STRIPE, CHOSEN_PSP_WORLDPAY, CHOSEN_PSP_SMARTPAY, CHOSEN_PSP_EPDQ, TERMS_AGREED_STRIPE, TERMS_AGREED_WORLDPAY, TERMS_AGREED_SMARTPAY, TERMS_AGREED_EPDQ, DENIED, LIVE]";
-    
+
     private final ObjectMapper mapper = new ObjectMapper();
     private final ServiceUpdateOperationValidator serviceUpdateOperationValidator = new ServiceUpdateOperationValidator(new RequestValidations());
 
@@ -34,503 +38,84 @@ public class ServiceUpdateOperationValidatorTest {
 
     @Test
     public void shouldFail_whenUpdate_whenInvalidPath() {
-        Map<String, String> payload = Map.of(
-                "path", "xyz",
-                "op", "replace",
-                "value", "example-name");
-
-        List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
-
-        assertThat(errors.size(), is(1));
-        assertThat(errors, hasItem("Path [xyz] is invalid"));
-    }
-
-    @Test
-    public void shouldFail_whenUpdate_whenInvalidOperationForSuppliedPath() {
-        shouldFailForAddOperation("collect_billing_address", false);
-    }
-
-    @Test
-    public void shouldSuccess_replacingCustomBranding() {
-        Map<String, String> branding = Map.of("image_url", "image url", "css_url", "css url");
-        replaceShouldSucceed("custom_branding", branding);
-    }
-
-    @Test
-    public void shouldSuccess_replacingCustomBranding_forEmptyObject() {
-        replaceShouldSucceed("custom_branding", emptyMap());
-    }
-
-    @Test
-    public void shouldError_ifCustomBrandingIsEmptyString() {
-        replaceShouldFailWhenValueIsEmptyString("custom_branding", "Value for path [custom_branding] must be a JSON");
-    }
-
-    @Test
-    public void shouldError_ifCustomBrandingIsNull() {
-        replaceShouldFailWhenValueIsNull("custom_branding", "Value for path [custom_branding] must be a JSON");
-    }
-
-    @Test
-    public void shouldError_replacingCustomBranding_ifValueIsNotJSON() {
-        replaceShouldFailWhenValueIsString("custom_branding", "Value for path [custom_branding] must be a JSON");
-    }
-
-    @Test
-    public void shouldSuccess_whenUpdateServiceName_withAllFieldsPresentAndValid() {
-        replaceShouldSucceed("service_name/en", "example-name");
-    }
-
-    @Test
-    public void shouldSuccess_whenUpdateServiceName_withAllFieldsPresentAndWelshServiceNameBlank() {
-        replaceShouldSucceed("service_name/cy", " ");
-    }
-
-    @Test
-    public void shouldFail_whenUpdateServiceName_withAllFieldsPresentAndEnglishServiceNameBlank() {
-        replaceShouldFailWhenValueIsEmptyString("service_name/en");
-    }
-
-    @Test
-    public void shouldFail_whenUpdateServiceName_whenServiceNameFieldPresentAndItIsTooLong() {
-        replaceShouldFailWhenStringValueIsTooLong("service_name/en", 50);
+        shouldFail("xyz", "replace", "any value", "Path [xyz] is invalid");
     }
 
     @Test
     public void shouldFail_whenUpdateServiceName_whenPathContainsUnsupportedLanguage() {
-        Map<String, String> payload = Map.of(
-                "path", "service_name/xx",
-                "op", "replace",
-                "value", "example-name");
-
-        List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
-
-        assertThat(errors.size(), is(1));
-        assertThat(errors, hasItem("Path [service_name/xx] is invalid"));
-    }
-
-    @Test
-    public void shouldSucceed_whenUpdateRedirectToService() {
-        replaceShouldSucceed("redirect_to_service_immediately_on_terminal_state", true);
-    }
-
-    @Test
-    public void shouldSucceed_whenUpdateExperimentalFeaturesEnabled() {
-        replaceShouldSucceed("experimental_features_enabled", true);
-    }
-
-    @Test
-    public void shouldFail_whenUpdateExperimentalFeaturesEnabled_whenOpIsNotReplace() {
-        shouldFailForAddOperation("experimental_features_enabled", true);
-    }
-
-    @Test
-    public void shouldFail_whenUpdateRedirectToService_whenOpIsNotReplace() {
-        shouldFailForAddOperation("redirect_to_service_immediately_on_terminal_state", true);
-    }
-
-    @Test
-    public void shouldFail_whenUpdateRedirectToService_whenValueIsNotBoolean() {
-        replaceShouldFailWhenValueIsString("redirect_to_service_immediately_on_terminal_state", "Field [value] must be a boolean");
-    }
-
-    @Test
-    public void shouldFail_whenUpdateRedirectToService_whenMissingValue() {
-        replaceShouldFailWhenValueMissing("redirect_to_service_immediately_on_terminal_state");
-    }
-
-    @Test
-    public void shouldSucceed_whenUpdateCollectBillingAddress() {
-        replaceShouldSucceed("collect_billing_address", true);
-    }
-
-    @Test
-    public void shouldFail_whenUpdateCollectBillingAddress_whenOpIsNotReplace() {
-        shouldFailForAddOperation("collect_billing_address", true);
-    }
-
-    @Test
-    public void shouldFail_whenUpdateCollectBillingAddress_whenValueIsNotBoolean() {
-        replaceShouldFailWhenValueIsString("collect_billing_address", "Field [value] must be a boolean");
-    }
-
-    @Test
-    public void shouldFail_whenUpdateCollectBillingAddress_whenMissingValue() {
-        replaceShouldFailWhenValueMissing("collect_billing_address");
-    }
-
-    @Test
-    public void shouldFail_updatingServiceName_whenValueIsNumeric() {
-        replaceShouldFailWhenValueIsNumeric("service_name/en", "Field [value] must be a string");
-    }
-
-    @Test
-    public void shouldFail_updatingServiceName_whenValueIsBoolean() {
-        replaceShouldFailWhenValueIsBoolean("service_name/en", "Field [value] must be a string");
-    }
-
-    @Test
-    public void shouldFail_updatingCurrentGoLiveStage_whenInvalidValue() {
-        ObjectNode payload = mapper.createObjectNode();
-        payload.put("path", "current_go_live_stage");
-        payload.put("op", "replace");
-        payload.put("value", "CAKE_ORDERED");
-        List<String> errors = serviceUpdateOperationValidator.validate(payload);
-        assertThat(errors.size(), is(1));
-        assertThat(errors, hasItem(GO_LIVE_STAGE_INVALID_ERROR_MESSAGE));
-    }
-
-    @Test
-    public void shouldFail_updatingCurrentGoLiveStage_whenIncorrectOperation() {
-        shouldFailForAddOperation("current_go_live_stage", "CHOSEN_PSP_STRIPE");
-    }
-
-    @Test
-    public void shouldFail_updatingCurrentGoLiveStage_whenValueIsNumeric() {
-        replaceShouldFailWhenValueIsNumeric("current_go_live_stage", GO_LIVE_STAGE_INVALID_ERROR_MESSAGE);
-    }
-
-    @Test
-    public void shouldFail_updatingCurrentGoLiveStage_whenValueIsBoolean() {
-        replaceShouldFailWhenValueIsBoolean("current_go_live_stage", GO_LIVE_STAGE_INVALID_ERROR_MESSAGE);
-    }
-
-    @Test
-    public void shouldFail_updatingCurrentGoLiveStage_whenValueIsMissing() {
-        replaceShouldFailWhenValueMissing("current_go_live_stage");
-    }
-
-    @Test
-    public void shouldFail_updatingCurrentGoLiveStage_whenValueIsEmptyString() {
-        replaceShouldFailWhenValueIsEmptyString("current_go_live_stage");
-    }
-
-    @Test
-    public void shouldSucceed_updatingCurrentGoLiveStage() {
-        replaceShouldSucceed("current_go_live_stage", "CHOSEN_PSP_STRIPE");
-    }
-    
-    @Test
-    public void shouldFail_updatingMerchantDetailsName_whenNotAllowedOperation() {
-        shouldFailForAddOperation("merchant_details/name", "any value");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsName_whenValueIsNotString() {
-        replaceShouldFailWhenValueIsNumeric("merchant_details/name", "Field [value] must be a string");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsName_whenValueIsMissing() {
-        replaceShouldFailWhenValueMissing("merchant_details/name");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsName_whenValueIsNull() {
-        replaceShouldFailWhenValueIsNull("merchant_details/name");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsName_whenValueIsEmptyString() {
-        replaceShouldFailWhenValueIsEmptyString("merchant_details/name");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsName_whenValueIsTooLong() {
-        replaceShouldFailWhenStringValueIsTooLong("merchant_details/name", 255);
-    }
-
-    @Test
-    public void shouldSucceed_updatingMerchantDetailsName() {
-        replaceShouldSucceed("merchant_details/name", "Bob's Building Business");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressLine1_whenNotAllowedOperation() {
-        shouldFailForAddOperation("merchant_details/address_line1", "any value");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressLine1_whenValueIsNotString() {
-        replaceShouldFailWhenValueIsNumeric("merchant_details/address_line1", "Field [value] must be a string");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressLine1_whenValueIsMissing() {
-        replaceShouldFailWhenValueMissing("merchant_details/address_line1");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressLine1_whenValueIsNull() {
-        replaceShouldFailWhenValueIsNull("merchant_details/address_line1");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressLine1_whenValueIsEmptyString() {
-        replaceShouldFailWhenValueIsEmptyString("merchant_details/address_line1");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressLine1_whenValueIsTooLong() {
-        replaceShouldFailWhenStringValueIsTooLong("merchant_details/address_line1", 255);
-    }
-
-    @Test
-    public void shouldSucceed_updatingMerchantDetailsAddressLine1() {
-        replaceShouldSucceed("merchant_details/address_line1", "1 Builders Avenue");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressLine2_whenNotAllowedOperation() {
-        shouldFailForAddOperation("merchant_details/address_line2", "any value");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressLine2_whenValueIsNotString() {
-        replaceShouldFailWhenValueIsNumeric("merchant_details/address_line2", "Field [value] must be a string");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressLine2_whenValueIsMissing() {
-        replaceShouldFailWhenValueMissing("merchant_details/address_line2");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressLine2_whenValueIsNull() {
-        replaceShouldFailWhenValueIsNull("merchant_details/address_line2");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressLine2_whenValueIsTooLong() {
-        replaceShouldFailWhenStringValueIsTooLong("merchant_details/address_line2", 255);
-    }
-
-    @Test
-    public void shouldSucceed_updatingMerchantDetailsAddressLine2_whenValueIsEmptyString() {
-        replaceShouldSucceed("merchant_details/address_line2", "");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressCity_whenNotAllowedOperation() {
-        shouldFailForAddOperation("merchant_details/address_city", "any value");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressCity_whenValueIsNotString() {
-        replaceShouldFailWhenValueIsNumeric("merchant_details/address_city", "Field [value] must be a string");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressCity_whenValueIsMissing() {
-        replaceShouldFailWhenValueMissing("merchant_details/address_city");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressCity_whenValueIsNull() {
-        replaceShouldFailWhenValueIsNull("merchant_details/address_city");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressCity_whenValueIsEmptyString() {
-        replaceShouldFailWhenValueIsEmptyString("merchant_details/address_city");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressCity_whenValueIsTooLong() {
-        replaceShouldFailWhenStringValueIsTooLong("merchant_details/address_city", 255);
-    }
-
-    @Test
-    public void shouldSucceed_updatingMerchantDetailsAddressCity() {
-        replaceShouldSucceed("merchant_details/address_city", "Burnley");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressCountry_whenNotAllowedOperation() {
-        shouldFailForAddOperation("merchant_details/address_country", "any value");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressCountry_whenValueIsNotString() {
-        replaceShouldFailWhenValueIsNumeric("merchant_details/address_country", "Field [value] must be a string");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressCountry_whenValueIsMissing() {
-        replaceShouldFailWhenValueMissing("merchant_details/address_country");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressCountry_whenValueIsNull() {
-        replaceShouldFailWhenValueIsNull("merchant_details/address_country");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressCountry_whenValueIsEmptyString() {
-        replaceShouldFailWhenValueIsEmptyString("merchant_details/address_country");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressCountry_whenValueIsTooLong() {
-        replaceShouldFailWhenStringValueIsTooLong("merchant_details/address_country", 10);
-    }
-
-    @Test
-    public void shouldSucceed_updatingMerchantDetailsAddressCountry() {
-        replaceShouldSucceed("merchant_details/address_country", "GB");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressPostcode_whenNotAllowedOperation() {
-        shouldFailForAddOperation("merchant_details/address_postcode", "any value");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressPostcode_whenValueIsNotString() {
-        replaceShouldFailWhenValueIsNumeric("merchant_details/address_postcode", "Field [value] must be a string");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressPostcode_whenValueIsMissing() {
-        replaceShouldFailWhenValueMissing("merchant_details/address_postcode");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressPostcode_whenValueIsNull() {
-        replaceShouldFailWhenValueIsNull("merchant_details/address_postcode");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressPostcode_whenValueIsEmptyString() {
-        replaceShouldFailWhenValueIsEmptyString("merchant_details/address_postcode");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsAddressPostcode_whenValueIsTooLong() {
-        replaceShouldFailWhenStringValueIsTooLong("merchant_details/address_postcode", 25);
-    }
-
-    @Test
-    public void shouldSucceed_updatingMerchantDetailsAddressPostcode() {
-        replaceShouldSucceed("merchant_details/address_postcode", "B52 9EG");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsEmail_whenNotAllowedOperation() {
-        shouldFailForAddOperation("merchant_details/email", "any value");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsEmail_whenValueIsNotString() {
-        replaceShouldFailWhenValueIsNumeric("merchant_details/email", "Field [value] must be a string");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsEmail_whenValueIsMissing() {
-        replaceShouldFailWhenValueMissing("merchant_details/email");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsEmail_whenValueIsNull() {
-        replaceShouldFailWhenValueIsNull("merchant_details/email");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsEmail_whenValueIsTooLong() {
-        replaceShouldFailWhenStringValueIsTooLong("merchant_details/email", 255);
-    }
-
-    @Test
-    public void shouldSucceed_updatingMerchantDetailsEmail_whenValueIsEmptyString() {
-        replaceShouldSucceed("merchant_details/email", "");
-    }
-
-    @Test
-    public void shouldSucceed_updatingMerchantDetailsEmail() {
-        replaceShouldSucceed("merchant_details/email", "bob-the-builder@example.com");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsTelephoneNumber_whenNotAllowedOperation() {
-        shouldFailForAddOperation("merchant_details/telephone_number", "any value");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsTelephoneNumber_whenValueIsNotString() {
-        replaceShouldFailWhenValueIsNumeric("merchant_details/telephone_number", "Field [value] must be a string");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsTelephoneNumber_whenValueIsMissing() {
-        replaceShouldFailWhenValueMissing("merchant_details/telephone_number");
-    }
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsTelephoneNumber_whenValueIsNull() {
-        replaceShouldFailWhenValueIsNull("merchant_details/telephone_number");
-    }
-    
-
-    @Test
-    public void shouldFail_updatingMerchantDetailsTelephoneNumber_whenValueIsTooLong() {
-        replaceShouldFailWhenStringValueIsTooLong("merchant_details/telephone_number", 255);
-    }
-
-    @Test
-    public void shouldSucceed_updatingMerchantDetailsTelephoneNumber_whenValueIsEmptyString() {
-        replaceShouldSucceed("merchant_details/telephone_number", "");
-    }
-
-    @Test
-    public void shouldSucceed_updatingMerchantDetailsTelephoneNumber() {
-        replaceShouldSucceed("merchant_details/telephone_number", "00000000000");
-    }
-    
-    private void shouldFailForAddOperation(String path, Object value) {
-        Map<String, Object> payload = Map.of(
-                "path", path,
-                "op", "add",
-                "value", value);
-
-        List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
-
-        assertThat(errors.size(), is(1));
-        assertThat(errors, hasItem(String.format("Operation [add] is invalid for path [%s]", path)));
-    }
-
-    private void replaceShouldFailWhenValueIsNumeric(String path, String expectedErrorMessage) {
-        ObjectNode payload = mapper.createObjectNode();
-        payload.put("path", path);
-        payload.put("op", "replace");
-        payload.put("value", 42);
-        List<String> errors = serviceUpdateOperationValidator.validate(payload);
-        assertThat(errors.size(), is(1));
-        assertThat(errors, hasItem(expectedErrorMessage));
-    }
-
-    private void replaceShouldFailWhenValueIsBoolean(String path, String expectedErrorMessage) {
-        ObjectNode payload = mapper.createObjectNode();
-        payload.put("path", path);
-        payload.put("op", "replace");
-        payload.put("value", false);
-        List<String> errors = serviceUpdateOperationValidator.validate(payload);
-        assertThat(errors.size(), is(1));
-        assertThat(errors, hasItem(expectedErrorMessage));
-    }
-
-    private void replaceShouldFailWhenValueIsString(String path, String expectedErrorMessage) {
-        ObjectNode payload = mapper.createObjectNode();
-        payload.put("path", path);
-        payload.put("op", "replace");
-        payload.put("value", "not a boolean");
-
-        List<String> errors = serviceUpdateOperationValidator.validate(payload);
-
-        assertThat(errors.size(), is(1));
-        assertThat(errors, hasItem(expectedErrorMessage));
-    }
-
-    private void replaceShouldFailWhenValueMissing(String path) {
+        shouldFail("service_name/xx", "replace", "example name", "Path [service_name/xx] is invalid");
+    }
+
+    private Object[] shouldFailForOperationParams() {
+        return new Object[]{
+                new Object[]{"replace", "gateway_account_ids", List.of(1, 2)},
+                new Object[]{"add", "collect_billing_address", false},
+                new Object[]{"add", "experimental_features_enabled", true},
+                new Object[]{"add", "redirect_to_service_immediately_on_terminal_state", true},
+                new Object[]{"add", "collect_billing_address", true},
+                new Object[]{"add", "current_go_live_stage", "CHOSEN_PSP_STRIPE"},
+                new Object[]{"add", "experimental_features_enabled", false},
+                new Object[]{"add", "merchant_details/name", "any value"},
+                new Object[]{"add", "merchant_details/address_line1", "any value"},
+                new Object[]{"add", "merchant_details/address_line2", "any value"},
+                new Object[]{"add", "merchant_details/address_city", "any value"},
+                new Object[]{"add", "merchant_details/address_country", "any value"},
+                new Object[]{"add", "merchant_details/address_postcode", "any value"},
+                new Object[]{"add", "merchant_details/email", "any value"},
+                new Object[]{"add", "merchant_details/telephone_number", "any value"}
+        };
+    }
+
+    @Test
+    @Parameters(method = "shouldFailForOperationParams")
+    public void shouldFailForOperation(String operation, String path, Object value) {
+        String expectedErrorMessage = String.format("Operation [%s] is invalid for path [%s]", operation, path);
+        shouldFail(path, operation, value, expectedErrorMessage);
+    }
+
+    private Object[] replaceShouldFailWhenValueInvalidValueParameters() {
+        return new Object[]{
+                new Object[]{"service_name/en", 42, "Field [value] must be a string"},
+                new Object[]{"current_go_live_stage", 42, GO_LIVE_STAGE_INVALID_ERROR_MESSAGE},
+                new Object[]{"current_go_live_stage", "CAKE_ORDERED", GO_LIVE_STAGE_INVALID_ERROR_MESSAGE},
+                new Object[]{"merchant_details/name", 42, "Field [value] must be a string"},
+                new Object[]{"merchant_details/address_line1", 42, "Field [value] must be a string"},
+                new Object[]{"merchant_details/address_line2", 42, "Field [value] must be a string"},
+                new Object[]{"merchant_details/address_city", 42, "Field [value] must be a string"},
+                new Object[]{"merchant_details/address_country", 42, "Field [value] must be a string"},
+                new Object[]{"merchant_details/address_postcode", 42, "Field [value] must be a string"},
+                new Object[]{"merchant_details/email", 42, "Field [value] must be a string"},
+                new Object[]{"merchant_details/telephone_number", 42, "Field [value] must be a string"},
+                new Object[]{"collect_billing_address", "a string", "Field [value] must be a boolean"},
+                new Object[]{"redirect_to_service_immediately_on_terminal_state", "a string", "Field [value] must be a boolean"},
+                new Object[]{"experimental_features_enabled", "a string", "Field [value] must be a boolean"},
+                new Object[]{"custom_branding", "a string", "Value for path [custom_branding] must be a JSON"}
+        };
+    }
+
+    @Test
+    @Parameters(method = "replaceShouldFailWhenValueInvalidValueParameters")
+    public void replaceShouldFailWhenInvalidValue(String path, Object value, String expectedErrorMessage) {
+        shouldFail(path, "replace", value, expectedErrorMessage);
+    }
+
+    @Test
+    @Parameters({
+            "redirect_to_service_immediately_on_terminal_state",
+            "collect_billing_address",
+            "current_go_live_stage",
+            "experimental_features_enabled",
+            "merchant_details/name",
+            "merchant_details/address_line1",
+            "merchant_details/address_line2",
+            "merchant_details/address_city",
+            "merchant_details/address_country",
+            "merchant_details/address_postcode",
+            "merchant_details/email",
+            "merchant_details/telephone_number",
+            "custom_branding"
+    })
+    public void replaceShouldFailWhenValueMissing(String path) {
         ObjectNode payload = mapper.createObjectNode();
         payload.put("path", path);
         payload.put("op", "replace");
@@ -539,51 +124,110 @@ public class ServiceUpdateOperationValidatorTest {
         assertThat(errors, hasItem("Field [value] is required"));
     }
 
-    private void replaceShouldFailWhenValueIsNull(String path) {
-        replaceShouldFailWhenValueIsNull(path, "Field [value] is required");
-    }
-
-    private void replaceShouldFailWhenValueIsNull(String path, String expectedErrorMessage) {
+    @Test
+    @Parameters({
+            "redirect_to_service_immediately_on_terminal_state",
+            "collect_billing_address",
+            "current_go_live_stage",
+            "experimental_features_enabled",
+            "merchant_details/name",
+            "merchant_details/address_line1",
+            "merchant_details/address_line2",
+            "merchant_details/address_city",
+            "merchant_details/address_country",
+            "merchant_details/address_postcode",
+            "merchant_details/email",
+            "merchant_details/telephone_number",
+            "custom_branding"
+    })
+    public void replaceShouldFailWhenValueIsNull(String path) {
         ObjectNode payload = mapper.createObjectNode();
         payload.put("path", path);
         payload.put("op", "replace");
         payload.putNull("value");
         List<String> errors = serviceUpdateOperationValidator.validate(payload);
         assertThat(errors.size(), is(1));
-        assertThat(errors, hasItem(expectedErrorMessage));
+        assertThat(errors, hasItem("Field [value] is required"));
     }
 
-    private void replaceShouldFailWhenValueIsEmptyString(String path) {
-        replaceShouldFailWhenValueIsEmptyString(path,"Field [value] is required");
+    @Test
+    @Parameters({
+            "service_name/en",
+            "current_go_live_stage",
+            "merchant_details/name",
+            "merchant_details/address_line1",
+            "merchant_details/address_city",
+            "merchant_details/address_country",
+            "merchant_details/address_postcode",
+    })
+    public void replaceShouldFailWhenValueIsEmptyString(String path) {
+        shouldFail(path, "replace", "", "Field [value] is required");
     }
 
-    private void replaceShouldFailWhenValueIsEmptyString(String path, String expectedErrorMessage) {
-        ObjectNode payload = mapper.createObjectNode();
-        payload.put("path", path);
-        payload.put("op", "replace");
-        payload.put("value", "");
-        List<String> errors = serviceUpdateOperationValidator.validate(payload);
-        assertThat(errors.size(), is(1));
-        assertThat(errors, hasItem(expectedErrorMessage));
+    private Object[] shouldFailWhenStringValueIsTooLongParameters() {
+        return new Object[]{
+                new Object[]{"service_name/en", 50},
+                new Object[]{"merchant_details/name", 255},
+                new Object[]{"merchant_details/address_line1", 255},
+                new Object[]{"merchant_details/address_line2", 255},
+                new Object[]{"merchant_details/address_city", 255},
+                new Object[]{"merchant_details/address_country", 10},
+                new Object[]{"merchant_details/address_postcode", 25},
+                new Object[]{"merchant_details/email", 255},
+                new Object[]{"merchant_details/telephone_number", 255}
+        };
     }
 
-    private void replaceShouldFailWhenStringValueIsTooLong(String path, int expectedMaxLength) {
-        ObjectNode payload = mapper.createObjectNode();
-        payload.put("path", path);
-        payload.put("op", "replace");
-        payload.put("value", randomAlphanumeric(expectedMaxLength + 1));
-        List<String> errors = serviceUpdateOperationValidator.validate(payload);
-        assertThat(errors.size(), is(1));
-        assertThat(errors, hasItem(String.format("Field [value] must have a maximum length of %s characters", expectedMaxLength)));
+    @Test
+    @Parameters(method = "shouldFailWhenStringValueIsTooLongParameters")
+    public void replaceShouldFailWhenStringValueIsTooLong(String path, int expectedMaxLength) {
+        shouldFail(path, "replace", randomAlphanumeric(expectedMaxLength + 1), String.format("Field [value] must have a maximum length of %s characters", expectedMaxLength));
     }
 
-    private void replaceShouldSucceed(String path, Object value) {
+    private Object[] shouldSucceedParams() {
+        return new Object[]{
+                new Object[]{"add", "gateway_account_ids", List.of(1, 2)},
+                new Object[]{"replace", "redirect_to_service_immediately_on_terminal_state", true},
+                new Object[]{"replace", "experimental_features_enabled", true},
+                new Object[]{"replace", "collect_billing_address", true},
+                new Object[]{"replace", "current_go_live_stage", "CHOSEN_PSP_STRIPE"},
+                new Object[]{"replace", "merchant_details/name", "Bob's Building Business"},
+                new Object[]{"replace", "merchant_details/address_line1", "1 Builders Avenue"},
+                new Object[]{"replace", "merchant_details/address_line2", ""},
+                new Object[]{"replace", "merchant_details/address_city", "Burnley"},
+                new Object[]{"replace", "merchant_details/address_country", "GB"},
+                new Object[]{"replace", "merchant_details/address_postcode", "B52 9EG"},
+                new Object[]{"replace", "merchant_details/email", ""},
+                new Object[]{"replace", "merchant_details/email", "bob-the-builder@example.com"},
+                new Object[]{"replace", "merchant_details/telephone_number", ""},
+                new Object[]{"replace", "merchant_details/telephone_number", "00000000000"},
+                new Object[]{"replace", "custom_branding", Map.of("image_url", "image url", "css_url", "css url")},
+                new Object[]{"replace", "custom_branding", emptyMap()},
+                new Object[]{"replace", "service_name/en", "example-name"},
+                new Object[]{"replace", "service_name/cy", " "}
+        };
+    }
+
+    @Test
+    @Parameters(method = "shouldSucceedParams")
+    public void shouldSucceed(String operation, String path, Object value) {
         Map<String, Object> payload = Map.of(
                 "path", path,
-                "op", "replace",
+                "op", operation,
                 "value", value);
 
         List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
         assertThat(errors.size(), is(0));
+    }
+
+    private void shouldFail(String path, String operation, Object value, String expectedErrorMessage) {
+        ObjectNode payload = mapper.valueToTree(Map.of(
+                "path", path,
+                "op", operation,
+                "value", value
+        ));
+        List<String> errors = serviceUpdateOperationValidator.validate(payload);
+        assertThat(errors.size(), is(1));
+        assertThat(errors, hasItem(expectedErrorMessage));
     }
 }


### PR DESCRIPTION
Make tests easier to read by using parameterized tests.
Add tests for "gateway_account_id" path validation.
Make validation message consistent when value is null or missing.