### PR TITLE
PP-6708 Upgrade integration tests to JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <guice.version>4.2.3</guice.version>
         <guava.version>29.0-jre</guava.version>
         <jackson.version>2.11.1</jackson.version>
-        <pay-java-commons.version>1.0.20200629180713</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20200702150539</pay-java-commons.version>
     </properties>
     <repositories>
         <repository>

--- a/src/test/java/uk/gov/pay/adminusers/infra/DropwizardAppWithPostgresExtension.java
+++ b/src/test/java/uk/gov/pay/adminusers/infra/DropwizardAppWithPostgresExtension.java
@@ -1,0 +1,125 @@
+package uk.gov.pay.adminusers.infra;
+
+import com.google.inject.persist.jpa.JpaPersistModule;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import liquibase.Liquibase;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.LiquibaseException;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.apache.commons.lang3.ArrayUtils;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.adminusers.app.AdminUsersApp;
+import uk.gov.pay.adminusers.app.config.AdminUsersConfig;
+import uk.gov.pay.adminusers.utils.DatabaseTestHelper;
+import uk.gov.pay.commons.testing.db.PostgresDockerExtension;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Properties;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+
+public class DropwizardAppWithPostgresExtension implements BeforeAllCallback {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DropwizardAppWithPostgresExtension.class);
+    private static final String JPA_UNIT = "AdminUsersUnit";
+
+    private final String configFilePath;
+    private final PostgresDockerExtension postgres;
+    private final DropwizardAppExtension<AdminUsersConfig> app;
+
+    private DatabaseTestHelper databaseTestHelper;
+
+    public DropwizardAppWithPostgresExtension(ConfigOverride... configOverrides) {
+        this("config/test-it-config.yaml", configOverrides);
+    }
+
+    public DropwizardAppWithPostgresExtension(String configPath, ConfigOverride... configOverrides) {
+        configFilePath = resourceFilePath(configPath);
+        postgres = new PostgresDockerExtension();
+
+        ConfigOverride[] postgresOverrides = List.of(
+                config("database.url", postgres.getConnectionUrl()),
+                config("database.user", postgres.getUsername()),
+                config("database.password", postgres.getPassword()))
+                .toArray(new ConfigOverride[0]);
+
+        app = new DropwizardAppExtension<>(
+                AdminUsersApp.class,
+                configFilePath,
+                ArrayUtils.addAll(postgresOverrides, configOverrides)
+        );
+
+        createJpaModule(postgres);
+        registerShutdownHook();
+
+        try {
+            // starts dropwizard application. This is required as we don't use DropwizardExtensionsSupport (which starts application)
+            // due to config overrides we need at runtime for database, sqs and any custom configuration needed for tests
+            app.before();
+        } catch (Exception e) {
+            LOGGER.error("Exception starting application - {}", e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        LOGGER.info("Clearing database.");
+        app.getApplication().run("db", "drop-all", "--confirm-delete-everything", configFilePath);
+        app.getApplication().run("migrateToInitialDbState", configFilePath);
+        doSecondaryDatabaseMigration();
+        restoreDropwizardsLogging();
+
+        DataSourceFactory dataSourceFactory = app.getConfiguration().getDataSourceFactory();
+        databaseTestHelper = new DatabaseTestHelper(Jdbi.create(dataSourceFactory.getUrl(),
+                dataSourceFactory.getUser(), dataSourceFactory.getPassword()));
+    }
+
+    private void doSecondaryDatabaseMigration() throws SQLException, LiquibaseException {
+        try (Connection connection = DriverManager.getConnection(postgres.getConnectionUrl(), postgres.getUsername(), postgres.getPassword())) {
+            Liquibase migrator = new Liquibase("migrations.xml", new ClassLoaderResourceAccessor(), new JdbcConnection(connection));
+            migrator.update("");
+        }
+    }
+
+    public int getLocalPort() {
+        return app.getLocalPort();
+    }
+
+    public DatabaseTestHelper getDatabaseTestHelper() {
+        return databaseTestHelper;
+    }
+
+    private void registerShutdownHook() {
+        Runtime.getRuntime().addShutdownHook(new Thread(postgres::stop));
+    }
+
+    private JpaPersistModule createJpaModule(final PostgresDockerExtension postgres) {
+        final Properties properties = new Properties();
+        properties.put("javax.persistence.jdbc.driver", postgres.getDriverClass());
+        properties.put("javax.persistence.jdbc.url", postgres.getConnectionUrl());
+        properties.put("javax.persistence.jdbc.user", postgres.getUsername());
+        properties.put("javax.persistence.jdbc.password", postgres.getPassword());
+
+        final JpaPersistModule jpaModule = new JpaPersistModule(JPA_UNIT);
+        jpaModule.properties(properties);
+
+        return jpaModule;
+    }
+
+    private void restoreDropwizardsLogging() {
+        app.getConfiguration().getLoggingFactory().configure(app.getEnvironment().metrics(),
+                app.getApplication().getName());
+    }
+
+}

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/DaoTestBase.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/DaoTestBase.java
@@ -5,15 +5,14 @@ import liquibase.Liquibase;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import org.jdbi.v3.core.Jdbi;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.adminusers.infra.GuicedTestEnvironment;
 import uk.gov.pay.adminusers.model.Permission;
 import uk.gov.pay.adminusers.utils.DatabaseTestHelper;
-import uk.gov.pay.commons.testing.db.PostgresDockerRule;
+import uk.gov.pay.commons.testing.db.PostgresDockerExtension;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -27,13 +26,12 @@ public class DaoTestBase {
 
     private static Logger logger = LoggerFactory.getLogger(DaoTestBase.class);
 
-    @ClassRule
-    public static PostgresDockerRule postgres = new PostgresDockerRule();
+    public static PostgresDockerExtension postgres = new PostgresDockerExtension();
 
     protected static DatabaseTestHelper databaseHelper;
     protected static GuicedTestEnvironment env;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws Exception {
         final Properties properties = new Properties();
         properties.put("javax.persistence.jdbc.driver", postgres.getDriverClass());
@@ -56,7 +54,7 @@ public class DaoTestBase {
         env = GuicedTestEnvironment.from(jpaModule).start();
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanUp() {
         try (Connection connection = DriverManager.getConnection(
                 postgres.getConnectionUrl(),

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/ForgottenPasswordDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/ForgottenPasswordDaoIT.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.adminusers.persistence.dao;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.ForgottenPassword;
 import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.persistence.entity.ForgottenPasswordEntity;
@@ -32,7 +32,7 @@ public class ForgottenPasswordDaoIT extends DaoTestBase {
     private UserDao userDao;
     private ForgottenPasswordDao forgottenPasswordDao;
 
-    @Before
+    @BeforeEach
     public void before() {
         userDao = env.getInstance(UserDao.class);
         forgottenPasswordDao = env.getInstance(ForgottenPasswordDao.class);

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/InviteDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/InviteDaoIT.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.adminusers.persistence.dao;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
@@ -32,7 +32,7 @@ public class InviteDaoIT extends DaoTestBase {
     private ServiceDao serviceDao;
     private UserDao userDao;
 
-    @Before
+    @BeforeEach
     public void before() {
         inviteDao = env.getInstance(InviteDao.class);
         roleDao = env.getInstance(RoleDao.class);

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/RoleDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/RoleDaoIT.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.adminusers.persistence.dao;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
 
@@ -16,7 +16,7 @@ public class RoleDaoIT extends DaoTestBase {
 
     private RoleDao roleDao;
 
-    @Before
+    @BeforeEach
     public void before() {
         roleDao = env.getInstance(RoleDao.class);
     }

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoIT.java
@@ -3,8 +3,8 @@ package uk.gov.pay.adminusers.persistence.dao;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.RandomUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.postgresql.util.PGobject;
 import uk.gov.pay.adminusers.fixtures.UserDbFixture;
 import uk.gov.pay.adminusers.model.GoLiveStage;
@@ -48,7 +48,7 @@ public class ServiceDaoIT extends DaoTestBase {
     private static final String EN_NAME = "en-test-name";
     private static final String CY_NAME = "gwasanaeth prawf";
 
-    @Before
+    @BeforeEach
     public void before() {
         serviceDao = env.getInstance(ServiceDao.class);
     }

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceRoleDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceRoleDaoIT.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.adminusers.persistence.dao;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.fixtures.RoleDbFixture;
 import uk.gov.pay.adminusers.fixtures.ServiceDbFixture;
 import uk.gov.pay.adminusers.fixtures.UserDbFixture;
@@ -21,7 +21,7 @@ public class ServiceRoleDaoIT extends DaoTestBase {
 
     private ServiceRoleDao serviceRoleDao;
 
-    @Before
+    @BeforeEach
     public void before() {
         serviceRoleDao = env.getInstance(ServiceRoleDao.class);
     }

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/StripeAgreementDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/StripeAgreementDaoIT.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.adminusers.persistence.dao;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.StripeAgreementEntity;
@@ -29,7 +29,7 @@ public class StripeAgreementDaoIT extends DaoTestBase {
     private StripeAgreementDao stripeAgreementDao;
     private ServiceDao serviceDao;
 
-    @Before
+    @BeforeEach
     public void before() {
         stripeAgreementDao = env.getInstance(StripeAgreementDao.class);
         serviceDao = env.getInstance(ServiceDao.class);

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoIT.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.adminusers.persistence.dao;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.model.SecondFactorMethod;
 import uk.gov.pay.adminusers.model.Service;
@@ -26,7 +26,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -43,7 +42,7 @@ public class UserDaoIT extends DaoTestBase {
     private ServiceDao serviceDao;
     private RoleDao roleDao;
 
-    @Before
+    @BeforeEach
     public void before() {
         userDao = env.getInstance(UserDao.class);
         serviceDao = env.getInstance(ServiceDao.class);

--- a/src/test/java/uk/gov/pay/adminusers/resources/EmailResourceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/EmailResourceIT.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.fixtures.ServiceDbFixture;
 import uk.gov.pay.adminusers.model.MerchantDetails;
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/ForgottenPasswordResourceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ForgottenPasswordResourceIT.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.adminusers.resources;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateServiceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateServiceIT.java
@@ -2,7 +2,7 @@ package uk.gov.pay.adminusers.resources;
 
 
 import io.restassured.http.ContentType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.fixtures.UserDbFixture;
 
 import java.util.Locale;

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateUserIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateUserIT.java
@@ -1,8 +1,8 @@
 package uk.gov.pay.adminusers.resources;
 
 import io.restassured.http.ContentType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.ServiceName;
 import uk.gov.pay.adminusers.model.User;
@@ -18,11 +18,11 @@ import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.text.IsEmptyString.isEmptyString;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
@@ -37,7 +37,7 @@ public class InviteResourceCreateUserIT extends IntegrationTest {
     private String roleAdminName;
     private String senderExternalId;
 
-    @Before
+    @BeforeEach
     public void givenAnExistingServiceAndARole() {
 
         service = serviceDbFixture(databaseHelper)
@@ -167,7 +167,7 @@ public class InviteResourceCreateUserIT extends IntegrationTest {
                 .post(INVITE_USER_RESOURCE_URL)
                 .then()
                 .statusCode(NOT_FOUND.getStatusCode())
-                .body(isEmptyString());
+                .body(emptyString());
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGenerateOtpIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGenerateOtpIT.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.adminusers.resources;
 
 import io.restassured.http.ContentType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.fixtures.InviteDbFixture;
 
 import java.util.Map;

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGetIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGetIT.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.adminusers.resources;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.Response.Status.GONE;

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpIT.java
@@ -2,8 +2,8 @@ package uk.gov.pay.adminusers.resources;
 
 import com.warrenstrange.googleauth.GoogleAuthenticator;
 import io.restassured.response.ValidatableResponse;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.fixtures.InviteDbFixture;
 
 import java.util.List;
@@ -19,10 +19,10 @@ import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static org.apache.commons.lang3.RandomStringUtils.random;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.newId;
 
 public class InviteResourceOtpIT extends IntegrationTest {
@@ -35,7 +35,7 @@ public class InviteResourceOtpIT extends IntegrationTest {
     private static final String TELEPHONE_NUMBER = "+447999999999";
     private static final String PASSWORD = "a-secure-password";
 
-    @Before
+    @BeforeEach
     public void givenAnExistingInvite() {
         code = InviteDbFixture.inviteDbFixture(databaseHelper)
                 .withEmail(EMAIL)

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceServiceCompleteIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceServiceCompleteIT.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.adminusers.resources;
 
 import io.restassured.response.ValidatableResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
@@ -12,11 +12,11 @@ import static java.util.Arrays.asList;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.Status.GONE;
 import static javax.ws.rs.core.Response.Status.OK;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
-import static org.junit.Assert.assertThat;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.InviteDbFixture.inviteDbFixture;

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceUserCompleteIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceUserCompleteIT.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.adminusers.resources;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;

--- a/src/test/java/uk/gov/pay/adminusers/resources/ResetPasswordResourceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ResetPasswordResourceIT.java
@@ -1,16 +1,17 @@
 package uk.gov.pay.adminusers.resources;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.ForgottenPasswordDbFixture.forgottenPasswordDbFixture;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
@@ -22,7 +23,7 @@ public class ResetPasswordResourceIT extends IntegrationTest {
 
     private int userId;
 
-    @Before
+    @BeforeEach
     public void before() {
         String username = randomUuid();
         String email = username + "@example.com";

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceGovUkPayAgreementResourceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceGovUkPayAgreementResourceIT.java
@@ -2,8 +2,8 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.fixtures.GovUkPayAgreementDbFixture;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.User;
@@ -25,17 +25,18 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
 
     private Service service;
     private User user;
-    private String email = randomUuid() + "@example.org";
+    private String email;
 
-    @Before
+    @BeforeEach
     public void setUp() {
+        email = randomUuid() + "@example.org";
         service = serviceDbFixture(databaseHelper).insertService();
         user = userDbFixture(databaseHelper)
                 .withServiceRole(service, 1)
                 .withEmail(email)
                 .insertUser();
     }
-    
+
     @Test
     public void shouldCreateGovUkPayAgreement() {
         JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_external_id", user.getExternalId()));
@@ -73,7 +74,7 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
                 .statusCode(400)
                 .body("errors[0]", is("Field [user_external_id] must be a valid user ID"));
     }
-    
+
     @Test
     public void shouldReturn_400_whenUserExternalIdIsNotAString() {
         JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_external_id", 100));
@@ -115,7 +116,7 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
                 .body("errors", hasSize(1))
                 .body("errors[0]", is("Field [user_external_id] is required"));
     }
-    
+
     @Test
     public void shouldReturn_409_whenAgreementAlreadyExists() {
         GovUkPayAgreementDbFixture.govUkPayAgreementDbFixture(databaseHelper)
@@ -133,7 +134,7 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
                 .body("errors", hasSize(1))
                 .body("errors[0]", is("GOV.UK Pay agreement information is already stored for this service"));
     }
-    
+
     @Test
     public void shouldReturn_400_whenUserDoesNotBelongToService() {
         user = userDbFixture(databaseHelper)
@@ -147,9 +148,9 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
                 .then()
                 .statusCode(400)
                 .body("errors[0]", is("User does not belong to the given service"));
-        
+
     }
-    
+
     @Test
     public void shouldReturnAgreement_whenExists() {
         ZonedDateTime agreementTime = ZonedDateTime.now(ZoneOffset.UTC);
@@ -169,7 +170,7 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
                 .body("email", is(user.getEmail()))
                 .body("agreement_time", is(expectedAgreementDate));
     }
-    
+
     @Test
     public void shouldReturn404_whenAgreementNotExists() {
         givenSetup()

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceIT.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.adminusers.resources;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.User;
@@ -11,10 +11,10 @@ import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.RoleDbFixture.roleDbFixture;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
@@ -27,7 +27,7 @@ public class ServiceResourceIT extends IntegrationTest {
     private User userWithRoleAdminInService1;
     private User user1WithRoleViewInService1;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         Role roleAdmin = roleDbFixture(databaseHelper).insertAdmin();
         Role roleView = roleDbFixture(databaseHelper)
@@ -164,7 +164,7 @@ public class ServiceResourceIT extends IntegrationTest {
                 .delete(format("/v1/api/services/%s/users/%s", serviceExternalId, user1WithRoleViewInService1.getExternalId()))
                 .then()
                 .statusCode(204)
-                .body(isEmptyString());
+                .body(emptyString());
 
         List<Map<String, Object>> serviceRoleForUserAfter = databaseHelper.findServiceRoleForUser(user1WithRoleViewInService1.getId());
         assertThat(serviceRoleForUserAfter.isEmpty(), is(true));
@@ -179,7 +179,7 @@ public class ServiceResourceIT extends IntegrationTest {
                 .delete(format("/v1/api/services/%s/users/%s", serviceExternalId, userWithRoleAdminInService1.getExternalId()))
                 .then()
                 .statusCode(409)
-                .body(isEmptyString());
+                .body(emptyString());
     }
 
     @Test
@@ -191,7 +191,7 @@ public class ServiceResourceIT extends IntegrationTest {
                 .delete(format("/v1/api/services/%s/users/%s", serviceExternalId, userWithRoleAdminInService1.getExternalId()))
                 .then()
                 .statusCode(403)
-                .body(isEmptyString());
+                .body(emptyString());
     }
 
     @Test
@@ -202,6 +202,6 @@ public class ServiceResourceIT extends IntegrationTest {
                 .delete(format("/v1/api/services/%s/users/%s", serviceExternalId, userWithRoleAdminInService1.getExternalId()))
                 .then()
                 .statusCode(403)
-                .body(isEmptyString());
+                .body(emptyString());
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceSendLiveAccountCreatedEmailIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceSendLiveAccountCreatedEmailIT.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.adminusers.resources;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.Service;
 
 import static java.lang.String.format;

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceStripeAgreementIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceStripeAgreementIT.java
@@ -2,8 +2,8 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.fixtures.StripeAgreementDbFixture;
 import uk.gov.pay.adminusers.model.Service;
 
@@ -24,7 +24,7 @@ public class ServiceResourceStripeAgreementIT extends IntegrationTest {
 
     private Service service;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         service = serviceDbFixture(databaseHelper).insertService();
     }

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateCustomBrandingIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateCustomBrandingIT.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.adminusers.resources;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.ServiceName;
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateIT.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.GoLiveStage;
 
 import java.util.List;

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateMerchantDetailsIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateMerchantDetailsIT.java
@@ -2,7 +2,7 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.ServiceName;
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateNameIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateNameIT.java
@@ -2,8 +2,8 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.Service;
 
 import java.util.Map;
@@ -17,7 +17,7 @@ public class ServiceResourceUpdateNameIT extends IntegrationTest {
     
     private String serviceExternalId;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         Service service = serviceDbFixture(databaseHelper).insertService();
         serviceExternalId = service.getExternalId();

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationIT.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.fixtures.UserDbFixture;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.service.PasswordHasher;

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateIT.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.adminusers.resources;
 
 import io.restassured.response.ValidatableResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.Service;
 
 import java.util.List;
@@ -12,11 +12,11 @@ import static java.lang.String.format;
 import static java.lang.String.valueOf;
 import static java.util.Collections.emptyMap;
 import static org.apache.commons.lang3.RandomUtils.nextInt;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateServiceRoleIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateServiceRoleIT.java
@@ -3,7 +3,7 @@ package uk.gov.pay.adminusers.resources;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.User;

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceFindIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceFindIT.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.adminusers.resources;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.User;
 
 import java.util.Map;
@@ -15,7 +15,7 @@ public class UserResourceFindIT extends IntegrationTest {
 
     private String username;
 
-    @Before
+    @BeforeEach
     public void createAUser() {
         String username = randomUuid();
         String email = username + "@example.com";

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceGetIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceGetIT.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.adminusers.resources;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.User;

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceGetMultipleIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceGetMultipleIT.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.adminusers.resources;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.User;

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourcePatchIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourcePatchIT.java
@@ -2,8 +2,8 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.User;
 
 import java.util.Map;
@@ -19,7 +19,7 @@ public class UserResourcePatchIT extends IntegrationTest {
 
     private String externalId;
 
-    @Before
+    @BeforeEach
     public void createAUser() {
         String username = randomUuid();
         String email = username + "@example.com";
@@ -74,7 +74,6 @@ public class UserResourcePatchIT extends IntegrationTest {
                 .then()
                 .statusCode(200)
                 .body("features", is(newFeatures));
-
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceResetSecondFactorIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceResetSecondFactorIT.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.adminusers.resources;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.SecondFactorMethod;
 import uk.gov.pay.adminusers.model.User;
 
@@ -13,7 +13,7 @@ public class UserResourceResetSecondFactorIT extends IntegrationTest {
     private static final String OTP_KEY = "34f34";
     private String externalId;
 
-    @Before
+    @BeforeEach
     public void createValidUser() {
         User user = userDbFixture(databaseHelper)
                 .withSecondFactorMethod(SecondFactorMethod.APP)

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceSecondFactorAuthenticationIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceSecondFactorAuthenticationIT.java
@@ -2,8 +2,8 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.warrenstrange.googleauth.GoogleAuthenticator;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.User;
 
 import java.util.Map;
@@ -23,7 +23,7 @@ public class UserResourceSecondFactorAuthenticationIT extends IntegrationTest {
     private String externalId;
     private String username;
 
-    @Before
+    @BeforeEach
     public void createValidUser() {
         String username = randomUuid();
         String email = username + "@example.com";

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceSecondFactorProvisioningIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceSecondFactorProvisioningIT.java
@@ -2,8 +2,8 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.warrenstrange.googleauth.GoogleAuthenticator;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.User;
 
 import java.util.Map;
@@ -26,7 +26,7 @@ public class UserResourceSecondFactorProvisioningIT extends IntegrationTest {
     private String externalId;
     private String username;
 
-    @Before
+    @BeforeEach
     public void createValidUser() {
         String username = randomUuid();
         String email = username + "@example.com";

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceUpdateServiceRoleIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceUpdateServiceRoleIT.java
@@ -2,7 +2,7 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.User;


### PR DESCRIPTION
## WHAT YOU DID
- Upgraded integration tests to JUnit5
- Added `DropwizardAppWithPostgresExtension` which is used by all integration tests to start and stop application and postgres container. This is potential candidate to refactor and move to pay-java-commons but at the moment each app has its own equivalent (for Rule) with few differences (DB libraries and initialisation, using DropwizardClientExtension, SQS container... )
 
