### PR TITLE
bau: Reduce ObjectMapper instantiation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-08-12T14:42:40Z",
+  "generated_at": "2020-12-22T18:07:34Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -167,7 +167,7 @@
         "hashed_secret": "c3a8fcf85a56dee95cff4ce7adf0bb9a4c18f747",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 60,
+        "line_number": 59,
         "type": "Hex High Entropy String"
       }
     ],
@@ -194,7 +194,7 @@
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 42,
+        "line_number": 44,
         "type": "Hex High Entropy String"
       }
     ],

--- a/src/main/java/uk/gov/pay/adminusers/model/ServiceUpdateRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/ServiceUpdateRequest.java
@@ -19,6 +19,8 @@ public class ServiceUpdateRequest {
     public static final String FIELD_PATH = "path";
     public static final String FIELD_VALUE = "value";
 
+    private static ObjectMapper objectMapper = new ObjectMapper();
+    
     private String op;
     private String path;
     private JsonNode value;
@@ -51,7 +53,7 @@ public class ServiceUpdateRequest {
         if (value != null) {
             if ((value.isTextual() && !isEmpty(value.asText())) || value.isObject()) {
                 try {
-                    return new ObjectMapper().readValue(value.traverse(), new TypeReference<Map<String, Object>>() {});
+                    return objectMapper.readValue(value.traverse(), new TypeReference<Map<String, Object>>() {});
                 } catch (IOException e) {
                     throw new RuntimeException("Malformed JSON object in ServiceUpdateRequest.value", e);
                 }

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/CustomBrandingConverter.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/CustomBrandingConverter.java
@@ -15,12 +15,15 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 @Converter
 public class CustomBrandingConverter implements AttributeConverter<Map<String, Object>, PGobject> {
+    
+    private static ObjectMapper objectMapper = new ObjectMapper();
+
     @Override
     public PGobject convertToDatabaseColumn(Map<String, Object> customBranding) {
         PGobject dbCustomBranding = new PGobject();
         dbCustomBranding.setType("json");
         try {
-            dbCustomBranding.setValue(new ObjectMapper().writeValueAsString(customBranding));
+            dbCustomBranding.setValue(objectMapper.writeValueAsString(customBranding));
         } catch (SQLException | JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -33,7 +36,7 @@ public class CustomBrandingConverter implements AttributeConverter<Map<String, O
             if (dbCustomBranding == null || isEmpty(dbCustomBranding.toString())) {
                 return null;
             } else {
-                return new ObjectMapper().readValue(dbCustomBranding.toString(), new TypeReference<>() {});
+                return objectMapper.readValue(dbCustomBranding.toString(), new TypeReference<>() {});
             }
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/test/java/uk/gov/pay/adminusers/model/CreateUserRequestTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/CreateUserRequestTest.java
@@ -8,10 +8,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 
-public class CreateUserRequestTest {
+class CreateUserRequestTest {
+
+    private static ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
-    public void shouldConstructAUser_fromMinimalValidUserJson() throws Exception {
+    void shouldConstructAUser_fromMinimalValidUserJson() throws Exception {
         String minimumUserJson = "{" +
                 "\"username\": \"a-username\"," +
                 "\"telephone_number\": \"2123524\"," +
@@ -19,7 +21,7 @@ public class CreateUserRequestTest {
                 "\"email\": \"email@example.com\"" +
                 "}";
 
-        JsonNode jsonNode = new ObjectMapper().readTree(minimumUserJson);
+        JsonNode jsonNode = objectMapper.readTree(minimumUserJson);
         CreateUserRequest createUserRequest = CreateUserRequest.from(jsonNode);
 
         assertThat(createUserRequest.getUsername(), is("a-username"));
@@ -33,7 +35,7 @@ public class CreateUserRequestTest {
     }
 
     @Test
-    public void shouldConstructAUser_fromCompleteValidUserJson() throws Exception {
+    void shouldConstructAUser_fromCompleteValidUserJson() throws Exception {
         String minimunUserJson = "{" +
                 "\"username\": \"a-username\"," +
                 "\"password\": \"a-password\"," +
@@ -43,7 +45,7 @@ public class CreateUserRequestTest {
                 "\"email\": \"email@example.com\"" +
                 "}";
 
-        JsonNode jsonNode = new ObjectMapper().readTree(minimunUserJson);
+        JsonNode jsonNode = objectMapper.readTree(minimunUserJson);
         CreateUserRequest createUserRequest = CreateUserRequest.from(jsonNode);
 
         assertThat(createUserRequest.getUsername(), is("a-username"));

--- a/src/test/java/uk/gov/pay/adminusers/model/ServiceUpdateRequestTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/ServiceUpdateRequestTest.java
@@ -15,17 +15,17 @@ import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-public class ServiceUpdateRequestTest {
+class ServiceUpdateRequestTest {
 
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private static ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeEach
-    public void before() {
+    void before() {
         objectMapper.configure(JsonParser.Feature.AUTO_CLOSE_SOURCE, true);
     }
 
     @Test
-    public void shouldTransformToObjectCorrectly() throws IOException {
+    void shouldTransformToObjectCorrectly() throws IOException {
         Map<String, Object> payload = Map.of("path", "custom_branding", "op", "replace", "value", Map.of("image_url", "image url", "css_url", "css url"));
         String content = objectMapper.writeValueAsString(payload);
         JsonNode jsonNode = objectMapper.readTree(content);
@@ -37,10 +37,10 @@ public class ServiceUpdateRequestTest {
     }
 
     @Test
-    public void shouldReturnAList_whenJsonIsArray() throws IOException {
+    void shouldReturnAList_whenJsonIsArray() throws IOException {
         String jsonPayload = fixture("fixtures/resource/service/patch/array-replace-service-name-en-replace-service-name-cy.json");
 
-        final List<ServiceUpdateRequest> requests = ServiceUpdateRequest.getUpdateRequests(new ObjectMapper().readTree(jsonPayload));
+        final List<ServiceUpdateRequest> requests = ServiceUpdateRequest.getUpdateRequests(objectMapper.readTree(jsonPayload));
 
         assertThat(requests.size(), is(2));
         requests.sort(Comparator.comparing(ServiceUpdateRequest::getPath));
@@ -52,7 +52,7 @@ public class ServiceUpdateRequestTest {
     }
 
     @Test
-    public void shouldReturnAList_whenJsonIsSingleObject() throws IOException {
+    void shouldReturnAList_whenJsonIsSingleObject() throws IOException {
         //language=JSON
         String jsonPayload =
                 "{\n" +
@@ -61,7 +61,7 @@ public class ServiceUpdateRequestTest {
                         "  \"value\": \"new-en-name\"\n" +
                         "}\n";
 
-        final List<ServiceUpdateRequest> requests = ServiceUpdateRequest.getUpdateRequests(new ObjectMapper().readTree(jsonPayload));
+        final List<ServiceUpdateRequest> requests = ServiceUpdateRequest.getUpdateRequests(objectMapper.readTree(jsonPayload));
 
         assertThat(requests.size(), is(1));
         assertThat(requests.get(0).getPath(), is("name"));

--- a/src/test/java/uk/gov/pay/adminusers/model/UpdateMerchantDetailsRequestTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/UpdateMerchantDetailsRequestTest.java
@@ -10,7 +10,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
 
-public class UpdateMerchantDetailsRequestTest {
+class UpdateMerchantDetailsRequestTest {
+
+    private static ObjectMapper objectMapper = new ObjectMapper();
 
     private final String name = "name";
     private final String telephoneNumber = "03069990000";
@@ -22,14 +24,14 @@ public class UpdateMerchantDetailsRequestTest {
     private final String email = "dd-merchant@example.com";
 
     @Test
-    public void shouldConstructMerchantDetails_fromMinimalValidJson() {
+    void shouldConstructMerchantDetails_fromMinimalValidJson() {
         Map<String, Object> payload = Map.of(
                 "name", name,
                 "address_line1", addressLine1,
                 "address_city", addressCity,
                 "address_country", addressCountry,
                 "address_postcode", addressPostcode);
-        JsonNode jsonNode = new ObjectMapper().valueToTree(payload);
+        JsonNode jsonNode = objectMapper.valueToTree(payload);
         UpdateMerchantDetailsRequest updateMerchantDetailsRequest = UpdateMerchantDetailsRequest.from(jsonNode);
         assertThat(updateMerchantDetailsRequest.getName(), is(name));
         assertThat(updateMerchantDetailsRequest.getAddressLine1(), is(addressLine1));
@@ -40,7 +42,7 @@ public class UpdateMerchantDetailsRequestTest {
     }
 
     @Test
-    public void shouldConstructMerchantDetails_fromCompleteValidJson() {
+    void shouldConstructMerchantDetails_fromCompleteValidJson() {
         Map<String, Object> payload = Map.of(
                 "name", name,
                 "telephone_number", telephoneNumber,
@@ -50,7 +52,7 @@ public class UpdateMerchantDetailsRequestTest {
                 "address_country", addressCountry,
                 "address_postcode", addressPostcode,
                 "email", email);
-        JsonNode jsonNode = new ObjectMapper().valueToTree(payload);
+        JsonNode jsonNode = objectMapper.valueToTree(payload);
         UpdateMerchantDetailsRequest updateMerchantDetailsRequest = UpdateMerchantDetailsRequest.from(jsonNode);
         assertThat(updateMerchantDetailsRequest.getName(), is(name));
         assertThat(updateMerchantDetailsRequest.getTelephoneNumber(), is(telephoneNumber));

--- a/src/test/java/uk/gov/pay/adminusers/model/UserEntityTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/UserEntityTest.java
@@ -18,10 +18,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.pay.adminusers.model.Permission.permission;
 import static uk.gov.pay.adminusers.model.Role.role;
 
-public class UserEntityTest {
+class UserEntityTest {
+
+    private static ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
-    public void shouldConstructAUser_fromMinimalValidUserJson() throws Exception {
+    void shouldConstructAUser_fromMinimalValidUserJson() throws Exception {
         String minimumUserJson = "{" +
                 "\"username\": \"a-username\"," +
                 "\"telephone_number\": \"+441134960000\"," +
@@ -29,7 +31,7 @@ public class UserEntityTest {
                 "\"email\": \"email@example.com\"" +
                 "}";
 
-        JsonNode jsonNode = new ObjectMapper().readTree(minimumUserJson);
+        JsonNode jsonNode = objectMapper.readTree(minimumUserJson);
         CreateUserRequest createUserRequest = CreateUserRequest.from(jsonNode);
 
         UserEntity userEntity = UserEntity.from(createUserRequest);
@@ -46,7 +48,7 @@ public class UserEntityTest {
     }
 
     @Test
-    public void creatingAUser_shouldSetGatewayAccountAndRole_whenServiceRoleIsSet() {
+    void creatingAUser_shouldSetGatewayAccountAndRole_whenServiceRoleIsSet() {
         UserEntity userEntity = new UserEntity();
         String gatewayAccountId = "1";
         ServiceEntity service = new ServiceEntity(List.of(gatewayAccountId));

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoIT.java
@@ -45,7 +45,7 @@ import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.model.Role.role;
 
-public class ServiceDaoIT extends DaoTestBase {
+class ServiceDaoIT extends DaoTestBase {
 
     private ServiceDao serviceDao;
     private ObjectMapper objectMapper = new ObjectMapper();
@@ -53,12 +53,12 @@ public class ServiceDaoIT extends DaoTestBase {
     private static final String CY_NAME = "gwasanaeth prawf";
 
     @BeforeEach
-    public void before() {
+    void before() {
         serviceDao = env.getInstance(ServiceDao.class);
     }
 
     @Test
-    public void shouldSaveAService_withCustomisations() throws Exception {
+    void shouldSaveAService_withCustomisations() throws Exception {
         ServiceEntity insertedServiceEntity = ServiceEntityBuilder.aServiceEntity()
                 .withExperimentalFeaturesEnabled(true)
                 .build();
@@ -78,7 +78,7 @@ public class ServiceDaoIT extends DaoTestBase {
     }
 
     @Test
-    public void shouldSaveAService_withMultipleServiceNames() {
+    void shouldSaveAService_withMultipleServiceNames() {
         ServiceEntity insertedServiceEntity = ServiceEntityBuilder.aServiceEntity()
                 .withCustomBranding(null)
                 .withServiceNameEntity(SupportedLanguage.WELSH, CY_NAME)
@@ -104,7 +104,7 @@ public class ServiceDaoIT extends DaoTestBase {
     }
 
     @Test
-    public void shouldSaveAService_withoutCustomisations_andServiceName() {
+    void shouldSaveAService_withoutCustomisations_andServiceName() {
         ServiceEntity insertedServiceEntity = ServiceEntityBuilder.aServiceEntity()
                 .withCustomBranding(null)
                 .withServiceNameEntity(SupportedLanguage.ENGLISH, EN_NAME)
@@ -131,7 +131,7 @@ public class ServiceDaoIT extends DaoTestBase {
     }
 
     @Test
-    public void shouldSaveAService_withMerchantDetails() {
+    void shouldSaveAService_withMerchantDetails() {
         MerchantDetailsEntity merchantDetails = MerchantDetailsEntityBuilder.aMerchantDetailsEntity().build();
         ServiceEntity insertedServiceEntity = ServiceEntityBuilder.aServiceEntity()
                 .withMerchantDetailsEntity(merchantDetails)
@@ -154,7 +154,7 @@ public class ServiceDaoIT extends DaoTestBase {
     }
 
     @Test
-    public void shouldFindByServiceExternalId() {
+    void shouldFindByServiceExternalId() {
         ZonedDateTime now = ZonedDateTime.now(UTC);
         ServiceEntity insertedServiceEntity = ServiceEntityBuilder.aServiceEntity()
                 .withExperimentalFeaturesEnabled(true)
@@ -177,7 +177,7 @@ public class ServiceDaoIT extends DaoTestBase {
     }
 
     @Test
-    public void shouldReturnServiceValuesFromDatabase() {
+    void shouldReturnServiceValuesFromDatabase() {
         ServiceEntity insertedServiceEntity = ServiceEntityBuilder.aServiceEntity()
                 .withRedirectToServiceImmediatelyOnTerminalState(true)
                 .withCreatedDate(ZonedDateTime.parse("2020-11-01T00:00:00Z"))
@@ -193,7 +193,7 @@ public class ServiceDaoIT extends DaoTestBase {
     }
 
     @Test
-    public void shouldFindServiceWithMultipleLanguage_byServiceExternalId() {
+    void shouldFindServiceWithMultipleLanguage_byServiceExternalId() {
         Set<ServiceNameEntity> serviceNames = new HashSet<>(List.of(
                 createServiceName(SupportedLanguage.ENGLISH, EN_NAME),
                 createServiceName(SupportedLanguage.WELSH, CY_NAME)
@@ -219,7 +219,7 @@ public class ServiceDaoIT extends DaoTestBase {
     }
 
     @Test
-    public void shouldFindByGatewayAccountId() {
+    void shouldFindByGatewayAccountId() {
         GatewayAccountIdEntity gatewayAccountIdEntity = new GatewayAccountIdEntity();
         String gatewayAccountId = randomUuid();
         gatewayAccountIdEntity.setGatewayAccountId(gatewayAccountId);
@@ -237,7 +237,7 @@ public class ServiceDaoIT extends DaoTestBase {
     }
 
     @Test
-    public void shouldGetRoleCountForAService() {
+    void shouldGetRoleCountForAService() {
         String serviceExternalId = randomUuid();
         Integer roleId = randomInt();
         setupUsersForServiceAndRole(serviceExternalId, roleId, 3);
@@ -248,7 +248,7 @@ public class ServiceDaoIT extends DaoTestBase {
     }
     
     @Test
-    public void shouldMergeGoLiveStage() {
+    void shouldMergeGoLiveStage() {
         GatewayAccountIdEntity gatewayAccountIdEntity = new GatewayAccountIdEntity();
         String gatewayAccountId = randomUuid();
         gatewayAccountIdEntity.setGatewayAccountId(gatewayAccountId);

--- a/src/test/java/uk/gov/pay/adminusers/resources/EmailResourceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/EmailResourceIT.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.adminusers.resources;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.fixtures.ServiceDbFixture;
 import uk.gov.pay.adminusers.model.MerchantDetails;
@@ -11,7 +10,6 @@ import static io.restassured.http.ContentType.JSON;
 
 public class EmailResourceIT extends IntegrationTest {
 
-    private ObjectMapper objectMapper = new ObjectMapper();
     private static final String GATEWAY_ACCOUNT_ID = "DIRECT_DEBIT:mdshfsehdtfsdtjg";
     private Map<String, Object> validEmailRequest = Map.of(
             "address", "cake@directdebitteam.test",
@@ -32,7 +30,7 @@ public class EmailResourceIT extends IntegrationTest {
                         "postcode", "country", "dd-merchant@example.com"
                 ))
                 .insertService();
-        String body = objectMapper.valueToTree(validEmailRequest).toString();
+        String body = mapper.valueToTree(validEmailRequest).toString();
         givenSetup()
                 .when()
                 .accept(JSON)

--- a/src/test/java/uk/gov/pay/adminusers/resources/GovUkPayAgreementRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/GovUkPayAgreementRequestValidatorTest.java
@@ -14,25 +14,26 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.core.Is.is;
 
-public class GovUkPayAgreementRequestValidatorTest {
-    
+class GovUkPayAgreementRequestValidatorTest {
+
+    private static ObjectMapper objectMapper = new ObjectMapper();
     private GovUkPayAgreementRequestValidator validator;
     
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         validator = new GovUkPayAgreementRequestValidator(new RequestValidations());
     }
     
     @Test
-    public void shouldPassValidation() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_external_id", "abcde1234"));
+    void shouldPassValidation() {
+        JsonNode payload = objectMapper.valueToTree(Map.of("user_external_id", "abcde1234"));
         Optional<Errors> optionalErrors = validator.validateCreateRequest(payload);
         assertThat(optionalErrors.isPresent(), is(false));
     }
     
     @Test
-    public void shouldFailValidation_whenUserExternalIdIsEmpty() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_external_id", ""));
+    void shouldFailValidation_whenUserExternalIdIsEmpty() {
+        JsonNode payload = objectMapper.valueToTree(Map.of("user_external_id", ""));
         Optional<Errors> optionalErrors = validator.validateCreateRequest(payload);
         assertThat(optionalErrors.isPresent(), is(true));
         assertThat(optionalErrors.get().getErrors().size(), is(1));
@@ -40,8 +41,8 @@ public class GovUkPayAgreementRequestValidatorTest {
     }
     
     @Test
-    public void shouldFailValidation_whenUserExternalIdIsNotString() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_external_id", true));
+    void shouldFailValidation_whenUserExternalIdIsNotString() {
+        JsonNode payload = objectMapper.valueToTree(Map.of("user_external_id", true));
         Optional<Errors> optionalErrors = validator.validateCreateRequest(payload);
         assertThat(optionalErrors.isPresent(), is(true));
         assertThat(optionalErrors.get().getErrors().size(), is(1));
@@ -49,8 +50,8 @@ public class GovUkPayAgreementRequestValidatorTest {
     }
     
     @Test
-    public void shouldFailValidation_whenUserExternalIdIsMissing() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("luser_external_id", "abcde1234"));
+    void shouldFailValidation_whenUserExternalIdIsMissing() {
+        JsonNode payload = objectMapper.valueToTree(Map.of("luser_external_id", "abcde1234"));
         Optional<Errors> optionalErrors = validator.validateCreateRequest(payload);
         assertThat(optionalErrors.isPresent(), is(true));
         assertThat(optionalErrors.get().getErrors().size(), is(1));

--- a/src/test/java/uk/gov/pay/adminusers/resources/HealthCheckResourceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/HealthCheckResourceTest.java
@@ -23,7 +23,10 @@ import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class HealthCheckResourceTest {
+class HealthCheckResourceTest {
+
+    private static ObjectMapper objectMapper = new ObjectMapper();
+    
     @Mock
     private Environment environment;
 
@@ -33,20 +36,20 @@ public class HealthCheckResourceTest {
     private HealthCheckResource resource;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         when(environment.healthChecks()).thenReturn(healthCheckRegistry);
         resource = new HealthCheckResource(environment);
     }
 
     @Test
-    public void checkHealthCheck_isUnHealthy() throws JsonProcessingException {
+    void checkHealthCheck_isUnHealthy() throws JsonProcessingException {
         SortedMap<String,HealthCheck.Result> map = new TreeMap<>();
         map.put("ping", HealthCheck.Result.unhealthy("application is unavailable"));
         map.put("deadlocks", HealthCheck.Result.unhealthy("no new threads available"));
         when(healthCheckRegistry.runHealthChecks()).thenReturn(map);
         Response response = resource.healthCheck();
         assertThat(response.getStatus(), is(503));
-        ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+        ObjectWriter ow = objectMapper.writer().withDefaultPrettyPrinter();
         String body = ow.writeValueAsString(response.getEntity());
 
         JsonAssert.with(body)
@@ -56,14 +59,14 @@ public class HealthCheckResourceTest {
     }
 
     @Test
-    public void checkHealthCheck_isHealthy() throws JsonProcessingException {
+    void checkHealthCheck_isHealthy() throws JsonProcessingException {
         SortedMap<String,HealthCheck.Result> map = new TreeMap<>();
         map.put("ping", HealthCheck.Result.healthy());
         map.put("deadlocks", HealthCheck.Result.healthy());
         when(healthCheckRegistry.runHealthChecks()).thenReturn(map);
         Response response = resource.healthCheck();
         assertThat(response.getStatus(), is(200));
-        ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+        ObjectWriter ow = objectMapper.writer().withDefaultPrettyPrinter();
         String body = ow.writeValueAsString(response.getEntity());
 
         JsonAssert.with(body)
@@ -73,14 +76,14 @@ public class HealthCheckResourceTest {
     }
 
     @Test
-    public void checkHealthCheck_pingIsHealthy_deadlocksIsUnhealthy() throws JsonProcessingException {
+    void checkHealthCheck_pingIsHealthy_deadlocksIsUnhealthy() throws JsonProcessingException {
         SortedMap<String,HealthCheck.Result> map = new TreeMap<>();
         map.put("ping", HealthCheck.Result.healthy());
         map.put("deadlocks", HealthCheck.Result.unhealthy("no new threads available"));
         when(healthCheckRegistry.runHealthChecks()).thenReturn(map);
         Response response = resource.healthCheck();
         assertThat(response.getStatus(), is(503));
-        ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+        ObjectWriter ow = objectMapper.writer().withDefaultPrettyPrinter();
         String body = ow.writeValueAsString(response.getEntity());
 
         JsonAssert.with(body)

--- a/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
@@ -54,7 +54,7 @@ public class IntegrationTest {
     public static final DropwizardAppWithPostgresExtension APP;
 
     protected DatabaseTestHelper databaseHelper;
-    protected ObjectMapper mapper;
+    protected static ObjectMapper mapper = new ObjectMapper();
 
     @Path("/v2/notifications")
     public static class NotifyResource {
@@ -85,7 +85,6 @@ public class IntegrationTest {
     @BeforeEach
     public void initialise() {
         databaseHelper = APP.getDatabaseTestHelper();
-        mapper = new ObjectMapper();
     }
 
     protected RequestSpecification givenSetup() {

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteUserRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteUserRequestValidatorTest.java
@@ -18,20 +18,19 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class InviteUserRequestValidatorTest {
+class InviteUserRequestValidatorTest {
 
     private InviteRequestValidator validator;
 
-    private ObjectMapper objectMapper;
+    private static ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeEach
-    public void before() {
+    void before() {
         validator = new InviteRequestValidator(new RequestValidations());
-        objectMapper = new ObjectMapper();
     }
 
     @Test
-    public void validateCreateRequest_shouldError_ifAllMandatoryFieldsAreMissing() throws Exception {
+    void validateCreateRequest_shouldError_ifAllMandatoryFieldsAreMissing() throws Exception {
 
         String invalidPayload = "{}";
         JsonNode jsonNode = objectMapper.readTree(invalidPayload);
@@ -48,7 +47,7 @@ public class InviteUserRequestValidatorTest {
     }
 
     @Test
-    public void validateCreateRequest_shouldError_ifRoleNameFieldIsMissing() throws Exception {
+    void validateCreateRequest_shouldError_ifRoleNameFieldIsMissing() throws Exception {
 
         String invalidPayload = "{" +
                 "\"sender\": \"12345abc\"," +
@@ -67,7 +66,7 @@ public class InviteUserRequestValidatorTest {
     }
 
     @Test
-    public void validateCreateRequest_shouldError_ifEmailFieldIsMissing() throws Exception {
+    void validateCreateRequest_shouldError_ifEmailFieldIsMissing() throws Exception {
 
         String invalidPayload = "{" +
                 "\"sender\": \"12345abc\"," +
@@ -86,7 +85,7 @@ public class InviteUserRequestValidatorTest {
     }
 
     @Test
-    public void validateCreateRequest_shouldError_ifSenderFieldIsMissing() throws Exception {
+    void validateCreateRequest_shouldError_ifSenderFieldIsMissing() throws Exception {
 
         String invalidPayload = "{" +
                 "\"email\": \"email@example.com\"," +
@@ -105,7 +104,7 @@ public class InviteUserRequestValidatorTest {
     }
 
     @Test
-    public void validateGenerateOtpRequest_shouldError_ifAllMandatoryFieldsAreMissing() throws Exception {
+    void validateGenerateOtpRequest_shouldError_ifAllMandatoryFieldsAreMissing() throws Exception {
 
         String invalidPayload = "{}";
         JsonNode jsonNode = objectMapper.readTree(invalidPayload);
@@ -121,7 +120,7 @@ public class InviteUserRequestValidatorTest {
     }
 
     @Test
-    public void validateGenerateOtpRequest_shouldError_ifCodeFieldIsMissing() throws Exception {
+    void validateGenerateOtpRequest_shouldError_ifCodeFieldIsMissing() throws Exception {
 
         String invalidPayload = "{" +
                 "\"password\": \"a-password\"" +
@@ -139,7 +138,7 @@ public class InviteUserRequestValidatorTest {
     }
 
     @Test
-    public void validateGenerateOtpRequest_shouldError_ifTelephoneNumberFieldIsMissing() throws Exception {
+    void validateGenerateOtpRequest_shouldError_ifTelephoneNumberFieldIsMissing() throws Exception {
 
         String invalidPayload = "{" +
                 "\"code\": \"a-code\"," +
@@ -158,7 +157,7 @@ public class InviteUserRequestValidatorTest {
     }
 
     @Test
-    public void validateGenerateOtpRequest_shouldError_ifPasswordFieldIsMissing() throws Exception {
+    void validateGenerateOtpRequest_shouldError_ifPasswordFieldIsMissing() throws Exception {
 
         String invalidPayload = "{" +
                 "\"code\": \"a-code\"," +
@@ -177,7 +176,7 @@ public class InviteUserRequestValidatorTest {
     }
 
     @Test
-    public void validateResendOtpRequest_shouldError_ifAllMandatoryFieldsAreMissing() throws Exception {
+    void validateResendOtpRequest_shouldError_ifAllMandatoryFieldsAreMissing() throws Exception {
 
         String invalidPayload = "{}";
         JsonNode jsonNode = objectMapper.readTree(invalidPayload);
@@ -193,7 +192,7 @@ public class InviteUserRequestValidatorTest {
     }
 
     @Test
-    public void validateResendOtpRequest_shouldError_ifCodeFieldIsMissing() throws Exception {
+    void validateResendOtpRequest_shouldError_ifCodeFieldIsMissing() throws Exception {
 
         String invalidPayload = "{" +
                 "\"telephone_number\": \"a-telephone_number\"" +
@@ -211,7 +210,7 @@ public class InviteUserRequestValidatorTest {
     }
 
     @Test
-    public void validateResendOtpRequest_shouldError_ifTelephoneNumberFieldIsMissing() throws Exception {
+    void validateResendOtpRequest_shouldError_ifTelephoneNumberFieldIsMissing() throws Exception {
 
         String invalidPayload = "{" +
                 "\"code\": \"a-code\"" +
@@ -229,7 +228,7 @@ public class InviteUserRequestValidatorTest {
     }
 
     @Test
-    public void validateOtpValidationRequest_shouldError_ifAllMandatoryFieldsAreMissing() throws Exception {
+    void validateOtpValidationRequest_shouldError_ifAllMandatoryFieldsAreMissing() throws Exception {
 
         String invalidPayload = "{}";
         JsonNode jsonNode = objectMapper.readTree(invalidPayload);
@@ -245,7 +244,7 @@ public class InviteUserRequestValidatorTest {
     }
 
     @Test
-    public void validateOtpValidationRequest_shouldError_ifCodeFieldIsMissing() throws Exception {
+    void validateOtpValidationRequest_shouldError_ifCodeFieldIsMissing() throws Exception {
 
         String invalidPayload = "{" +
                 "\"otp\": \"an-otp-code\"" +
@@ -262,7 +261,7 @@ public class InviteUserRequestValidatorTest {
     }
 
     @Test
-    public void validateOtpValidationRequest_shouldError_ifOtpFieldIsMissing() throws Exception {
+    void validateOtpValidationRequest_shouldError_ifOtpFieldIsMissing() throws Exception {
 
         String invalidPayload = "{" +
                 "\"code\": \"a-code\"" +
@@ -279,7 +278,7 @@ public class InviteUserRequestValidatorTest {
     }
 
     @Test
-    public void shouldSuccess_ifAllFieldsArePresentAndValidEmailDomain() {
+    void shouldSuccess_ifAllFieldsArePresentAndValidEmailDomain() {
         Map<String, String> payload = Map.of("email", "example@example.gov.uk", "telephone_number", "01134960000", "password", "super-secure-password");
         JsonNode payloadNode = objectMapper.valueToTree(payload);
         Optional<Errors> errors = validator.validateCreateServiceRequest(payloadNode);
@@ -288,7 +287,7 @@ public class InviteUserRequestValidatorTest {
     }
 
     @Test
-    public void shouldFail_ifMissingRequiredField() {
+    void shouldFail_ifMissingRequiredField() {
         Map<String, String> payload = Map.of( "telephone_number", "01134960000", "password", "super-secure-password");
         JsonNode payloadNode = objectMapper.valueToTree(payload);
         Optional<Errors> errors = validator.validateCreateServiceRequest(payloadNode);
@@ -299,7 +298,7 @@ public class InviteUserRequestValidatorTest {
     }
 
     @Test
-    public void shouldFail_ifInvalidEmailFormat() {
+    void shouldFail_ifInvalidEmailFormat() {
         Map<String, String> payload = Map.of( "email", "exampleatexample.com", "telephone_number", "01134960000", "password", "super-secure-password");
         JsonNode payloadNode = objectMapper.valueToTree(payload);
         Optional<Errors> errors = validator.validateCreateServiceRequest(payloadNode);
@@ -310,14 +309,14 @@ public class InviteUserRequestValidatorTest {
     }
 
     @Test
-    public void shouldFail_ifEmailAddressNotPublicSector() {
+    void shouldFail_ifEmailAddressNotPublicSector() {
         Map<String, String> payload = Map.of( "email", "example@example.com","telephone_number", "01134960000", "password", "super-secure-password");
         JsonNode payloadNode = objectMapper.valueToTree(payload);
         assertThrows(WebApplicationException.class, () -> validator.validateCreateServiceRequest(payloadNode));
     }
 
     @Test
-    public void shouldFail_ifTelephoneNumberIsInvalid() {
+    void shouldFail_ifTelephoneNumberIsInvalid() {
         Map<String, String> payload = Map.of( "email", "example@example.gov.uk","telephone_number", "0770090000A", "password", "super-secure-password");
         JsonNode payloadNode = objectMapper.valueToTree(payload);
         Optional<Errors> errors = validator.validateCreateServiceRequest(payloadNode);

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceGovUkPayAgreementResourceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceGovUkPayAgreementResourceIT.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.fixtures.GovUkPayAgreementDbFixture;
@@ -21,14 +20,14 @@ import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
 import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
-public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest {
+class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest {
 
     private Service service;
     private User user;
     private String email;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         email = randomUuid() + "@example.org";
         service = serviceDbFixture(databaseHelper).insertService();
         user = userDbFixture(databaseHelper)
@@ -38,8 +37,8 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
     }
 
     @Test
-    public void shouldCreateGovUkPayAgreement() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_external_id", user.getExternalId()));
+    void shouldCreateGovUkPayAgreement() {
+        JsonNode payload = mapper.valueToTree(Map.of("user_external_id", user.getExternalId()));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -51,8 +50,8 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
     }
 
     @Test
-    public void shouldReturn_404_whenServiceNotFound() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_external_id", user.getExternalId()));
+    void shouldReturn_404_whenServiceNotFound() {
+        JsonNode payload = mapper.valueToTree(Map.of("user_external_id", user.getExternalId()));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -63,8 +62,8 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
     }
 
     @Test
-    public void shouldReturn_400_whenUserNotFound() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_external_id", "abcde1234"));
+    void shouldReturn_400_whenUserNotFound() {
+        JsonNode payload = mapper.valueToTree(Map.of("user_external_id", "abcde1234"));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -76,8 +75,8 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
     }
 
     @Test
-    public void shouldReturn_400_whenUserExternalIdIsNotAString() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_external_id", 100));
+    void shouldReturn_400_whenUserExternalIdIsNotAString() {
+        JsonNode payload = mapper.valueToTree(Map.of("user_external_id", 100));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -90,8 +89,8 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
     }
 
     @Test
-    public void shouldReturn_400_whenUserExternalIdIsEmpty() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_external_id", ""));
+    void shouldReturn_400_whenUserExternalIdIsEmpty() {
+        JsonNode payload = mapper.valueToTree(Map.of("user_external_id", ""));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -104,8 +103,8 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
     }
 
     @Test
-    public void shouldReturn_400_whenUserExternalIdIsMissing() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_id", user.getExternalId()));
+    void shouldReturn_400_whenUserExternalIdIsMissing() {
+        JsonNode payload = mapper.valueToTree(Map.of("user_id", user.getExternalId()));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -118,12 +117,12 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
     }
 
     @Test
-    public void shouldReturn_409_whenAgreementAlreadyExists() {
+    void shouldReturn_409_whenAgreementAlreadyExists() {
         GovUkPayAgreementDbFixture.govUkPayAgreementDbFixture(databaseHelper)
                 .withServiceId(service.getId())
                 .insert();
 
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_external_id", user.getExternalId()));
+        JsonNode payload = mapper.valueToTree(Map.of("user_external_id", user.getExternalId()));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -136,10 +135,10 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
     }
 
     @Test
-    public void shouldReturn_400_whenUserDoesNotBelongToService() {
+    void shouldReturn_400_whenUserDoesNotBelongToService() {
         user = userDbFixture(databaseHelper)
                 .insertUser();
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("user_external_id", user.getExternalId()));
+        JsonNode payload = mapper.valueToTree(Map.of("user_external_id", user.getExternalId()));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -152,7 +151,7 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
     }
 
     @Test
-    public void shouldReturnAgreement_whenExists() {
+    void shouldReturnAgreement_whenExists() {
         ZonedDateTime agreementTime = ZonedDateTime.now(ZoneOffset.UTC);
         GovUkPayAgreementDbFixture.govUkPayAgreementDbFixture(databaseHelper)
                 .withServiceId(service.getId())
@@ -172,7 +171,7 @@ public class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest 
     }
 
     @Test
-    public void shouldReturn404_whenAgreementNotExists() {
+    void shouldReturn404_whenAgreementNotExists() {
         givenSetup()
                 .when()
                 .accept(JSON)

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceStripeAgreementIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceStripeAgreementIT.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.fixtures.StripeAgreementDbFixture;
@@ -20,18 +19,18 @@ import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 import static uk.gov.pay.adminusers.model.StripeAgreement.FIELD_IP_ADDRESS;
 import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
-public class ServiceResourceStripeAgreementIT extends IntegrationTest {
+class ServiceResourceStripeAgreementIT extends IntegrationTest {
 
     private Service service;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         service = serviceDbFixture(databaseHelper).insertService();
     }
 
     @Test
-    public void shouldCreateStripeAgreement() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of(FIELD_IP_ADDRESS, "0.0.0.0"));
+    void shouldCreateStripeAgreement() {
+        JsonNode payload = mapper.valueToTree(Map.of(FIELD_IP_ADDRESS, "0.0.0.0"));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -42,8 +41,8 @@ public class ServiceResourceStripeAgreementIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldReturn_NOT_FOUND_whenServiceNotFound() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of(FIELD_IP_ADDRESS, "0.0.0.0"));
+    void shouldReturn_NOT_FOUND_whenServiceNotFound() {
+        JsonNode payload = mapper.valueToTree(Map.of(FIELD_IP_ADDRESS, "0.0.0.0"));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -54,12 +53,12 @@ public class ServiceResourceStripeAgreementIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldReturn_409_whenStripeAgreementAlreadyExists() {
+    void shouldReturn_409_whenStripeAgreementAlreadyExists() {
         StripeAgreementDbFixture.stripeAgreementDbFixture(databaseHelper)
                 .withServiceId(service.getId())
                 .insert();
 
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of(FIELD_IP_ADDRESS, "0.0.0.0"));
+        JsonNode payload = mapper.valueToTree(Map.of(FIELD_IP_ADDRESS, "0.0.0.0"));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -72,8 +71,8 @@ public class ServiceResourceStripeAgreementIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldReturn_422_whenProvidedInvalidIPAddress() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of(FIELD_IP_ADDRESS, "257.0.0.0"));
+    void shouldReturn_422_whenProvidedInvalidIPAddress() {
+        JsonNode payload = mapper.valueToTree(Map.of(FIELD_IP_ADDRESS, "257.0.0.0"));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -86,8 +85,8 @@ public class ServiceResourceStripeAgreementIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldReturn_422_whenIpAddressIsNotAString() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of(FIELD_IP_ADDRESS, 100));
+    void shouldReturn_422_whenIpAddressIsNotAString() {
+        JsonNode payload = mapper.valueToTree(Map.of(FIELD_IP_ADDRESS, 100));
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -100,8 +99,8 @@ public class ServiceResourceStripeAgreementIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldReturn_422_whenIpAddressNotProvided() {
-        JsonNode payload = new ObjectMapper().valueToTree(emptyMap());
+    void shouldReturn_422_whenIpAddressNotProvided() {
+        JsonNode payload = mapper.valueToTree(emptyMap());
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -114,7 +113,7 @@ public class ServiceResourceStripeAgreementIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldGetStripeAgreementDetails() {
+    void shouldGetStripeAgreementDetails() {
         ZonedDateTime agreementTime = ZonedDateTime.now(ZoneId.of("UTC"));
         String ipAddress = "192.0.2.0";
 
@@ -134,7 +133,7 @@ public class ServiceResourceStripeAgreementIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldReturn_NOT_FOUND_whenStripeAgreementDoesNotExist() {
+    void shouldReturn_NOT_FOUND_whenStripeAgreementDoesNotExist() {
         givenSetup()
                 .when()
                 .accept(JSON)
@@ -144,7 +143,7 @@ public class ServiceResourceStripeAgreementIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldReturn_NOT_FOUND_whenServiceDoesNotExist() {
+    void shouldReturn_NOT_FOUND_whenServiceDoesNotExist() {
         givenSetup()
                 .when()
                 .accept(JSON)

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateNameIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateNameIT.java
@@ -13,18 +13,18 @@ import static java.lang.String.format;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 
-public class ServiceResourceUpdateNameIT extends IntegrationTest {
-    
+class ServiceResourceUpdateNameIT extends IntegrationTest {
+
     private String serviceExternalId;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         Service service = serviceDbFixture(databaseHelper).insertService();
         serviceExternalId = service.getExternalId();
     }
     @Test
-    public void shouldUpdateBothNameAndEnglishServiceName_whenUpdatingEnglishName() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "replace", "path", "service_name/en", "value", "New Service Name"));
+    void shouldUpdateBothNameAndEnglishServiceName_whenUpdatingEnglishName() {
+        JsonNode payload = mapper.valueToTree(Map.of("op", "replace", "path", "service_name/en", "value", "New Service Name"));
         givenSetup()
                 .when()
                 .accept(JSON)

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserRequestValidatorTest.java
@@ -20,20 +20,19 @@ import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class UserRequestValidatorTest {
+class UserRequestValidatorTest {
 
     private UserRequestValidator validator;
 
-    private ObjectMapper objectMapper;
+    private static ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeEach
-    public void before() {
+    void before() {
         validator = new UserRequestValidator(new RequestValidations());
-        objectMapper = new ObjectMapper();
     }
 
     @Test
-    public void shouldError_ifAllMandatoryFieldsAreMissing() throws Exception {
+    void shouldError_ifAllMandatoryFieldsAreMissing() throws Exception {
         String invalidPayload = "{}";
         JsonNode jsonNode = objectMapper.readTree(invalidPayload);
         Optional<Errors> optionalErrors = validator.validateCreateRequest(jsonNode);
@@ -50,7 +49,7 @@ public class UserRequestValidatorTest {
     }
 
     @Test
-    public void shouldError_ifSomeMandatoryFieldsAreMissing() throws Exception {
+    void shouldError_ifSomeMandatoryFieldsAreMissing() throws Exception {
         String invalidPayload = "{" +
                 "\"username\": \"a-username\"," +
                 "\"email\": \"email@example.com\"," +
@@ -71,7 +70,7 @@ public class UserRequestValidatorTest {
     }
 
     @Test
-    public void shouldError_ifMandatoryPatchFieldsAreMissing() {
+    void shouldError_ifMandatoryPatchFieldsAreMissing() {
         JsonNode invalidPayload = mock(JsonNode.class);
         mockValidValuesFor(invalidPayload, Map.of("foo", "blah", "bar", "blah@blah.com"));
         Optional<Errors> optionalErrors = validator.validatePatchRequest(invalidPayload);
@@ -87,7 +86,7 @@ public class UserRequestValidatorTest {
     }
 
     @Test
-    public void shouldError_ifPathNotAllowed_whenPatching() {
+    void shouldError_ifPathNotAllowed_whenPatching() {
         JsonNode invalidPayload = mock(JsonNode.class);
         mockValidValuesFor(invalidPayload, Map.of("op", "append", "path", "version", "value", "1"));
         Optional<Errors> optionalErrors = validator.validatePatchRequest(invalidPayload);
@@ -100,7 +99,7 @@ public class UserRequestValidatorTest {
     }
 
     @Test
-    public void shouldError_ifPathOperationNotValid_whenPatching() {
+    void shouldError_ifPathOperationNotValid_whenPatching() {
         JsonNode invalidPayload = mock(JsonNode.class);
         mockValidValuesFor(invalidPayload, Map.of("op", "replace", "path", "sessionVersion", "value", "1"));
         Optional<Errors> optionalErrors = validator.validatePatchRequest(invalidPayload);
@@ -113,8 +112,8 @@ public class UserRequestValidatorTest {
     }
 
     @Test
-    public void shouldError_ifSessionVersionNotNumeric_whenPatching() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "append", "path", "sessionVersion", "value", "1r"));
+    void shouldError_ifSessionVersionNotNumeric_whenPatching() {
+        JsonNode payload = objectMapper.valueToTree(Map.of("op", "append", "path", "sessionVersion", "value", "1r"));
         Optional<Errors> optionalErrors = validator.validatePatchRequest(payload);
 
         assertTrue(optionalErrors.isPresent());
@@ -125,8 +124,8 @@ public class UserRequestValidatorTest {
     }
 
     @Test
-    public void shouldError_ifDisabledNotBoolean_whenPatching() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "replace", "path", "disabled", "value", "1r"));
+    void shouldError_ifDisabledNotBoolean_whenPatching() {
+        JsonNode payload = objectMapper.valueToTree(Map.of("op", "replace", "path", "disabled", "value", "1r"));
         Optional<Errors> optionalErrors = validator.validatePatchRequest(payload);
 
         assertTrue(optionalErrors.isPresent());
@@ -137,40 +136,40 @@ public class UserRequestValidatorTest {
     }
 
     @Test
-    public void shouldSuccess_forDisabled_whenPatching() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "replace", "path", "disabled", "value", "true"));
+    void shouldSuccess_forDisabled_whenPatching() {
+        JsonNode payload = objectMapper.valueToTree(Map.of("op", "replace", "path", "disabled", "value", "true"));
         Optional<Errors> optionalErrors = validator.validatePatchRequest(payload);
 
         assertFalse(optionalErrors.isPresent());
     }
 
     @Test
-    public void shouldSuccess_forSessionVersion_whenPatching() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "append", "path", "sessionVersion", "value", "2"));
+    void shouldSuccess_forSessionVersion_whenPatching() {
+        JsonNode payload = objectMapper.valueToTree(Map.of("op", "append", "path", "sessionVersion", "value", "2"));
         Optional<Errors> optionalErrors = validator.validatePatchRequest(payload);
 
         assertFalse(optionalErrors.isPresent());
     }
 
     @Test
-    public void shouldSuccess_replacingTelephoneNumber_whenPatchingLocalTelephoneNumber() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "replace", "path", "telephone_number", "value", "01134960000"));
+    void shouldSuccess_replacingTelephoneNumber_whenPatchingLocalTelephoneNumber() {
+        JsonNode payload = objectMapper.valueToTree(Map.of("op", "replace", "path", "telephone_number", "value", "01134960000"));
         Optional<Errors> optionalErrors = validator.validatePatchRequest(payload);
 
         assertFalse(optionalErrors.isPresent());
     }
 
     @Test
-    public void shouldSuccess_replacingTelephoneNumber_whenPatchingInternationalTelephoneNumber() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "replace", "path", "telephone_number", "value", "+441134960000"));
+    void shouldSuccess_replacingTelephoneNumber_whenPatchingInternationalTelephoneNumber() {
+        JsonNode payload = objectMapper.valueToTree(Map.of("op", "replace", "path", "telephone_number", "value", "+441134960000"));
         Optional<Errors> optionalErrors = validator.validatePatchRequest(payload);
 
         assertFalse(optionalErrors.isPresent());
     }
 
     @Test
-    public void shouldError_replacingTelephoneNumber_whenPatchingInvalidTelephoneNumber() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "replace", "path", "telephone_number", "value", "(╯°□°）╯︵ ┻━┻"));
+    void shouldError_replacingTelephoneNumber_whenPatchingInvalidTelephoneNumber() {
+        JsonNode payload = objectMapper.valueToTree(Map.of("op", "replace", "path", "telephone_number", "value", "(╯°□°）╯︵ ┻━┻"));
         Optional<Errors> optionalErrors = validator.validatePatchRequest(payload);
 
         Errors errors = optionalErrors.get();
@@ -180,16 +179,16 @@ public class UserRequestValidatorTest {
     }
 
     @Test
-    public void shouldSuccess_whenAddingServiceRole() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("service_external_id", "blah-blah", "role_name", "blah"));
+    void shouldSuccess_whenAddingServiceRole() {
+        JsonNode payload = objectMapper.valueToTree(Map.of("service_external_id", "blah-blah", "role_name", "blah"));
         Optional<Errors> optionalErrors = validator.validateAssignServiceRequest(payload);
 
         assertFalse(optionalErrors.isPresent());
     }
 
     @Test
-    public void shouldError_whenAddingServiceRole_ifRequiredParamMissing() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("service_external_id", "blah-blah"));
+    void shouldError_whenAddingServiceRole_ifRequiredParamMissing() {
+        JsonNode payload = objectMapper.valueToTree(Map.of("service_external_id", "blah-blah"));
         Optional<Errors> optionalErrors = validator.validateAssignServiceRequest(payload);
 
         Errors errors = optionalErrors.get();
@@ -199,7 +198,7 @@ public class UserRequestValidatorTest {
     }
 
     @Test
-    public void shouldError_ifTelephoneNumberFieldIsInvalid() throws Exception {
+    void shouldError_ifTelephoneNumberFieldIsInvalid() throws Exception {
         String invalidPayload = "{" +
                 "\"username\": \"a-username\"," +
                 "\"password\": \"a-password\"," +
@@ -222,7 +221,7 @@ public class UserRequestValidatorTest {
     }
 
     @Test
-    public void shouldError_ifFieldsAreBiggerThanMaxLength() throws Exception {
+    void shouldError_ifFieldsAreBiggerThanMaxLength() throws Exception {
         String invalidPayload = "{" +
                 "\"username\": \"" + RandomStringUtils.randomAlphanumeric(256) + "\"," +
                 "\"password\": \"" + RandomStringUtils.randomAlphanumeric(256) + "\"," +
@@ -245,7 +244,7 @@ public class UserRequestValidatorTest {
     }
 
     @Test
-    public void shouldReturnEmpty_ifAllValidationsArePassed() throws Exception {
+    void shouldReturnEmpty_ifAllValidationsArePassed() throws Exception {
         String validPayload = "{" +
                 "\"username\": \"a-username\"," +
                 "\"password\": \"a-password\"," +
@@ -262,23 +261,23 @@ public class UserRequestValidatorTest {
     }
 
     @Test
-    public void shouldSuccess_ifValidSearchRequest_whenFindingAUser() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("username", "some-existing-user"));
+    void shouldSuccess_ifValidSearchRequest_whenFindingAUser() {
+        JsonNode payload = objectMapper.valueToTree(Map.of("username", "some-existing-user"));
         Optional<Errors> optionalErrors = validator.validateFindRequest(payload);
 
         assertThat(optionalErrors.isPresent(), is(false));
     }
 
     @Test
-    public void shouldSuccess_ifNoBody_whenValidateNewSecondFactorPasscodeRequest() {
+    void shouldSuccess_ifNoBody_whenValidateNewSecondFactorPasscodeRequest() {
         Optional<Errors> optionalErrors = validator.validateNewSecondFactorPasscodeRequest(null);
 
         assertThat(optionalErrors.isPresent(), is(false));
     }
 
     @Test
-    public void shouldSuccess_ifProvisionalNotPresent_whenValidateNewSecondFactorPasscodeRequest() {
-        JsonNode payload = new ObjectMapper().valueToTree(Collections.emptyMap());
+    void shouldSuccess_ifProvisionalNotPresent_whenValidateNewSecondFactorPasscodeRequest() {
+        JsonNode payload = objectMapper.valueToTree(Collections.emptyMap());
 
         Optional<Errors> optionalErrors = validator.validateNewSecondFactorPasscodeRequest(payload);
 
@@ -286,8 +285,8 @@ public class UserRequestValidatorTest {
     }
 
     @Test
-    public void shouldSuccess_ifProvisionalTrue_whenValidateNewSecondFactorPasscodeRequest() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("provisional", true));
+    void shouldSuccess_ifProvisionalTrue_whenValidateNewSecondFactorPasscodeRequest() {
+        JsonNode payload = objectMapper.valueToTree(Map.of("provisional", true));
 
         Optional<Errors> optionalErrors = validator.validateNewSecondFactorPasscodeRequest(payload);
 
@@ -295,8 +294,8 @@ public class UserRequestValidatorTest {
     }
 
     @Test
-    public void shouldSuccess_ifProvisionalFalse_whenValidateNewSecondFactorPasscodeRequest() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("provisional", false));
+    void shouldSuccess_ifProvisionalFalse_whenValidateNewSecondFactorPasscodeRequest() {
+        JsonNode payload = objectMapper.valueToTree(Map.of("provisional", false));
 
         Optional<Errors> optionalErrors = validator.validateNewSecondFactorPasscodeRequest(payload);
 
@@ -304,8 +303,8 @@ public class UserRequestValidatorTest {
     }
 
     @Test
-    public void shouldError_ifProvisionalNotBoolean_whenValidateNewSecondFactorPasscodeRequest() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("provisional", "maybe"));
+    void shouldError_ifProvisionalNotBoolean_whenValidateNewSecondFactorPasscodeRequest() {
+        JsonNode payload = objectMapper.valueToTree(Map.of("provisional", "maybe"));
 
         Optional<Errors> optionalErrors = validator.validateNewSecondFactorPasscodeRequest(payload);
 
@@ -317,8 +316,8 @@ public class UserRequestValidatorTest {
     }
 
     @Test
-    public void shouldError_ifCodeMissing_whenValidate2faActivateRequest() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("second_factor", "SMS"));
+    void shouldError_ifCodeMissing_whenValidate2faActivateRequest() {
+        JsonNode payload = objectMapper.valueToTree(Map.of("second_factor", "SMS"));
 
         Optional<Errors> optionalErrors = validator.validate2faActivateRequest(payload);
 
@@ -330,8 +329,8 @@ public class UserRequestValidatorTest {
     }
 
     @Test
-    public void shouldError_ifCodeNotNumeric_whenValidate2faActivateRequest() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("code", "I am not a number, I’m a free man!",
+    void shouldError_ifCodeNotNumeric_whenValidate2faActivateRequest() {
+        JsonNode payload = objectMapper.valueToTree(Map.of("code", "I am not a number, I’m a free man!",
                 "second_factor", "SMS"));
 
         Optional<Errors> optionalErrors = validator.validate2faActivateRequest(payload);
@@ -344,8 +343,8 @@ public class UserRequestValidatorTest {
     }
 
     @Test
-    public void shouldError_ifSecondFactorMissing_whenValidate2faActivateRequest() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("code", 123456));
+    void shouldError_ifSecondFactorMissing_whenValidate2faActivateRequest() {
+        JsonNode payload = objectMapper.valueToTree(Map.of("code", 123456));
 
         Optional<Errors> optionalErrors = validator.validate2faActivateRequest(payload);
 
@@ -357,8 +356,8 @@ public class UserRequestValidatorTest {
     }
 
     @Test
-    public void shouldError_ifSecondFactorInvalid_whenValidate2faActivateRequest() {
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("code", 123456,
+    void shouldError_ifSecondFactorInvalid_whenValidate2faActivateRequest() {
+        JsonNode payload = objectMapper.valueToTree(Map.of("code", 123456,
                 "second_factor", "PINKY_SWEAR"));
 
         Optional<Errors> optionalErrors = validator.validate2faActivateRequest(payload);
@@ -371,8 +370,8 @@ public class UserRequestValidatorTest {
     }
 
     @Test
-    public void shouldError_ifRequiredFieldsMissing_whenFindingAUser() throws Exception {
-        JsonNode payload = new ObjectMapper().readTree("{}");
+    void shouldError_ifRequiredFieldsMissing_whenFindingAUser() throws Exception {
+        JsonNode payload = objectMapper.readTree("{}");
         Optional<Errors> optionalErrors = validator.validateFindRequest(payload);
 
         assertTrue(optionalErrors.isPresent());

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateServiceRoleIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateServiceRoleIT.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.Role;
@@ -19,17 +18,17 @@ import static uk.gov.pay.adminusers.fixtures.RoleDbFixture.roleDbFixture;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
 
-public class UserResourceCreateServiceRoleIT extends IntegrationTest {
+class UserResourceCreateServiceRoleIT extends IntegrationTest {
 
     @Test
-    public void shouldSuccess_whenAddServiceRoleForUser() {
+    void shouldSuccess_whenAddServiceRoleForUser() {
         Role role = roleDbFixture(databaseHelper).insertAdmin();
         Service service = serviceDbFixture(databaseHelper).insertService();
         String username = randomUuid();
         String email = username + "@example.com";
         User user = userDbFixture(databaseHelper).withUsername(username).withEmail(email).insertUser();
 
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("service_external_id", service.getExternalId(), "role_name", role.getName()));
+        JsonNode payload = mapper.valueToTree(Map.of("service_external_id", service.getExternalId(), "role_name", role.getName()));
 
         givenSetup()
                 .when()
@@ -45,14 +44,14 @@ public class UserResourceCreateServiceRoleIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldError_whenAddServiceRoleForUser_ifMandatoryParamsMissing() {
+    void shouldError_whenAddServiceRoleForUser_ifMandatoryParamsMissing() {
         Role role = roleDbFixture(databaseHelper).insertAdmin();
         serviceDbFixture(databaseHelper).insertService();
         String username = randomUuid();
         String email = username + "@example.com";
         User user = userDbFixture(databaseHelper).withUsername(username).withEmail(email).insertUser();
 
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("role_name", role.getName()));
+        JsonNode payload = mapper.valueToTree(Map.of("role_name", role.getName()));
 
         givenSetup()
                 .when()
@@ -66,7 +65,7 @@ public class UserResourceCreateServiceRoleIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldError_whenAddServiceRoleForUser_ifUserAlreadyHasService() {
+    void shouldError_whenAddServiceRoleForUser_ifUserAlreadyHasService() {
         Role role = roleDbFixture(databaseHelper).insertAdmin();
         String roleName = "view-and-refund";
         roleDbFixture(databaseHelper).withName(roleName).insertAdmin();
@@ -75,7 +74,7 @@ public class UserResourceCreateServiceRoleIT extends IntegrationTest {
         String email = username + "@example.com";
         User user = userDbFixture(databaseHelper).withServiceRole(service.getId(), role.getId()).withUsername(username).withEmail(email).insertUser();
 
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("service_external_id", service.getExternalId(), "role_name", roleName));
+        JsonNode payload = mapper.valueToTree(Map.of("service_external_id", service.getExternalId(), "role_name", roleName));
 
         givenSetup()
                 .when()

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourcePatchIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourcePatchIT.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.User;
@@ -15,12 +14,12 @@ import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
 
-public class UserResourcePatchIT extends IntegrationTest {
+class UserResourcePatchIT extends IntegrationTest {
 
     private String externalId;
 
     @BeforeEach
-    public void createAUser() {
+    void createAUser() {
         String username = randomUuid();
         String email = username + "@example.com";
         User user = userDbFixture(databaseHelper).withUsername(username).withEmail(email).insertUser();
@@ -29,9 +28,9 @@ public class UserResourcePatchIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldIncreaseSessionVersion_whenPatchAttempt() {
+    void shouldIncreaseSessionVersion_whenPatchAttempt() {
 
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "append", "path", "sessionVersion", "value", 2));
+        JsonNode payload = mapper.valueToTree(Map.of("op", "append", "path", "sessionVersion", "value", 2));
 
         givenSetup()
                 .when()
@@ -44,10 +43,10 @@ public class UserResourcePatchIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldUpdateTelephoneNumber_whenPatchAttempt() {
+    void shouldUpdateTelephoneNumber_whenPatchAttempt() {
 
         String newTelephoneNumber = "+441134960000";
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "replace", "path", "telephone_number", "value", newTelephoneNumber));
+        JsonNode payload = mapper.valueToTree(Map.of("op", "replace", "path", "telephone_number", "value", newTelephoneNumber));
 
         givenSetup()
                 .when()
@@ -61,10 +60,10 @@ public class UserResourcePatchIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldUpdateFeatures_whenPatchAttempt() {
+    void shouldUpdateFeatures_whenPatchAttempt() {
 
         String newFeatures = "SUPER_FEATURE_1, SECRET_SQUIRREL_FEATURE";
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "replace", "path", "features", "value", newFeatures));
+        JsonNode payload = mapper.valueToTree(Map.of("op", "replace", "path", "features", "value", newFeatures));
 
         givenSetup()
                 .when()
@@ -77,9 +76,9 @@ public class UserResourcePatchIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldDisableUser_whenPatchAttempt() {
+    void shouldDisableUser_whenPatchAttempt() {
 
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "replace", "path", "disabled", "value", "true"));
+        JsonNode payload = mapper.valueToTree(Map.of("op", "replace", "path", "disabled", "value", "true"));
 
         givenSetup()
                 .when()
@@ -92,9 +91,9 @@ public class UserResourcePatchIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldReturn404_whenUnknownExternalIdIsSupplied() {
+    void shouldReturn404_whenUnknownExternalIdIsSupplied() {
 
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("op", "append", "path", "sessionVersion", "value", 1));
+        JsonNode payload = mapper.valueToTree(Map.of("op", "append", "path", "sessionVersion", "value", 1));
 
         givenSetup()
                 .when()
@@ -106,9 +105,9 @@ public class UserResourcePatchIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldError_whenPatchRequiredFieldsAreMissing() {
+    void shouldError_whenPatchRequiredFieldsAreMissing() {
 
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("blah", "sessionVersion", "value", 1));
+        JsonNode payload = mapper.valueToTree(Map.of("blah", "sessionVersion", "value", 1));
 
         givenSetup()
                 .when()

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceUpdateServiceRoleIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceUpdateServiceRoleIT.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.model.Service;
@@ -32,7 +31,7 @@ public class UserResourceUpdateServiceRoleIT extends IntegrationTest {
         String email2 = username2 + "@example.com";
         userDbFixture(databaseHelper).withServiceRole(service, role.getId()).withUsername(username2).withEmail(email2).insertUser();
 
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("role_name", "view-and-refund"));
+        JsonNode payload = mapper.valueToTree(Map.of("role_name", "view-and-refund"));
 
         givenSetup()
                 .when()
@@ -49,7 +48,7 @@ public class UserResourceUpdateServiceRoleIT extends IntegrationTest {
     @Test
     public void shouldError404_ifUserNotFound_whenUpdatingServiceRole() {
         String serviceExternalId = serviceDbFixture(databaseHelper).insertService().getExternalId();
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("role_name", "view-and-refund"));
+        JsonNode payload = mapper.valueToTree(Map.of("role_name", "view-and-refund"));
 
         givenSetup()
                 .when()
@@ -69,7 +68,7 @@ public class UserResourceUpdateServiceRoleIT extends IntegrationTest {
         String email = username + "@example.com";
         User user = userDbFixture(databaseHelper).withServiceRole(service, role.getId()).withUsername(username).withEmail(email).insertUser();
 
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("role_name", "view-and-refund"));
+        JsonNode payload = mapper.valueToTree(Map.of("role_name", "view-and-refund"));
 
         givenSetup()
                 .when()

--- a/src/test/java/uk/gov/pay/adminusers/service/LinksBuilderTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/LinksBuilderTest.java
@@ -18,12 +18,14 @@ import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 
-public class LinksBuilderTest {
+class LinksBuilderTest {
+
+    private static ObjectMapper objectMapper = new ObjectMapper();
 
     private LinksBuilder linksBuilder = new LinksBuilder("http://localhost:8080");
 
     @Test
-    public void shouldConstruct_userSelfLinkCorrectly() throws Exception {
+    void shouldConstruct_userSelfLinkCorrectly() throws Exception {
         Service service = Service.from(2, "34783g87ebg764r", new ServiceName(Service.DEFAULT_NAME_VALUE));
         Role role = Role.role(2, "blah", "blah");
         ServiceRole serviceRole = ServiceRole.from(service, role);
@@ -33,16 +35,16 @@ public class LinksBuilderTest {
                 SecondFactorMethod.SMS, null, null, null);
         User decoratedUser = linksBuilder.decorate(user);
 
-        String linkJson = new ObjectMapper().writeValueAsString(decoratedUser.getLinks().get(0));
+        String linkJson = objectMapper.writeValueAsString(decoratedUser.getLinks().get(0));
         assertThat(linkJson, is("{\"rel\":\"self\",\"method\":\"GET\",\"href\":\"http://localhost:8080/v1/api/users/" + decoratedUser.getExternalId() + "\"}"));
     }
 
     @Test
-    public void shouldConstruct_forgottenPasswordSelfLinkCorrectly() throws Exception {
+    void shouldConstruct_forgottenPasswordSelfLinkCorrectly() throws Exception {
         ForgottenPassword forgottenPassword = ForgottenPassword.forgottenPassword(1, "a-code", ZonedDateTime.now(), "7d19aff33f8948deb97ed16b2912dcd3");
         ForgottenPassword decorated = linksBuilder.decorate(forgottenPassword);
 
-        String linkJson = new ObjectMapper().writeValueAsString(decorated.getLinks().get(0));
+        String linkJson = objectMapper.writeValueAsString(decorated.getLinks().get(0));
         assertThat(linkJson, is("{\"rel\":\"self\",\"method\":\"GET\",\"href\":\"http://localhost:8080/v1/api/forgotten-passwords/a-code\"}"));
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/service/UserOtpDispatcherTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserOtpDispatcherTest.java
@@ -24,8 +24,10 @@ import static org.mockito.Mockito.when;
 import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE;
 
 @ExtendWith(MockitoExtension.class)
-public class UserOtpDispatcherTest {
+class UserOtpDispatcherTest {
 
+    private static ObjectMapper objectMapper = new ObjectMapper();
+    
     @Mock
     private InviteDao inviteDao;
     @Mock
@@ -38,12 +40,12 @@ public class UserOtpDispatcherTest {
     private InviteOtpDispatcher userOtpDispatcher;
 
     @BeforeEach
-    public void before() {
+    void before() {
         userOtpDispatcher = new UserOtpDispatcher(inviteDao, secondFactorAuthenticator, new PasswordHasher(), notificationService);
     }
 
     @Test
-    public void shouldSuccess_whenDispatchUserOtp_ifInviteEntityExist() {
+    void shouldSuccess_whenDispatchUserOtp_ifInviteEntityExist() {
         String inviteCode = "valid-invite-code";
         String telephone = "+441134960000";
         InviteEntity inviteEntity = new InviteEntity();
@@ -51,7 +53,7 @@ public class UserOtpDispatcherTest {
         inviteEntity.setType(InviteType.USER);
         inviteEntity.setOtpKey("otp-key");
 
-        JsonNode payload = new ObjectMapper().valueToTree(Map.of("telephone_number", telephone, "password", "random"));
+        JsonNode payload = objectMapper.valueToTree(Map.of("telephone_number", telephone, "password", "random"));
         userOtpDispatcher = userOtpDispatcher.withData(InviteOtpRequest.from(payload));
 
         when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
@@ -67,7 +69,7 @@ public class UserOtpDispatcherTest {
     }
 
     @Test
-    public void shouldFail_whenDispatchServiceOtp_ifInviteEntityNotFound() {
+    void shouldFail_whenDispatchServiceOtp_ifInviteEntityNotFound() {
         String inviteCode = "non-existent-code";
         when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.empty());
 

--- a/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
@@ -52,7 +52,7 @@ import static uk.gov.pay.adminusers.model.Permission.permission;
 import static uk.gov.pay.adminusers.model.Role.role;
 
 @ExtendWith(MockitoExtension.class)
-public class UserServicesTest {
+class UserServicesTest {
 
     @Mock
     private UserDao userDao;
@@ -72,15 +72,17 @@ public class UserServicesTest {
     private static final String ANOTHER_USER_EXTERNAL_ID = "7d19aff33f8948deb97ed16b2912dcd4";
     private static final String ANOTHER_USER_USERNAME = "another-random-name";
 
+    private static ObjectMapper objectMapper = new ObjectMapper();
+
     @BeforeEach
-    public void before() {
+    void before() {
         userServices = new UserServices(userDao, passwordHasher,
                 new LinksBuilder("http://localhost"), 3,
                 () -> notificationService, secondFactorAuthenticator);
     }
 
     @Test
-    public void shouldFindAUserByExternalId() {
+    void shouldFindAUserByExternalId() {
         User user = aUser();
 
         UserEntity userEntity = aUserEntityWithTrimmings(user);
@@ -95,7 +97,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldFindAUsersByExternalIds() {
+    void shouldFindAUsersByExternalIds() {
         User user1 = aUser();
         User user2 = anotherUser();
 
@@ -112,7 +114,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldReturnEmpty_WhenFindByExternalId_ifNotFound() {
+    void shouldReturnEmpty_WhenFindByExternalId_ifNotFound() {
         when(userDao.findByExternalId(USER_EXTERNAL_ID)).thenReturn(Optional.empty());
 
         Optional<User> userOptional = userServices.findUserByExternalId(USER_EXTERNAL_ID);
@@ -120,7 +122,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldFindAUserByUserName() {
+    void shouldFindAUserByUserName() {
         User user = aUser();
 
         UserEntity userEntity = aUserEntityWithTrimmings(user);
@@ -135,7 +137,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldReturnEmpty_WhenFindByUserName_ifNotFound() {
+    void shouldReturnEmpty_WhenFindByUserName_ifNotFound() {
         when(userDao.findByUsername(USER_USERNAME)).thenReturn(Optional.empty());
 
         Optional<User> userOptional = userServices.findUserByUsername(USER_USERNAME);
@@ -143,7 +145,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldReturnUserAndResetLoginCount_ifAuthenticationSuccessfulAndUserNotDisabled() {
+    void shouldReturnUserAndResetLoginCount_ifAuthenticationSuccessfulAndUserNotDisabled() {
         User user = aUser();
         user.setLoginCounter(2);
 
@@ -164,7 +166,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldReturnUserAndNotResetLoginCount_ifAuthenticationSuccessfulButUserDisabled() {
+    void shouldReturnUserAndNotResetLoginCount_ifAuthenticationSuccessfulButUserDisabled() {
         User user = aUser();
         user.setLoginCounter(2);
         user.setDisabled(true);
@@ -186,7 +188,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldReturnEmptyAndIncrementLoginCount_ifAuthenticationFail() {
+    void shouldReturnEmptyAndIncrementLoginCount_ifAuthenticationFail() {
         User user = aUser();
         user.setLoginCounter(1);
         UserEntity userEntity = aUserEntityWithTrimmings(user);
@@ -205,7 +207,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldLockUser_onTooManyAuthFailures() {
+    void shouldLockUser_onTooManyAuthFailures() {
         User user = aUser();
         user.setLoginCounter(2);
         UserEntity userEntity = aUserEntityWithTrimmings(user);
@@ -222,10 +224,10 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldReturnUser_whenIncrementingSessionVersion_ifUserFound() {
+    void shouldReturnUser_whenIncrementingSessionVersion_ifUserFound() {
         User user = aUser();
 
-        JsonNode node = new ObjectMapper().valueToTree(Map.of("path", "sessionVersion", "op", "append", "value", "2"));
+        JsonNode node = objectMapper.valueToTree(Map.of("path", "sessionVersion", "op", "append", "value", "2"));
         UserEntity userEntity = aUserEntityWithTrimmings(user);
 
         Optional<UserEntity> userEntityOptional = Optional.of(userEntity);
@@ -239,10 +241,10 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldReturnUser_withDisabled_ifUserFoundDuringPatch() {
+    void shouldReturnUser_withDisabled_ifUserFoundDuringPatch() {
         User user = aUser();
 
-        JsonNode node = new ObjectMapper().valueToTree(Map.of("path", "disabled", "op", "replace", "value", "true"));
+        JsonNode node = objectMapper.valueToTree(Map.of("path", "disabled", "op", "replace", "value", "true"));
 
         UserEntity userEntity = aUserEntityWithTrimmings(user);
 
@@ -259,12 +261,12 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldResetLoginCounter_whenTheUserIsEnabled() {
+    void shouldResetLoginCounter_whenTheUserIsEnabled() {
         User user = aUser();
         user.setDisabled(Boolean.TRUE);
         user.setLoginCounter(11);
 
-        JsonNode node = new ObjectMapper().valueToTree(Map.of("path", "disabled", "op", "replace", "value", "false"));
+        JsonNode node = objectMapper.valueToTree(Map.of("path", "disabled", "op", "replace", "value", "false"));
         UserEntity userEntity = aUserEntityWithTrimmings(user);
         Optional<UserEntity> userEntityOptional = Optional.of(userEntity);
         when(userDao.findByExternalId(USER_EXTERNAL_ID)).thenReturn(userEntityOptional);
@@ -280,13 +282,13 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldUpdateTelephoneNumber_whenReplacingTelephoneNumber_ifUserFound() {
+    void shouldUpdateTelephoneNumber_whenReplacingTelephoneNumber_ifUserFound() {
         User user = aUser();
         UserEntity userEntity = aUserEntityWithTrimmings(user);
         userEntity.setTelephoneNumber("+447700900000");
 
         String newTelephoneNumber = "+441134960000";
-        JsonNode node = new ObjectMapper().valueToTree(Map.of("path", "telephone_number", "op", "replace", "value", newTelephoneNumber));
+        JsonNode node = objectMapper.valueToTree(Map.of("path", "telephone_number", "op", "replace", "value", newTelephoneNumber));
         Optional<UserEntity> userEntityOptional = Optional.of(userEntity);
 
         when(userDao.findByExternalId(USER_EXTERNAL_ID)).thenReturn(userEntityOptional);
@@ -303,13 +305,13 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldUpdateFeatures_whenPathIsFeatures_ifUserFound() {
+    void shouldUpdateFeatures_whenPathIsFeatures_ifUserFound() {
         User user = aUser();
         UserEntity userEntity = aUserEntityWithTrimmings(user);
         userEntity.setFeatures("1");
 
         String newFeature = "1,2,3";
-        JsonNode node = new ObjectMapper().valueToTree(Map.of("path", "features", "op", "replace", "value", newFeature));
+        JsonNode node = objectMapper.valueToTree(Map.of("path", "features", "op", "replace", "value", newFeature));
         Optional<UserEntity> userEntityOptional = Optional.of(userEntity);
 
         when(userDao.findByExternalId(USER_EXTERNAL_ID)).thenReturn(userEntityOptional);
@@ -326,7 +328,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldReturnUser_whenAuthenticate2FA_ifSuccessful() {
+    void shouldReturnUser_whenAuthenticate2FA_ifSuccessful() {
         ZonedDateTime now = ZonedDateTime.now(ZoneId.of("UTC"));
         User aUser = aUser();
         int newPassCode = 123456;
@@ -345,7 +347,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldReturnEmpty_whenAuthenticate2FA_ifUnsuccessful_whenTheUserNeverLoggedIn() {
+    void shouldReturnEmpty_whenAuthenticate2FA_ifUnsuccessful_whenTheUserNeverLoggedIn() {
         User user = aUser();
         UserEntity userEntity = aUserEntityWithTrimmings(user);
         when(userDao.findByExternalId(user.getExternalId())).thenReturn(Optional.of(userEntity));
@@ -363,7 +365,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldReturnEmpty_whenAuthenticate2FA_ifUnsuccessful_whenTheUserLoggedInAtLeastOnce() {
+    void shouldReturnEmpty_whenAuthenticate2FA_ifUnsuccessful_whenTheUserLoggedInAtLeastOnce() {
         ZonedDateTime lastLoggedInDateTime = ZonedDateTime.now(ZoneId.of("UTC")).minusDays(7);
         User user = aUser();
         UserEntity userEntity = aUserEntityWithTrimmings(user);
@@ -383,7 +385,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldReturnEmptyAndDisable_whenAuthenticate2FA_ifUnsuccessfulMaxRetry() {
+    void shouldReturnEmptyAndDisable_whenAuthenticate2FA_ifUnsuccessfulMaxRetry() {
         User user = aUser();
         user.setLoginCounter(3);
         UserEntity userEntity = aUserEntityWithTrimmings(user);
@@ -401,7 +403,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldReturnEmpty_whenAuthenticate2FA_ifUserNotFound() {
+    void shouldReturnEmpty_whenAuthenticate2FA_ifUserNotFound() {
         String nonExistentExternalId = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
         when(userDao.findByExternalId(nonExistentExternalId)).thenReturn(Optional.empty());
 
@@ -411,7 +413,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldReturnUser_whenProvisionNewOtpKey_ifUserFound() {
+    void shouldReturnUser_whenProvisionNewOtpKey_ifUserFound() {
         User user = aUser();
         UserEntity userEntity = UserEntity.from(user);
         userEntity.setOtpKey("Original OTP key");
@@ -433,7 +435,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldReturnEmpty_whenProvisionNewOtpKey_ifUserNotFound() {
+    void shouldReturnEmpty_whenProvisionNewOtpKey_ifUserNotFound() {
         String nonExistentExternalId = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
         when(userDao.findByExternalId(nonExistentExternalId)).thenReturn(Optional.empty());
 
@@ -445,7 +447,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldReturnEmpty_whenProvisionNewOtpKey_ifUserDisabled() {
+    void shouldReturnEmpty_whenProvisionNewOtpKey_ifUserDisabled() {
         User user = aUser();
         UserEntity userEntity = UserEntity.from(user);
         userEntity.setOtpKey("Original OTP key");
@@ -465,7 +467,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldReturnUser_whenActivateNewOtpKey_ifUserFound() {
+    void shouldReturnUser_whenActivateNewOtpKey_ifUserFound() {
         User user = aUser();
         UserEntity userEntity = UserEntity.from(user);
         userEntity.setSecondFactor(SecondFactorMethod.SMS);
@@ -490,7 +492,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldReturnUser_whenActivateNewOtpKey_ifCodeIncorrect() {
+    void shouldReturnUser_whenActivateNewOtpKey_ifCodeIncorrect() {
         User user = aUser();
         UserEntity userEntity = UserEntity.from(user);
         userEntity.setSecondFactor(SecondFactorMethod.SMS);
@@ -512,7 +514,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldReturnUser_whenActivateNewOtpKey_ifNoProvisionalOtpCode() {
+    void shouldReturnUser_whenActivateNewOtpKey_ifNoProvisionalOtpCode() {
         User user = aUser();
         UserEntity userEntity = UserEntity.from(user);
         userEntity.setSecondFactor(SecondFactorMethod.SMS);
@@ -532,7 +534,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldReturnUser_whenActivateNewOtpKey_ifNoProvisionalOtpCodeCreatedAt() {
+    void shouldReturnUser_whenActivateNewOtpKey_ifNoProvisionalOtpCodeCreatedAt() {
         User user = aUser();
         UserEntity userEntity = UserEntity.from(user);
         userEntity.setSecondFactor(SecondFactorMethod.SMS);
@@ -552,7 +554,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldReturnUser_whenActivateNewOtpKey_ifProvisionalOtpCodeCreatedAtTooLongAgo() {
+    void shouldReturnUser_whenActivateNewOtpKey_ifProvisionalOtpCodeCreatedAtTooLongAgo() {
         User user = aUser();
         UserEntity userEntity = UserEntity.from(user);
         userEntity.setSecondFactor(SecondFactorMethod.SMS);
@@ -573,7 +575,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldReturnEmpty_whenActivateNewOtpKey_ifUserNotFound() {
+    void shouldReturnEmpty_whenActivateNewOtpKey_ifUserNotFound() {
         String nonExistentExternalId = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
         when(userDao.findByExternalId(nonExistentExternalId)).thenReturn(Optional.empty());
 
@@ -585,7 +587,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void shouldReturnUser_whenActivateNewOtpKey_ifUserDisabled() {
+    void shouldReturnUser_whenActivateNewOtpKey_ifUserDisabled() {
         User user = aUser();
         UserEntity userEntity = UserEntity.from(user);
         userEntity.setSecondFactor(SecondFactorMethod.SMS);
@@ -607,7 +609,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void resetSecondFactor_shouldUpdateOtpMethodAndSetNewOtpKey_ifSecondFactorMethodIsApp() {
+    void resetSecondFactor_shouldUpdateOtpMethodAndSetNewOtpKey_ifSecondFactorMethodIsApp() {
         User user = aUser();
         user.setSecondFactor(SecondFactorMethod.APP);
         UserEntity userEntity = UserEntity.from(user);
@@ -628,7 +630,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void resetSecondFactor_shouldNotUpdateUser_ifSecondFactorMethodIsSms() {
+    void resetSecondFactor_shouldNotUpdateUser_ifSecondFactorMethodIsSms() {
         User user = aUser();
         user.setSecondFactor(SecondFactorMethod.SMS);
         UserEntity userEntity = UserEntity.from(user);
@@ -642,7 +644,7 @@ public class UserServicesTest {
     }
 
     @Test
-    public void resetSecondFactor_shouldReturnEmptyOptional_ifUserNotFound() {
+    void resetSecondFactor_shouldReturnEmptyOptional_ifUserNotFound() {
         String externalId = "not-found";
         when(userDao.findByExternalId(externalId)).thenReturn(Optional.empty());
 

--- a/src/test/java/uk/gov/pay/adminusers/utils/ErrorsTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/ErrorsTest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.adminusers.utils;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -14,22 +13,17 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 
-public class ErrorsTest {
+class ErrorsTest {
 
-    private ObjectMapper mapper;
-
-    @BeforeEach
-    public void before() {
-        mapper = new ObjectMapper();
-    }
+    private static ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
-    public void shouldMarshalMultipleErrorsCorrectly() throws Exception {
+    void shouldMarshalMultipleErrorsCorrectly() throws Exception {
         List<String> errorList = List.of("Error 1", "Error 2", "Error 3");
         Errors errors = Errors.from(errorList);
 
-        String errorsJson = mapper.writeValueAsString(errors);
-        Map<String, List<String>> response = mapper.readValue(errorsJson, new TypeReference<Map<String, List<String>>>() {
+        String errorsJson = objectMapper.writeValueAsString(errors);
+        Map<String, List<String>> response = objectMapper.readValue(errorsJson, new TypeReference<>() {
         });
 
         assertThat(response.get("errors"), is(notNullValue()));
@@ -38,11 +32,11 @@ public class ErrorsTest {
     }
 
     @Test
-    public void shouldMarshalSingleErrorsCorrectly() throws Exception {
+    void shouldMarshalSingleErrorsCorrectly() throws Exception {
         Errors errors = Errors.from("an error");
 
-        String errorsJson = mapper.writeValueAsString(errors);
-        Map<String, List<String>> response = mapper.readValue(errorsJson, new TypeReference<Map<String, List<String>>>() {
+        String errorsJson = objectMapper.writeValueAsString(errors);
+        Map<String, List<String>> response = objectMapper.readValue(errorsJson, new TypeReference<>() {
         });
 
         assertThat(response.get("errors"), is(notNullValue()));


### PR DESCRIPTION
ObjectMapper is an expensive object so reduce its instantiation.
Also remove [some] unnecessary `public` qualifiers not needed for junit5 tests.
