### PR TITLE
PP-7938 Move Package Coordinates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <guice.version>5.0.1</guice.version>
         <guava.version>29.0-jre</guava.version>
         <jackson.version>2.12.2</jackson.version>
-        <pay-java-commons.version>1.0.20210310094438</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20210326162042</pay-java-commons.version>
         <junit5.version>5.7.1</junit5.version>
     </properties>
     <repositories>
@@ -25,23 +25,15 @@
             <name>bintray</name>
             <url>http://dl.bintray.com/gov-uk-notify/maven</url>
         </repository>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>bintray-govuk-pay-pay-java-commons</id>
-            <name>bintray</name>
-            <url>https://dl.bintray.com/govuk-pay/pay-java-commons</url>
-        </repository>
     </repositories>
     <dependencies>
         <dependency>
-            <groupId>uk.gov.pay</groupId>
+            <groupId>uk.gov.service.payments</groupId>
             <artifactId>logging</artifactId>
             <version>${pay-java-commons.version}</version>
         </dependency>
         <dependency>
-            <groupId>uk.gov.pay</groupId>
+            <groupId>uk.gov.service.payments</groupId>
             <artifactId>model</artifactId>
             <version>${pay-java-commons.version}</version>
         </dependency>
@@ -194,7 +186,7 @@
             <version>8.12.20</version>
         </dependency>
         <dependency>
-            <groupId>uk.gov.pay</groupId>
+            <groupId>uk.gov.service.payments</groupId>
             <artifactId>utils</artifactId>
             <version>${pay-java-commons.version}</version>
         </dependency>
@@ -266,7 +258,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>uk.gov.pay</groupId>
+            <groupId>uk.gov.service.payments</groupId>
             <artifactId>testing</artifactId>
             <version>${pay-java-commons.version}</version>
             <scope>test</scope>

--- a/src/main/java/uk/gov/pay/adminusers/app/AdminUsersApp.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/AdminUsersApp.java
@@ -31,12 +31,12 @@ import uk.gov.pay.adminusers.resources.InviteResource;
 import uk.gov.pay.adminusers.resources.ResetPasswordResource;
 import uk.gov.pay.adminusers.resources.ServiceResource;
 import uk.gov.pay.adminusers.resources.UserResource;
-import uk.gov.pay.commons.utils.healthchecks.DatabaseHealthCheck;
-import uk.gov.pay.commons.utils.metrics.DatabaseMetricsService;
-import uk.gov.pay.commons.utils.xray.Xray;
-import uk.gov.pay.logging.GovUkPayDropwizardRequestJsonLogLayoutFactory;
-import uk.gov.pay.logging.LoggingFilter;
-import uk.gov.pay.logging.LogstashConsoleAppenderFactory;
+import uk.gov.service.payments.commons.utils.healthchecks.DatabaseHealthCheck;
+import uk.gov.service.payments.commons.utils.metrics.DatabaseMetricsService;
+import uk.gov.service.payments.commons.utils.xray.Xray;
+import uk.gov.service.payments.logging.GovUkPayDropwizardRequestJsonLogLayoutFactory;
+import uk.gov.service.payments.logging.LoggingFilter;
+import uk.gov.service.payments.logging.LogstashConsoleAppenderFactory;
 
 import java.util.concurrent.TimeUnit;
 

--- a/src/main/java/uk/gov/pay/adminusers/app/healthchecks/DependentResourceWaitCommand.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/healthchecks/DependentResourceWaitCommand.java
@@ -5,8 +5,8 @@ import io.dropwizard.setup.Bootstrap;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 import uk.gov.pay.adminusers.app.config.AdminUsersConfig;
-import uk.gov.pay.commons.utils.startup.ApplicationStartupDependentResourceChecker;
-import uk.gov.pay.commons.utils.startup.DatabaseStartupResource;
+import uk.gov.service.payments.commons.utils.startup.ApplicationStartupDependentResourceChecker;
+import uk.gov.service.payments.commons.utils.startup.DatabaseStartupResource;
 
 public class DependentResourceWaitCommand extends ConfiguredCommand<AdminUsersConfig> {
     public DependentResourceWaitCommand() {

--- a/src/main/java/uk/gov/pay/adminusers/filters/LoggingMDCRequestFilter.java
+++ b/src/main/java/uk/gov/pay/adminusers/filters/LoggingMDCRequestFilter.java
@@ -7,8 +7,8 @@ import javax.ws.rs.container.ContainerRequestFilter;
 import java.io.IOException;
 import java.util.Optional;
 
-import static uk.gov.pay.logging.LoggingKeys.SERVICE_EXTERNAL_ID;
-import static uk.gov.pay.logging.LoggingKeys.USER_EXTERNAL_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.SERVICE_EXTERNAL_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.USER_EXTERNAL_ID;
 
 public class LoggingMDCRequestFilter implements ContainerRequestFilter {
     @Override

--- a/src/main/java/uk/gov/pay/adminusers/filters/LoggingMDCResponseFilter.java
+++ b/src/main/java/uk/gov/pay/adminusers/filters/LoggingMDCResponseFilter.java
@@ -8,8 +8,8 @@ import javax.ws.rs.container.ContainerResponseFilter;
 import java.io.IOException;
 import java.util.List;
 
-import static uk.gov.pay.logging.LoggingKeys.SERVICE_EXTERNAL_ID;
-import static uk.gov.pay.logging.LoggingKeys.USER_EXTERNAL_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.SERVICE_EXTERNAL_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.USER_EXTERNAL_ID;
 
 public class LoggingMDCResponseFilter implements ContainerResponseFilter {
     @Override

--- a/src/main/java/uk/gov/pay/adminusers/model/ForgottenPassword.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/ForgottenPassword.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import uk.gov.pay.commons.api.json.ApiResponseDateTimeSerializer;
+import uk.gov.service.payments.commons.api.json.ApiResponseDateTimeSerializer;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;

--- a/src/main/java/uk/gov/pay/adminusers/model/GovUkPayAgreement.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/GovUkPayAgreement.java
@@ -3,7 +3,7 @@ package uk.gov.pay.adminusers.model;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import uk.gov.pay.commons.api.json.ApiResponseDateTimeSerializer;
+import uk.gov.service.payments.commons.api.json.ApiResponseDateTimeSerializer;
 
 import java.time.ZonedDateTime;
 

--- a/src/main/java/uk/gov/pay/adminusers/model/Service.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Service.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import uk.gov.pay.commons.api.json.ApiResponseDateTimeSerializer;
+import uk.gov.service.payments.commons.api.json.ApiResponseDateTimeSerializer;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;

--- a/src/main/java/uk/gov/pay/adminusers/model/ServiceName.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/ServiceName.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.adminusers.model;
 
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/src/main/java/uk/gov/pay/adminusers/model/StripeAgreement.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/StripeAgreement.java
@@ -2,7 +2,7 @@ package uk.gov.pay.adminusers.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import uk.gov.pay.commons.api.json.ApiResponseDateTimeSerializer;
+import uk.gov.service.payments.commons.api.json.ApiResponseDateTimeSerializer;
 
 import java.net.InetAddress;
 import java.time.ZonedDateTime;

--- a/src/main/java/uk/gov/pay/adminusers/model/User.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/User.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import uk.gov.pay.commons.api.json.ApiResponseDateTimeSerializer;
+import uk.gov.service.payments.commons.api.json.ApiResponseDateTimeSerializer;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
@@ -5,7 +5,7 @@ import uk.gov.pay.adminusers.model.PspTestAccountStage;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.ServiceName;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/service/ServiceNameEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/service/ServiceNameEntity.java
@@ -1,8 +1,8 @@
 package uk.gov.pay.adminusers.persistence.entity.service;
 
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
-import uk.gov.pay.commons.model.SupportedLanguage;
-import uk.gov.pay.commons.model.SupportedLanguageJpaConverter;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguageJpaConverter;
 
 import javax.persistence.Column;
 import javax.persistence.Convert;

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
@@ -23,7 +23,7 @@ import uk.gov.pay.adminusers.service.SendLiveAccountCreatedEmailService;
 import uk.gov.pay.adminusers.service.ServiceServicesFactory;
 import uk.gov.pay.adminusers.service.StripeAgreementService;
 import uk.gov.pay.adminusers.utils.Errors;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import uk.gov.pay.adminusers.model.GoLiveStage;
 import uk.gov.pay.adminusers.model.PspTestAccountStage;
 import uk.gov.pay.adminusers.validations.RequestValidations;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import javax.inject.Inject;
 import java.util.ArrayList;

--- a/src/main/java/uk/gov/pay/adminusers/service/EmailService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/EmailService.java
@@ -11,7 +11,7 @@ import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.resources.EmailTemplate;
 import uk.gov.pay.adminusers.resources.InvalidMerchantDetailsException;
 import uk.gov.pay.adminusers.utils.CountryConverter;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceCreator.java
@@ -6,7 +6,7 @@ import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
@@ -12,7 +12,7 @@ import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
 import uk.gov.pay.adminusers.persistence.entity.MerchantDetailsEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/main/java/uk/gov/pay/adminusers/service/UserCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserCreator.java
@@ -15,7 +15,7 @@ import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/uk/gov/pay/adminusers/service/UserInviteCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserInviteCreator.java
@@ -14,7 +14,7 @@ import uk.gov.pay.adminusers.persistence.dao.UserDao;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.1" xmlns="http://java.sun.com/xml/ns/persistence">
     <persistence-unit name="AdminUsersUnit" transaction-type="RESOURCE_LOCAL">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <class>uk.gov.pay.commons.model.SupportedLanguageJpaConverter</class>
+        <class>uk.gov.service.payments.commons.model.SupportedLanguageJpaConverter</class>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
     </persistence-unit>
 </persistence>

--- a/src/test/java/uk/gov/pay/adminusers/infra/DropwizardAppWithPostgresExtension.java
+++ b/src/test/java/uk/gov/pay/adminusers/infra/DropwizardAppWithPostgresExtension.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.adminusers.app.AdminUsersApp;
 import uk.gov.pay.adminusers.app.config.AdminUsersConfig;
 import uk.gov.pay.adminusers.utils.DatabaseTestHelper;
-import uk.gov.pay.commons.testing.db.PostgresDockerExtension;
+import uk.gov.service.payments.commons.testing.db.PostgresDockerExtension;
 
 import java.sql.Connection;
 import java.sql.DriverManager;

--- a/src/test/java/uk/gov/pay/adminusers/infra/DropwizardAppWithPostgresRule.java
+++ b/src/test/java/uk/gov/pay/adminusers/infra/DropwizardAppWithPostgresRule.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.adminusers.app.AdminUsersApp;
 import uk.gov.pay.adminusers.app.config.AdminUsersConfig;
 import uk.gov.pay.adminusers.utils.DatabaseTestHelper;
-import uk.gov.pay.commons.testing.db.PostgresDockerRule;
+import uk.gov.service.payments.commons.testing.db.PostgresDockerRule;
 
 import java.sql.Connection;
 import java.sql.DriverManager;

--- a/src/test/java/uk/gov/pay/adminusers/model/ServiceNameTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/ServiceNameTest.java
@@ -2,7 +2,7 @@ package uk.gov.pay.adminusers.model;
 
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/uk/gov/pay/adminusers/pact/ContractTestSuite.java
+++ b/src/test/java/uk/gov/pay/adminusers/pact/ContractTestSuite.java
@@ -5,7 +5,7 @@ import junit.framework.JUnit4TestAdapter;
 import junit.framework.TestSuite;
 import org.junit.runner.RunWith;
 import org.junit.runners.AllTests;
-import uk.gov.pay.commons.testing.pact.provider.CreateTestSuite;
+import uk.gov.service.payments.commons.testing.pact.provider.CreateTestSuite;
 
 
 @RunWith(AllTests.class)

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/DaoTestBase.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/DaoTestBase.java
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.adminusers.infra.GuicedTestEnvironment;
 import uk.gov.pay.adminusers.model.Permission;
 import uk.gov.pay.adminusers.utils.DatabaseTestHelper;
-import uk.gov.pay.commons.testing.db.PostgresDockerExtension;
+import uk.gov.service.payments.commons.testing.db.PostgresDockerExtension;
 
 import java.sql.Connection;
 import java.sql.DriverManager;

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoIT.java
@@ -21,7 +21,7 @@ import uk.gov.pay.adminusers.persistence.entity.MerchantDetailsEntityBuilder;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntityBuilder;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import java.time.ZonedDateTime;
 import java.util.Collections;

--- a/src/test/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntityBuilder.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntityBuilder.java
@@ -5,7 +5,7 @@ import uk.gov.pay.adminusers.model.GoLiveStage;
 import uk.gov.pay.adminusers.model.PspTestAccountStage;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import static org.apache.commons.lang3.RandomUtils.nextInt;
 

--- a/src/test/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntityTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntityTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.GoLiveStage;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceCreateIT.java
@@ -2,7 +2,7 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.Test;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceGovUkPayAgreementResourceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceGovUkPayAgreementResourceIT.java
@@ -18,7 +18,7 @@ import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
-import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
+import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
 class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest {
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceStripeAgreementIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceStripeAgreementIT.java
@@ -17,7 +17,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 import static uk.gov.pay.adminusers.model.StripeAgreement.FIELD_IP_ADDRESS;
-import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
+import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
 class ServiceResourceStripeAgreementIT extends IntegrationTest {
 

--- a/src/test/java/uk/gov/pay/adminusers/service/EmailServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/EmailServiceTest.java
@@ -27,7 +27,7 @@ import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static uk.gov.pay.commons.model.SupportedLanguage.ENGLISH;
+import static uk.gov.service.payments.commons.model.SupportedLanguage.ENGLISH;
 
 @ExtendWith(MockitoExtension.class)
 public class EmailServiceTest {

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceCreatorTest.java
@@ -12,7 +12,7 @@ import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
 import uk.gov.pay.adminusers.persistence.entity.GatewayAccountIdEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.WebApplicationException;

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceFinderTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceFinderTest.java
@@ -9,7 +9,7 @@ import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import java.util.Optional;
 

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCompleterTest.java
@@ -21,7 +21,7 @@ import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import javax.ws.rs.WebApplicationException;
 import java.time.ZonedDateTime;

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceRoleUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceRoleUpdaterTest.java
@@ -17,7 +17,7 @@ import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import javax.ws.rs.WebApplicationException;
 import java.util.Collections;

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceUpdaterTest.java
@@ -14,7 +14,7 @@ import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
 import uk.gov.pay.adminusers.persistence.entity.MerchantDetailsEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import javax.ws.rs.WebApplicationException;
 import java.time.ZonedDateTime;

--- a/src/test/java/uk/gov/pay/adminusers/service/UserCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserCreatorTest.java
@@ -16,7 +16,7 @@ import uk.gov.pay.adminusers.persistence.dao.UserDao;
 import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import javax.ws.rs.WebApplicationException;
 import java.util.Optional;

--- a/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
@@ -24,7 +24,7 @@ import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import javax.ws.rs.WebApplicationException;
 import java.time.ZonedDateTime;

--- a/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
@@ -21,7 +21,7 @@ import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import java.time.ZoneId;
 import java.time.ZoneOffset;

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceBaseTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceBaseTest.java
@@ -3,7 +3,7 @@ package uk.gov.pay.adminusers.unit.service;
 import io.restassured.path.json.JsonPath;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
 import uk.gov.pay.adminusers.service.LinksBuilder;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasKey;

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceCreateTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceCreateTest.java
@@ -25,7 +25,7 @@ import uk.gov.pay.adminusers.service.ServiceCreator;
 import uk.gov.pay.adminusers.service.ServiceServicesFactory;
 import uk.gov.pay.adminusers.service.StripeAgreementService;
 import uk.gov.pay.adminusers.validations.RequestValidations;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceFindTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceFindTest.java
@@ -22,7 +22,7 @@ import uk.gov.pay.adminusers.service.ServiceFinder;
 import uk.gov.pay.adminusers.service.ServiceServicesFactory;
 import uk.gov.pay.adminusers.service.StripeAgreementService;
 import uk.gov.pay.adminusers.validations.RequestValidations;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import javax.ws.rs.core.Response;
 import java.time.ZonedDateTime;

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceUpdateTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceUpdateTest.java
@@ -20,7 +20,7 @@ import uk.gov.pay.adminusers.service.ServiceServicesFactory;
 import uk.gov.pay.adminusers.service.ServiceUpdater;
 import uk.gov.pay.adminusers.service.StripeAgreementService;
 import uk.gov.pay.adminusers.validations.RequestValidations;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;

--- a/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
@@ -12,7 +12,7 @@ import uk.gov.pay.adminusers.persistence.entity.CustomBrandingConverter;
 import uk.gov.pay.adminusers.persistence.entity.MerchantDetailsEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
-import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import java.sql.Timestamp;
 import java.time.ZoneId;

--- a/src/test/java/uk/gov/pay/adminusers/utils/DateTimeUtilsTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/DateTimeUtilsTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.time.ZonedDateTime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
+import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
 public class DateTimeUtilsTest {
 


### PR DESCRIPTION
- As part of the migration from Bintray to Maven Central we must move our coordinates to match the domain we own

- This means that the coordinates of our java packages will now exist under `uk.gov.service.payments` instead of `uk.gov.pay`

- This moves the dependencies of pay-java-commons to maven central from bintray
