### PR TITLE
PP-6708 Use assertThrows for asserting exceptions

### DIFF
--- a/src/test/java/uk/gov/pay/adminusers/model/ServiceNameTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/ServiceNameTest.java
@@ -10,16 +10,17 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThrows;
 
 public class ServiceNameTest {
 
     private static final String ENGLISH_SERVICE_NAME = "Apply for your licence";
     private static final String WELSH_SERVICE_NAME = "Gwneud cais am eich trwydded";
-    
+
     @Test
     public void shouldCreateWithJustEnglishServiceName() {
         ServiceName serviceName = new ServiceName(ENGLISH_SERVICE_NAME);
-        
+
         assertThat(serviceName.getEnglish(), is(ENGLISH_SERVICE_NAME));
         assertThat(serviceName.getEnglishAndTranslations().size(), is(1));
         assertThat(serviceName.getEnglishAndTranslations().get(SupportedLanguage.ENGLISH), is(ENGLISH_SERVICE_NAME));
@@ -55,14 +56,15 @@ public class ServiceNameTest {
         assertThat(serviceName.getEnglishAndTranslations().get(SupportedLanguage.WELSH), is(nullValue()));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowIfNullEnglishServiceName() {
-        new ServiceName(null);
+        assertThrows(NullPointerException.class, () -> new ServiceName(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowIfEnglishServiceNameIncludedInMap() {
-        new ServiceName(ENGLISH_SERVICE_NAME, Map.of(SupportedLanguage.WELSH, WELSH_SERVICE_NAME, SupportedLanguage.ENGLISH, ENGLISH_SERVICE_NAME));
+        assertThrows(IllegalArgumentException.class, () ->
+                new ServiceName(ENGLISH_SERVICE_NAME, Map.of(SupportedLanguage.WELSH, WELSH_SERVICE_NAME, SupportedLanguage.ENGLISH, ENGLISH_SERVICE_NAME)));
     }
 
     @Test
@@ -107,16 +109,18 @@ public class ServiceNameTest {
         assertThat(serviceName.getEnglishAndTranslations().get(SupportedLanguage.WELSH), is(nullValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowIfWhenConvertingFromServiceNameEntitiesIfNoEnglishServiceName() {
-        ServiceName.from(List.of(ServiceNameEntity.from(SupportedLanguage.WELSH, "  ")));
+        assertThrows(IllegalArgumentException.class, () ->
+                ServiceName.from(List.of(ServiceNameEntity.from(SupportedLanguage.WELSH, "  "))));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldReturnUnmodifiableMap() {
         ServiceName serviceName = new ServiceName(ENGLISH_SERVICE_NAME, Map.of(SupportedLanguage.WELSH, WELSH_SERVICE_NAME));
 
-        serviceName.getEnglishAndTranslations().put(SupportedLanguage.WELSH, "Sneakily try to add something");
+        assertThrows(UnsupportedOperationException.class, () ->
+                serviceName.getEnglishAndTranslations().put(SupportedLanguage.WELSH, "Sneakily try to add something"));
     }
-    
+
 }

--- a/src/test/java/uk/gov/pay/adminusers/persistence/entity/InviteTypeConverterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/entity/InviteTypeConverterTest.java
@@ -5,6 +5,7 @@ import uk.gov.pay.adminusers.model.InviteType;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
 
 public class InviteTypeConverterTest {
 
@@ -26,7 +27,7 @@ public class InviteTypeConverterTest {
     public void userStringConvertToEntityAttributeReturnsUserEnumConstant() {
         InviteType entityAttribute = inviteTypeConverter.convertToEntityAttribute("user");
         assertThat(entityAttribute, is(InviteType.USER));
-    }   
+    }
 
     @Test
     public void serviceStringConvertToEntityAttributeReturnsServiceEnumConstant() {
@@ -34,8 +35,9 @@ public class InviteTypeConverterTest {
         assertThat(entityAttribute, is(InviteType.SERVICE));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void unhandledStringConvertToEntityAttributeThrowsException() {
-        inviteTypeConverter.convertToEntityAttribute("Someone went wild in the DB!");
+        assertThrows(RuntimeException.class, () ->
+                inviteTypeConverter.convertToEntityAttribute("Someone went wild in the DB!"));
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteUserRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteUserRequestValidatorTest.java
@@ -16,6 +16,7 @@ import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThrows;
 
 public class InviteUserRequestValidatorTest {
 
@@ -308,11 +309,11 @@ public class InviteUserRequestValidatorTest {
         assertThat(errors.get().getErrors().size(),is(1));
     }
 
-    @Test(expected = WebApplicationException.class)
+    @Test
     public void shouldFail_ifEmailAddressNotPublicSector() {
         Map<String, String> payload = Map.of( "email", "example@example.com","telephone_number", "01134960000", "password", "super-secure-password");
         JsonNode payloadNode = objectMapper.valueToTree(payload);
-        validator.validateCreateServiceRequest(payloadNode);
+        assertThrows(WebApplicationException.class, () -> validator.validateCreateServiceRequest(payloadNode));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceRequestValidatorTest.java
@@ -21,6 +21,7 @@ import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.BDDMockito.given;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -119,13 +120,13 @@ public class ServiceRequestValidatorTest {
         serviceRequestValidator.validateUpdateMerchantDetailsRequest(payload);
     }
 
-    @Test(expected = ValidationException.class)
+    @Test
     public void shouldFail_updatingMerchantDetails_forEmptyObject() throws ValidationException {
         ObjectNode payload = JsonNodeFactory.instance.objectNode();
-        serviceRequestValidator.validateUpdateMerchantDetailsRequest(payload);
+        assertThrows(ValidationException.class, () -> serviceRequestValidator.validateUpdateMerchantDetailsRequest(payload));
     }
 
-    @Test(expected = ValidationException.class)
+    @Test
     public void shouldFail_updatingMerchantDetails_forMissingMandatoryFields() throws ValidationException {
         ObjectNode payload = JsonNodeFactory.instance.objectNode();
         payload.put(ServiceRequestValidator.FIELD_MERCHANT_DETAILS_ADDRESS_LINE1, "line1");
@@ -133,61 +134,55 @@ public class ServiceRequestValidatorTest {
         payload.put(ServiceRequestValidator.FIELD_MERCHANT_DETAILS_ADDRESS_COUNTRY, "country");
         payload.put(ServiceRequestValidator.FIELD_MERCHANT_DETAILS_ADDRESS_POSTCODE, "postcode");
 
-        serviceRequestValidator.validateUpdateMerchantDetailsRequest(payload);
+        assertThrows(ValidationException.class, () -> serviceRequestValidator.validateUpdateMerchantDetailsRequest(payload));
     }
 
-    @Test(expected = ValidationException.class)
+    @Test
     public void shouldFail_updatingMerchantDetails_forBlankStringMandatoryFields() throws ValidationException {
         ObjectNode payload = JsonNodeFactory.instance.objectNode();
         payload.put(ServiceRequestValidator.FIELD_MERCHANT_DETAILS_NAME, "");
 
-        serviceRequestValidator.validateUpdateMerchantDetailsRequest(payload);
+        assertThrows(ValidationException.class, () -> serviceRequestValidator.validateUpdateMerchantDetailsRequest(payload));
     }
 
-    @Test(expected = ValidationException.class)
+    @Test
     public void shouldFail_updatingMerchantDetails_forNullValueMandatoryFields() throws ValidationException {
         ObjectNode payload = JsonNodeFactory.instance.objectNode();
         payload.set(ServiceRequestValidator.FIELD_MERCHANT_DETAILS_NAME, null);
 
-        serviceRequestValidator.validateUpdateMerchantDetailsRequest(payload);
+        assertThrows(ValidationException.class, () -> serviceRequestValidator.validateUpdateMerchantDetailsRequest(payload));
     }
 
-    @Test(expected = ValidationException.class)
+    @Test
     public void shouldFail_updatingMerchantDetails_whenInvalidEmail() throws ValidationException {
         ObjectNode payload = createMerchantDetailsJsonPayload(DEFAULT_MERCHANT_DETAILS_NAME, "invalid@example.com-uk");
 
-        try {
-            serviceRequestValidator.validateUpdateMerchantDetailsRequest(payload);
-        } catch (ValidationException e) {
-            assertThat(e.getErrors().getErrors(), hasItem("Field [email] must be a valid email address"));
-            throw e;
-        }
+        ValidationException validationException = assertThrows(ValidationException.class,
+                () -> serviceRequestValidator.validateUpdateMerchantDetailsRequest(payload));
+
+        assertThat(validationException.getErrors().getErrors(), hasItem("Field [email] must be a valid email address"));
     }
 
-    @Test(expected = ValidationException.class)
+    @Test
     public void shouldFail_updatingMerchantDetails_whenEmailOver255() throws ValidationException {
         String longEmail = randomAlphanumeric(256);
         ObjectNode payload = createMerchantDetailsJsonPayload(DEFAULT_MERCHANT_DETAILS_NAME, longEmail);
 
-        try {
-            serviceRequestValidator.validateUpdateMerchantDetailsRequest(payload);
-        } catch (ValidationException e) {
-            assertThat(e.getErrors().getErrors(), hasItem("Field [email] must have a maximum length of 255 characters"));
-            throw e;
-        }
+        ValidationException validationException = assertThrows(ValidationException.class,
+                () -> serviceRequestValidator.validateUpdateMerchantDetailsRequest(payload));
+
+        assertThat(validationException.getErrors().getErrors(), hasItem("Field [email] must have a maximum length of 255 characters"));
     }
 
-    @Test(expected = ValidationException.class)
+    @Test
     public void shouldFail_updatingMerchantDetails_whenNameOver255() throws ValidationException {
         String longName = randomAlphanumeric(256);
         ObjectNode payload = createMerchantDetailsJsonPayload(longName, DEFAULT_MERCHANT_DETAILS_EMAIL);
 
-        try {
-            serviceRequestValidator.validateUpdateMerchantDetailsRequest(payload);
-        } catch (ValidationException e) {
-            assertThat(e.getErrors().getErrors(), hasItem("Field [name] must have a maximum length of 255 characters"));
-            throw e;
-        }
+        ValidationException validationException = assertThrows(ValidationException.class,
+                () -> serviceRequestValidator.validateUpdateMerchantDetailsRequest(payload));
+
+        assertThat(validationException.getErrors().getErrors(), hasItem("Field [name] must have a maximum length of 255 characters"));
     }
 
     private static ObjectNode createMerchantDetailsJsonPayload(String name, String email) {

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceCreatorTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.hasValue;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -150,11 +151,12 @@ public class ServiceCreatorTest {
         assertSelfLink(service);
     }
 
-    @Test(expected = WebApplicationException.class)
+    @Test
     public void shouldFail_whenProvidedAConflictingGatewayID() {
         List<String> gatewayAccountsIds = List.of("3");
         when(mockedServiceDao.checkIfGatewayAccountsUsed(gatewayAccountsIds)).thenReturn(true);
-        serviceCreator.doCreate(gatewayAccountsIds, Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME));
+        assertThrows(WebApplicationException.class, () ->
+                serviceCreator.doCreate(gatewayAccountsIds, Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME)));
     }
 
     private void assertEnServiceNameMap(Service service, String serviceName) {


### PR DESCRIPTION
## WHAT YOU DID
- Uses `assertThrows` for asserting exceptions instead of annotation specification (like `@Test (expected = ServiceNotFoundException.class)`) which is not supported anymore in JUnit5
