### PR TITLE
PP-7765 add psp test account field to service

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/model/PspTestAccountStage.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/PspTestAccountStage.java
@@ -1,0 +1,7 @@
+package uk.gov.pay.adminusers.model;
+
+public enum PspTestAccountStage {
+    NOT_STARTED,
+    REQUEST_SUBMITTED,
+    CREATED
+}

--- a/src/main/java/uk/gov/pay/adminusers/model/Service.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Service.java
@@ -38,6 +38,7 @@ public class Service {
     private boolean internal;
     private boolean archived;
     private boolean agentInitiatedMotoEnabled;
+    private PspTestAccountStage currentPspTestAccountStage;
 
     @JsonSerialize(using = ApiResponseDateTimeSerializer.class)
     private ZonedDateTime createdDate;
@@ -69,6 +70,7 @@ public class Service {
                 false,
                 false,
                 null,
+                null,
                 null);
     }
 
@@ -84,7 +86,8 @@ public class Service {
                                boolean internal,
                                boolean archived,
                                ZonedDateTime createdDate,
-                               ZonedDateTime wentLiveDate ) {
+                               ZonedDateTime wentLiveDate,
+                               PspTestAccountStage pspTestAccountStage) {
         return new Service(id,
                 externalId,
                 serviceName,
@@ -97,7 +100,8 @@ public class Service {
                 internal,
                 archived,
                 createdDate,
-                wentLiveDate);
+                wentLiveDate,
+                pspTestAccountStage);
     }
 
     private Service(@JsonProperty("id") Integer id,
@@ -112,7 +116,8 @@ public class Service {
                     boolean internal,
                     boolean archived,
                     ZonedDateTime createdDate,
-                    ZonedDateTime wentLiveDate) {
+                    ZonedDateTime wentLiveDate,
+                    PspTestAccountStage currentPspTestAccountStage) {
         this.id = id;
         this.externalId = externalId;
         this.redirectToServiceImmediatelyOnTerminalState = redirectToServiceImmediatelyOnTerminalState;
@@ -126,6 +131,7 @@ public class Service {
         this.archived = archived;
         this.createdDate = createdDate;
         this.wentLiveDate = wentLiveDate;
+        this.currentPspTestAccountStage = currentPspTestAccountStage;
     }
 
     public String getExternalId() {
@@ -222,6 +228,15 @@ public class Service {
 
     public void setGoLiveStage(GoLiveStage goLiveStage) {
         this.goLiveStage = goLiveStage;
+    }
+
+    @JsonProperty("current_psp_test_account_stage")
+    public PspTestAccountStage getCurrentPspTestAccountStage() {
+        return currentPspTestAccountStage;
+    }
+
+    public void setCurrentPspTestAccountStage(PspTestAccountStage currentPspTestAccountStage) {
+        this.currentPspTestAccountStage = currentPspTestAccountStage;
     }
 
     @JsonProperty("experimental_features_enabled")

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.adminusers.persistence.entity;
 
 import uk.gov.pay.adminusers.model.GoLiveStage;
+import uk.gov.pay.adminusers.model.PspTestAccountStage;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.ServiceName;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
@@ -92,6 +93,10 @@ public class ServiceEntity {
     @Column(name = "went_live_date")
     @Convert(converter = UTCDateTimeConverter.class)
     private ZonedDateTime wentLiveDate;
+
+    @Column(name = "current_psp_test_account_stage")
+    @Enumerated(STRING)
+    private PspTestAccountStage currentPspTestAccountStage = PspTestAccountStage.NOT_STARTED;
 
     public ServiceEntity() {
     }
@@ -232,6 +237,15 @@ public class ServiceEntity {
         this.wentLiveDate = wentLiveDate;
     }
 
+    public PspTestAccountStage getCurrentPspTestAccountStage() {
+        return currentPspTestAccountStage;
+    }
+
+    public ServiceEntity setCurrentPspTestAccountStage(PspTestAccountStage currentPspTestAccountStage) {
+        this.currentPspTestAccountStage = currentPspTestAccountStage;
+        return this;
+    }
+
     public Service toService() {
         Service service = Service.from(id,
                 externalId, 
@@ -245,7 +259,8 @@ public class ServiceEntity {
                 this.internal,
                 this.archived,
                 this.createdDate,
-                this.wentLiveDate);
+                this.wentLiveDate,
+                this.currentPspTestAccountStage);
         service.setGatewayAccountIds(gatewayAccountIds.stream()
                 .map(GatewayAccountIdEntity::getGatewayAccountId)
                 .collect(Collectors.toList()));

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
@@ -2,6 +2,7 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import uk.gov.pay.adminusers.model.GoLiveStage;
+import uk.gov.pay.adminusers.model.PspTestAccountStage;
 import uk.gov.pay.adminusers.validations.RequestValidations;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
@@ -24,6 +25,7 @@ import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_AGENT_INITIATED
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_ARCHIVED;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_COLLECT_BILLING_ADDRESS;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_CURRENT_GO_LIVE_STAGE;
+import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_CURRENT_PSP_TEST_ACCOUNT_STAGE;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_CUSTOM_BRANDING;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_EXPERIMENTAL_FEATURES_ENABLED;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_GATEWAY_ACCOUNT_IDS;
@@ -63,6 +65,7 @@ public class ServiceUpdateOperationValidator {
     private final RequestValidations requestValidations;
 
     private static final EnumSet<GoLiveStage> GO_LIVE_STAGES = EnumSet.allOf(GoLiveStage.class);
+    private static final EnumSet<PspTestAccountStage> PSP_TEST_ACCOUNT_STAGES = EnumSet.allOf(PspTestAccountStage.class);
 
     @Inject
     public ServiceUpdateOperationValidator(RequestValidations requestValidations) {
@@ -74,6 +77,7 @@ public class ServiceUpdateOperationValidator {
                 entry(FIELD_AGENT_INITIATED_MOTO_ENABLED, singletonList(REPLACE)),
                 entry(FIELD_COLLECT_BILLING_ADDRESS, singletonList(REPLACE)),
                 entry(FIELD_CURRENT_GO_LIVE_STAGE, singletonList(REPLACE)),
+                entry(FIELD_CURRENT_PSP_TEST_ACCOUNT_STAGE, singletonList(REPLACE)),
                 entry(FIELD_SECTOR, singletonList(REPLACE)),
                 entry(FIELD_INTERNAL, singletonList(REPLACE)),
                 entry(FIELD_ARCHIVED, singletonList(REPLACE)),
@@ -134,6 +138,8 @@ public class ServiceUpdateOperationValidator {
             return validateMandatoryBooleanValue(operation);
         } else if (FIELD_CURRENT_GO_LIVE_STAGE.equals(path)) {
             return validateCurrentGoLiveStageValue(operation);
+        } else if (FIELD_CURRENT_PSP_TEST_ACCOUNT_STAGE.equals(path)){
+            return validateCurrentPspTestAccountStageValue(operation);
         } else if (FIELD_SECTOR.equals(path)) {
             return validateNotNullStringValueWithMaxLength(operation, false, FIELD_SECTOR_MAX_LENGTH);
         } else if (FIELD_INTERNAL.equals(path)) {
@@ -193,6 +199,21 @@ public class ServiceUpdateOperationValidator {
         }
         if (errors.isEmpty()) {
             requestValidations.isValidEnumValue(operation, GO_LIVE_STAGES, FIELD_VALUE).ifPresent(errors::addAll);
+        }
+        return errors;
+    }
+
+    private List<String> validateCurrentPspTestAccountStageValue(JsonNode operation) {
+        List<String> errors = new ArrayList<>();
+        requestValidations.checkExistsAndNotEmpty(operation, FIELD_VALUE).ifPresent(errors::addAll);
+        if (errors.isEmpty()) {
+            requestValidations.checkIsString(
+                    format("Field [%s] must be one of %s", FIELD_VALUE, PSP_TEST_ACCOUNT_STAGES),
+                    operation,
+                    FIELD_VALUE).ifPresent(errors::addAll);
+        }
+        if (errors.isEmpty()) {
+            requestValidations.isValidEnumValue(operation, PSP_TEST_ACCOUNT_STAGES, FIELD_VALUE).ifPresent(errors::addAll);
         }
         return errors;
     }

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 import uk.gov.pay.adminusers.exception.ServiceNotFoundException;
 import uk.gov.pay.adminusers.model.GoLiveStage;
+import uk.gov.pay.adminusers.model.PspTestAccountStage;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.ServiceUpdateRequest;
 import uk.gov.pay.adminusers.model.UpdateMerchantDetailsRequest;
@@ -34,6 +35,7 @@ public class ServiceUpdater {
     public static final String FIELD_AGENT_INITIATED_MOTO_ENABLED = "agent_initiated_moto_enabled";
     public static final String FIELD_COLLECT_BILLING_ADDRESS = "collect_billing_address";
     public static final String FIELD_CURRENT_GO_LIVE_STAGE = "current_go_live_stage";
+    public static final String FIELD_CURRENT_PSP_TEST_ACCOUNT_STAGE = "current_psp_test_account_stage";
     public static final String FIELD_SECTOR = "sector";
     public static final String FIELD_INTERNAL = "internal";
     public static final String FIELD_ARCHIVED = "archived";
@@ -59,6 +61,7 @@ public class ServiceUpdater {
                 entry(FIELD_AGENT_INITIATED_MOTO_ENABLED, updateAgentInitiatedMotoEnabled()),
                 entry(FIELD_COLLECT_BILLING_ADDRESS, updateCollectBillingAddress()),
                 entry(FIELD_CURRENT_GO_LIVE_STAGE, updateCurrentGoLiveStage()),
+                entry(FIELD_CURRENT_PSP_TEST_ACCOUNT_STAGE, updateCurrentPspTestAccountStage()),
                 entry(FIELD_SECTOR, updateSector()),
                 entry(FIELD_INTERNAL, updateInternal()),
                 entry(FIELD_ARCHIVED, updateArchived()),
@@ -154,6 +157,11 @@ public class ServiceUpdater {
     private BiConsumer<ServiceUpdateRequest, ServiceEntity> updateCurrentGoLiveStage() {
         return (serviceUpdateRequest, serviceEntity) ->
                 serviceEntity.setCurrentGoLiveStage(GoLiveStage.valueOf(serviceUpdateRequest.valueAsString()));
+    }
+
+    private BiConsumer<ServiceUpdateRequest, ServiceEntity> updateCurrentPspTestAccountStage() {
+        return (serviceUpdateRequest, serviceEntity) ->
+                serviceEntity.setCurrentPspTestAccountStage(PspTestAccountStage.valueOf(serviceUpdateRequest.valueAsString()));
     }
 
     private BiConsumer<ServiceUpdateRequest, ServiceEntity> updateSector() {

--- a/src/test/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntityBuilder.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntityBuilder.java
@@ -2,6 +2,7 @@ package uk.gov.pay.adminusers.persistence.entity;
 
 import uk.gov.pay.adminusers.app.util.RandomIdGenerator;
 import uk.gov.pay.adminusers.model.GoLiveStage;
+import uk.gov.pay.adminusers.model.PspTestAccountStage;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
 import uk.gov.pay.commons.model.SupportedLanguage;
@@ -30,6 +31,7 @@ public final class ServiceEntityBuilder {
     private ZonedDateTime createdDate = ZonedDateTime.parse("2020-06-29T01:16:00Z");
     private ZonedDateTime wentLiveDate;
     private String sector;
+    private PspTestAccountStage pspTestAccountStage = PspTestAccountStage.NOT_STARTED;
 
     private ServiceEntityBuilder() {
     }
@@ -111,6 +113,11 @@ public final class ServiceEntityBuilder {
         return this;
     }
 
+    public ServiceEntityBuilder withPspTestAccountStage(PspTestAccountStage pspTestAccountStage) {
+        this.pspTestAccountStage = pspTestAccountStage;
+        return this;
+    }
+
     public ServiceEntity build() {
         ServiceEntity serviceEntity = new ServiceEntity();
         serviceEntity.setId(id);
@@ -127,6 +134,7 @@ public final class ServiceEntityBuilder {
         serviceEntity.setCreatedDate(createdDate);
         serviceEntity.setWentLiveDate(wentLiveDate);
         serviceEntity.setSector(sector);
+        serviceEntity.setCurrentPspTestAccountStage(pspTestAccountStage);
         return serviceEntity;
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateIT.java
@@ -29,7 +29,8 @@ public class ServiceResourceUpdateIT extends IntegrationTest {
                         patchRequest("replace", "sector", "local government"),
                         patchRequest("replace", "internal", true),
                         patchRequest("replace", "archived", true),
-                        patchRequest("replace", "went_live_date", "2020-01-01T01:01:00Z")
+                        patchRequest("replace", "went_live_date", "2020-01-01T01:01:00Z"),
+                        patchRequest("replace", "current_psp_test_account_stage", "REQUEST_SUBMITTED")
                 ));
         
         givenSetup()
@@ -47,7 +48,8 @@ public class ServiceResourceUpdateIT extends IntegrationTest {
                 .body("sector", is("local government"))
                 .body("internal", is(true))
                 .body("archived", is(true))
-                .body("went_live_date", is("2020-01-01T01:01:00.000Z"));
+                .body("went_live_date", is("2020-01-01T01:01:00.000Z"))
+                .body("current_psp_test_account_stage", is("REQUEST_SUBMITTED"));
                 
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.core.Is.is;
 public class ServiceUpdateOperationValidatorTest {
 
     private static final String GO_LIVE_STAGE_INVALID_ERROR_MESSAGE = "Field [value] must be one of [NOT_STARTED, ENTERED_ORGANISATION_NAME, ENTERED_ORGANISATION_ADDRESS, CHOSEN_PSP_STRIPE, CHOSEN_PSP_WORLDPAY, CHOSEN_PSP_SMARTPAY, CHOSEN_PSP_EPDQ, CHOSEN_PSP_GOV_BANKING_WORLDPAY, TERMS_AGREED_STRIPE, TERMS_AGREED_WORLDPAY, TERMS_AGREED_SMARTPAY, TERMS_AGREED_EPDQ, TERMS_AGREED_GOV_BANKING_WORLDPAY, DENIED, LIVE]";
+    private static final String PSP_TEST_ACCOUNT_STAGE_INVALID_ERROR_MESSAGE = "Field [value] must be one of [NOT_STARTED, REQUEST_SUBMITTED, CREATED]";
 
     private final ObjectMapper mapper = new ObjectMapper();
     private final ServiceUpdateOperationValidator serviceUpdateOperationValidator = new ServiceUpdateOperationValidator(new RequestValidations());
@@ -53,6 +54,7 @@ public class ServiceUpdateOperationValidatorTest {
                 new Object[]{"add", "redirect_to_service_immediately_on_terminal_state", true},
                 new Object[]{"add", "collect_billing_address", true},
                 new Object[]{"add", "current_go_live_stage", "CHOSEN_PSP_STRIPE"},
+                new Object[]{"add", "current_psp_test_account_stage", "REQUEST_SUBMITTED"},
                 new Object[]{"add", "experimental_features_enabled", false},
                 new Object[]{"add", "agent_initiated_moto_enabled", false},
                 new Object[]{"add", "sector", "any value"},
@@ -83,6 +85,7 @@ public class ServiceUpdateOperationValidatorTest {
                 new Object[]{"sector", 42, "Field [value] must be a string"},
                 new Object[]{"current_go_live_stage", 42, GO_LIVE_STAGE_INVALID_ERROR_MESSAGE},
                 new Object[]{"current_go_live_stage", "CAKE_ORDERED", GO_LIVE_STAGE_INVALID_ERROR_MESSAGE},
+                new Object[]{"current_psp_test_account_stage", "42", PSP_TEST_ACCOUNT_STAGE_INVALID_ERROR_MESSAGE},
                 new Object[]{"merchant_details/name", 42, "Field [value] must be a string"},
                 new Object[]{"merchant_details/address_line1", 42, "Field [value] must be a string"},
                 new Object[]{"merchant_details/address_line2", 42, "Field [value] must be a string"},
@@ -114,6 +117,7 @@ public class ServiceUpdateOperationValidatorTest {
             "redirect_to_service_immediately_on_terminal_state",
             "collect_billing_address",
             "current_go_live_stage",
+            "current_psp_test_account_stage",
             "experimental_features_enabled",
             "agent_initiated_moto_enabled",
             "merchant_details/name",
@@ -144,6 +148,7 @@ public class ServiceUpdateOperationValidatorTest {
             "redirect_to_service_immediately_on_terminal_state",
             "collect_billing_address",
             "current_go_live_stage",
+            "current_psp_test_account_stage",
             "experimental_features_enabled",
             "agent_initiated_moto_enabled",
             "merchant_details/name",
@@ -174,6 +179,7 @@ public class ServiceUpdateOperationValidatorTest {
     @ValueSource(strings = {
             "service_name/en",
             "current_go_live_stage",
+            "current_psp_test_account_stage",
             "merchant_details/name",
             "merchant_details/address_line1",
             "merchant_details/address_city",
@@ -213,6 +219,7 @@ public class ServiceUpdateOperationValidatorTest {
                 new Object[]{"replace", "agent_initiated_moto_enabled", true},
                 new Object[]{"replace", "collect_billing_address", true},
                 new Object[]{"replace", "current_go_live_stage", "CHOSEN_PSP_STRIPE"},
+                new Object[]{"replace", "current_psp_test_account_stage", "REQUEST_SUBMITTED"},
                 new Object[]{"replace", "merchant_details/name", "Bob's Building Business"},
                 new Object[]{"replace", "merchant_details/address_line1", "1 Builders Avenue"},
                 new Object[]{"replace", "merchant_details/address_line2", ""},

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceUpdaterTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import uk.gov.pay.adminusers.exception.ServiceNotFoundException;
 import uk.gov.pay.adminusers.model.GoLiveStage;
+import uk.gov.pay.adminusers.model.PspTestAccountStage;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.ServiceUpdateRequest;
 import uk.gov.pay.adminusers.model.UpdateMerchantDetailsRequest;
@@ -225,7 +226,7 @@ public class ServiceUpdaterTest {
     }
 
     @Test
-    public void shouldUpdateCurrentGoLIveStageSuccessfully() {
+    public void shouldUpdateCurrentGoLiveStageSuccessfully() {
         ServiceUpdateRequest request = serviceUpdateRequest("replace", "current_go_live_stage", valueOf(GoLiveStage.CHOSEN_PSP_STRIPE));
         ServiceEntity serviceEntity = mock(ServiceEntity.class);
 
@@ -236,6 +237,21 @@ public class ServiceUpdaterTest {
 
         assertThat(maybeService.isPresent(), is(true));
         verify(serviceEntity).setCurrentGoLiveStage(GoLiveStage.CHOSEN_PSP_STRIPE);
+        verify(serviceDao).merge(serviceEntity);
+    }
+
+    @Test
+    public void shouldUpdateCurrentPspTestAccountStageSuccessfully() {
+        ServiceUpdateRequest request = serviceUpdateRequest("replace", "current_psp_test_account_stage", valueOf(PspTestAccountStage.REQUEST_SUBMITTED));
+        ServiceEntity serviceEntity = mock(ServiceEntity.class);
+
+        when(serviceDao.findByExternalId(SERVICE_ID)).thenReturn(of(serviceEntity));
+        when(serviceEntity.toService()).thenReturn(Service.from());
+
+        Optional<Service> maybeService = updater.doUpdate(SERVICE_ID, request);
+
+        assertThat(maybeService.isPresent(), is(true));
+        verify(serviceEntity).setCurrentPspTestAccountStage(PspTestAccountStage.REQUEST_SUBMITTED);
         verify(serviceDao).merge(serviceEntity);
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
@@ -383,9 +383,11 @@ public class DatabaseTestHelper {
             return handle.createUpdate("INSERT INTO services(" +
                     "id, custom_branding, " +
                     "merchant_name, merchant_telephone_number, merchant_address_line1, merchant_address_line2, merchant_address_city, " +
-                    "merchant_address_postcode, merchant_address_country, merchant_email, external_id, redirect_to_service_immediately_on_terminal_state, current_go_live_stage, experimental_features_enabled) " +
+                    "merchant_address_postcode, merchant_address_country, merchant_email, external_id, redirect_to_service_immediately_on_terminal_state, " +
+                    "current_go_live_stage, experimental_features_enabled, current_psp_test_account_stage) " +
                     "VALUES (:id, :customBranding, :merchantName, :merchantTelephoneNumber, :merchantAddressLine1, :merchantAddressLine2, " +
-                    ":merchantAddressCity, :merchantAddressPostcode, :merchantAddressCountry, :merchantEmail, :externalId, :redirectToServiceImmediatelyOnTerminalState, :currentGoLiveStage, :experimentalFeaturesEnabled)")
+                    ":merchantAddressCity, :merchantAddressPostcode, :merchantAddressCountry, :merchantEmail, :externalId, :redirectToServiceImmediatelyOnTerminalState, " +
+                    ":currentGoLiveStage, :experimentalFeaturesEnabled, :pspTestAccountStage)")
                     .bind("id", serviceEntity.getId())
                     .bindBySqlType("customBranding", customBranding, OTHER)
                     .bind("merchantName", merchantDetails.getName())
@@ -400,6 +402,7 @@ public class DatabaseTestHelper {
                     .bind("redirectToServiceImmediatelyOnTerminalState", serviceEntity.isRedirectToServiceImmediatelyOnTerminalState())
                     .bind("currentGoLiveStage", serviceEntity.getCurrentGoLiveStage())
                     .bind("experimentalFeaturesEnabled", serviceEntity.isExperimentalFeaturesEnabled())
+                    .bind("pspTestAccountStage", serviceEntity.getCurrentPspTestAccountStage())
                     .execute();
         });
         serviceEntity.getGatewayAccountIds().forEach(gatewayAccount ->


### PR DESCRIPTION
## WHAT YOU DID

Keeping track of the new feature of services asking for a non sandbox test account (PSP specific)

- add the new field `current_psp_test_account_stage` to Service and ServiceEntity objects.
- update patch journey for the new field
- update/create relevant tests
