### PR TITLE
PP-7458 Capture created date for services

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static java.time.ZoneOffset.UTC;
 import static java.util.Arrays.asList;
 import static javax.persistence.EnumType.STRING;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
@@ -83,7 +84,7 @@ public class ServiceEntity {
     
     @Column(name = "created_date")
     @Convert(converter = UTCDateTimeConverter.class)
-    private ZonedDateTime createdDate;
+    private ZonedDateTime createdDate = ZonedDateTime.now(UTC);
     
     @Column(name = "went_live_date")
     @Convert(converter = UTCDateTimeConverter.class)

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceCreateIT.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.adminusers.resources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.commons.model.SupportedLanguage;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.http.ContentType.JSON;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+class ServiceResourceCreateIT extends IntegrationTest {
+
+    @Test
+    void shouldCreateService() {
+        JsonNode payload = mapper
+                .valueToTree(Map.of(
+                        "service_name", Map.of(SupportedLanguage.ENGLISH.toString(), "Service name"),
+                        "gateway_account_ids", List.of("1")
+                ));
+        
+        givenSetup()
+                .when()
+                .contentType(JSON)
+                .body(payload)
+                .post("v1/api/services")
+                .then()
+                .statusCode(201)
+                .body("created_date", is(not(nullValue())))
+                .body("gateway_account_ids", is(List.of("1")))
+                .body("service_name", hasEntry("en", "Service name"));
+    }
+}


### PR DESCRIPTION
`created_date` column already exists with a default, but as it is a nullable column the value was set to the null value on the ServiceEntity, as we are using JPA for entity management.

Fix this by adding a default value of `now()` on the ServiceEntity. Add an integration test to ensure a `created_date` is set and returned.