### PR TITLE
PP-7765 correct psp test account permission name

### DIFF
--- a/src/main/resources/migrations/00069_add_psp_test_account_stage_permission.sql
+++ b/src/main/resources/migrations/00069_add_psp_test_account_stage_permission.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:psp_test_account_stage_update_permission
+UPDATE permissions SET name = 'psp-test-account-stage:update' WHERE name = 'psp_test_account_stage:update';


### PR DESCRIPTION
## WHAT YOU DID
- replace underscore with hyphen in permission's name
