### PR TITLE
PP-7708 Don’t check exact number of permissions in tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-12-22T18:07:34Z",
+  "generated_at": "2021-02-09T12:03:07Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -176,7 +176,7 @@
         "hashed_secret": "95578813f8acdd659caf14acd19b09c875addbb6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 59,
+        "line_number": 60,
         "type": "Secret Keyword"
       }
     ],

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationIT.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 
 import static io.restassured.http.ContentType.JSON;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
@@ -49,7 +50,7 @@ public class UserResourceAuthenticationIT extends IntegrationTest {
                 .body("disabled", is(false))
                 .body("_links", hasSize(1))
                 .body("service_roles[0].role.name", is("admin"))
-                .body("service_roles[0].role.permissions", hasSize(49));
+                .body("service_roles[0].role.permissions.size()", greaterThan(1));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateIT.java
@@ -13,6 +13,7 @@ import static java.lang.String.valueOf;
 import static java.util.Collections.emptyMap;
 import static org.apache.commons.lang3.RandomUtils.nextInt;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
@@ -109,7 +110,7 @@ public class UserResourceCreateIT extends IntegrationTest {
                 .body("disabled", is(false))
                 .body("service_roles[0].role.name", is("admin"))
                 .body("service_roles[0].role.description", is("Administrator"))
-                .body("service_roles[0].role.permissions", hasSize(49));
+                .body("service_roles[0].role.permissions.size()", is(greaterThan(1)));
 
         response
                 .body("_links", hasSize(1))


### PR DESCRIPTION
Stop checking the exact number of permissions a user has in tests. Checking the exact number means the test breaks every time we add a new permission (which is a database migration, not a code change). Just check there‘s at least one permission instead.