### PR TITLE
PP-7708 Database migrations for agent-initiated MOTO payments

### DIFF
--- a/src/main/resources/migrations/00064_add_agent_initiated_moto_enabled_to_services.sql
+++ b/src/main/resources/migrations/00064_add_agent_initiated_moto_enabled_to_services.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_agent_initiated_moto_enabled_to_services
+ALTER TABLE services ADD COLUMN agent_initiated_moto_enabled BOOLEAN NOT NULL DEFAULT false;

--- a/src/main/resources/migrations/00065_add_agent_initiated_moto_create_permission.sql
+++ b/src/main/resources/migrations/00065_add_agent_initiated_moto_create_permission.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:agent_initiated_moto_permission
+INSERT INTO permissions(id, name, description) VALUES ((SELECT MAX(id) + 1 FROM permissions), 'agent-initiated-moto:create', 'Create payment from agent-initiated MOTO product');
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'admin'), (SELECT id FROM permissions WHERE name = 'agent-initiated-moto:create'));

--- a/src/main/resources/migrations/00066_add_view_and_intiate_moto_and_view_refund_and_intiate_moto_roles.sql
+++ b/src/main/resources/migrations/00066_add_view_and_intiate_moto_and_view_refund_and_intiate_moto_roles.sql
@@ -1,0 +1,44 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:view_and_initiate_moto_role
+INSERT INTO roles(id, name, description) VALUES ((SELECT MAX(id) + 1 FROM roles), 'view-and-initiate-moto', 'View and create MOTO payments');
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'transactions:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'transactions-by-date:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'transactions-by-fields:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'transactions-download:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'transactions-details:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'transactions-events:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'transactions-amount:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'transactions-description:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'transactions-email:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'transactions-card-type:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'service-name:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'toggle-3ds:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'payment-types:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'email-notification-template:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'toggle-billing-address:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'payouts:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'moto-mask-input:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'agent-initiated-moto:create'));
+
+--changeset uk.gov.pay:view_refund_and_initiate_moto_role
+INSERT INTO roles(id, name, description) VALUES ((SELECT MAX(id) + 1 FROM roles), 'view-refund-and-initiate-moto', 'View, refund and create MOTO payments');
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-refund-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'transactions:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-refund-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'transactions-by-date:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-refund-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'transactions-by-fields:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-refund-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'transactions-download:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-refund-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'transactions-details:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-refund-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'transactions-events:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-refund-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'refunds:create'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-refund-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'transactions-amount:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-refund-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'transactions-description:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-refund-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'transactions-email:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-refund-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'transactions-card-type:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-refund-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'service-name:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-refund-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'toggle-3ds:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-refund-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'payment-types:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-refund-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'email-notification-template:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-refund-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'toggle-billing-address:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-refund-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'payouts:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-refund-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'moto-mask-input:read'));
+INSERT INTO role_permission (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE name = 'view-refund-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'agent-initiated-moto:create'));


### PR DESCRIPTION
- Add `agent_initiated_moto_enabled` boolean column to services table with default value of false
- Add `agent-initiated-moto:create` permission, granting it to the `admin` role
- Add new `view-and-initiate-moto` role, giving it the same permissions as `view-only` and also `agent-initiated-moto:create`
- Add new `view-refund-and-initiate-moto` role, giving it the same permissions as `view-and-refund` and also `agent-initiated-moto:create`

Tested locally and it did what I expected.