### PR TITLE
PP-6763 - Remove direct debit smoke and end test from adminusers Jenk…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,14 +102,6 @@ pipeline {
         tagPact("adminusers", gitCommit(), "test")
       }
     }
-    stage('Smoke Tests') {
-      when {
-        branch 'master'
-      }
-      steps {
-        runDirectDebitSmokeTest()
-      }
-    }
     stage('Complete') {
       failFast true
       parallel {


### PR DESCRIPTION
Description:

- Before we can turn off the direct debit smoke test we need to ensure that no pipeline calls it. This ensures that the adminusers Jenkins pipeline doesn't call the direct debit smoke Jenkins function.
- This also ensures that the direct debit portion of the end to end test suit won't be run