### PR TITLE
PP-6763 Remove Direct Debit smoke tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,14 +102,6 @@ pipeline {
         tagPact("adminusers", gitCommit(), "test")
       }
     }
-    stage('Smoke Tests') {
-      when {
-        branch 'master'
-      }
-      steps {
-        runDirectDebitSmokeTest()
-      }
-    }
     stage('Complete') {
       failFast true
       parallel {


### PR DESCRIPTION
Description:
- Removing Direct Debit smoke tests, so snitches aren't fired for Graphite

