### PR TITLE
PP-7964 Replace Collectors.toList() with Collectors.toUnmodifiableList()

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/persistence/dao/UserDao.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/dao/UserDao.java
@@ -16,7 +16,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toUnmodifiableList;
+import static java.util.stream.Collectors.toUnmodifiableMap;
 
 @Transactional
 public class UserDao extends JpaDao<UserEntity> {
@@ -39,7 +40,7 @@ public class UserDao extends JpaDao<UserEntity> {
     public List<UserEntity> findByExternalIds(List<String> externalIds) {
         String query = "SELECT u FROM UserEntity u WHERE LOWER(u.externalId) in :externalIds";
 
-        List<String> lowerCaseExternalIds = externalIds.stream().map(String::toLowerCase).collect(toList());
+        List<String> lowerCaseExternalIds = externalIds.stream().map(String::toLowerCase).collect(toUnmodifiableList());
 
         return entityManager.get()
                 .createQuery(query, UserEntity.class)
@@ -72,14 +73,14 @@ public class UserDao extends JpaDao<UserEntity> {
                     .collect(groupingBy(SimpleEntry::getKey))
                     .entrySet()
                     .stream()
-                    .collect(Collectors.toMap(
+                    .collect(toUnmodifiableMap(
                             Map.Entry::getKey,
-                            abstractMap -> abstractMap.getValue().stream().map(SimpleEntry::getValue).collect(toList())));
+                            abstractMap -> abstractMap.getValue().stream().map(SimpleEntry::getValue).collect(toUnmodifiableList())));
         } else {
             return Map.of();
         }
     }
-    
+
     public Optional<UserEntity> findByUsername(String username) {
         String query = "SELECT u FROM UserEntity u " +
                 "WHERE LOWER(u.username) = LOWER(:username)";
@@ -110,6 +111,6 @@ public class UserDao extends JpaDao<UserEntity> {
                 .setParameter("serviceId", serviceId)
                 .getResultList().stream()
                 .map(ServiceRoleEntity::getUser)
-                .collect(toList());
+                .collect(toUnmodifiableList());
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 
 import static java.time.ZoneOffset.UTC;
 import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toUnmodifiableList;
 import static javax.persistence.EnumType.STRING;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 
@@ -263,7 +264,7 @@ public class ServiceEntity {
                 this.currentPspTestAccountStage);
         service.setGatewayAccountIds(gatewayAccountIds.stream()
                 .map(GatewayAccountIdEntity::getGatewayAccountId)
-                .collect(Collectors.toList()));
+                .collect(toUnmodifiableList()));
         service.setCustomBranding(this.customBranding);
         if (this.merchantDetailsEntity != null) {
             service.setMerchantDetails(this.merchantDetailsEntity.toMerchantDetails());

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toUnmodifiableList;
 
 @Entity
 @Table(name = "users")
@@ -282,12 +282,7 @@ public class UserEntity extends AbstractEntity {
     }
 
     public User toUser() {
-
-        List<ServiceRole> serviceRoles = new ArrayList<>();
-
-        if (!this.servicesRoles.isEmpty()) {
-            serviceRoles = this.servicesRoles.stream().map(ServiceRoleEntity::toServiceRole).collect(toList());
-        }
+        List<ServiceRole> serviceRoles = this.servicesRoles.stream().map(ServiceRoleEntity::toServiceRole).collect(toUnmodifiableList());
 
         User user = User.from(getId(), externalId, username, password, email, otpKey, telephoneNumber, serviceRoles,
                 features, secondFactor, provisionalOtpKey, provisionalOtpKeyCreatedAt, lastLoggedInAt);

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteFinder.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteFinder.java
@@ -7,8 +7,8 @@ import uk.gov.pay.adminusers.persistence.dao.UserDao;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.toUnmodifiableList;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.inviteLockedException;
 
 public class InviteFinder {
@@ -50,6 +50,6 @@ public class InviteFinder {
                         return invite;
                     }).orElse(invite);
                 })
-                .collect(Collectors.toList());
+                .collect(toUnmodifiableList());
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceInviteCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceInviteCreator.java
@@ -17,9 +17,9 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static java.lang.String.format;
+import static java.util.stream.Collectors.toUnmodifiableList;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.model.InviteType.SERVICE;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.conflictingEmail;
@@ -65,7 +65,7 @@ public class ServiceInviteCreator {
         List<InviteEntity> exitingInvites = inviteDao.findByEmail(requestEmail);
         List<InviteEntity> existingValidServiceInvitesForSameEmail =  exitingInvites.stream()
                 .filter(inviteEntity -> !inviteEntity.isDisabled() && !inviteEntity.isExpired())
-                .filter(InviteEntity::isServiceType).collect(Collectors.toList());
+                .filter(InviteEntity::isServiceType).collect(toUnmodifiableList());
 
         if(!existingValidServiceInvitesForSameEmail.isEmpty()) {
             InviteEntity foundInvite = existingValidServiceInvitesForSameEmail.get(0);

--- a/src/main/java/uk/gov/pay/adminusers/service/UserInviteCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserInviteCreator.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static java.lang.String.format;
-import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toUnmodifiableList;
 import static javax.ws.rs.core.UriBuilder.fromUri;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.model.InviteType.USER;
@@ -68,7 +68,7 @@ public class UserInviteCreator {
         List<InviteEntity> validInvitesToTheSameService = existingInvites.stream()
                 .filter(inviteEntity -> !inviteEntity.isDisabled() && !inviteEntity.isExpired())
                 .filter(inviteEntity -> inviteEntity.getService() != null && inviteUserRequest.getServiceExternalId().equals(inviteEntity.getService().getExternalId()))
-                .collect(toList());
+                .collect(toUnmodifiableList());
 
         if (!validInvitesToTheSameService.isEmpty()) {
             InviteEntity existingInvite = validInvitesToTheSameService.get(0);

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
@@ -12,8 +12,8 @@ import uk.gov.pay.adminusers.utils.DatabaseTestHelper;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.toUnmodifiableList;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 
@@ -40,7 +40,10 @@ public class UserDbFixture {
     }
 
     public User insertUser() {
-        List<ServiceRole> serviceRoles = serviceRolePairs.stream().map(servicePair -> ServiceRole.from(servicePair.getLeft(), servicePair.getRight())).collect(Collectors.toList());
+        List<ServiceRole> serviceRoles = serviceRolePairs.stream()
+                .map(servicePair -> ServiceRole.from(servicePair.getLeft(), servicePair.getRight()))
+                .collect(toUnmodifiableList());
+
         User user = User.from(randomInt(), externalId, username, password, email, otpKey, telephoneNumber,
                 serviceRoles, features, secondFactorMethod, provisionalOtpKey, null, null);
 

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoIT.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.String.valueOf;
-import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.apache.commons.lang3.RandomUtils.nextInt;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyOrNullString;
@@ -301,8 +301,10 @@ public class UserDaoIT extends DaoTestBase {
         UserEntity changedUser = userDao.findByUsername(username).get();
         List<ServiceRoleEntity> servicesRoles = changedUser.getServicesRoles();
         assertThat(servicesRoles.size(), is(2));
-        assertThat(servicesRoles.stream().map(sr -> sr.getService().getExternalId()).collect(toList()), hasItems(service1.getExternalId(), serviceEntity2.getExternalId()));
-        assertThat(servicesRoles.stream().map(sr -> sr.getRole().getName()).collect(toList()), hasItems(role1.getName(), role2.getName()));
+        assertThat(servicesRoles.stream().map(sr -> sr.getService().getExternalId()).collect(toUnmodifiableList()),
+                hasItems(service1.getExternalId(), serviceEntity2.getExternalId()));
+        assertThat(servicesRoles.stream().map(sr -> sr.getRole().getName()).collect(toUnmodifiableList()),
+                hasItems(role1.getName(), role2.getName()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceCreatorTest.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasItems;
@@ -117,7 +117,11 @@ public class ServiceCreatorTest {
 
         assertThat(service.getName(), is("System Generated"));
 
-        List<String> persistedGatewayIds = persistedServiceEntity.getValue().getGatewayAccountIds().stream().map(GatewayAccountIdEntity::getGatewayAccountId).collect(toList());
+        List<String> persistedGatewayIds = persistedServiceEntity.getValue().getGatewayAccountIds()
+                .stream()
+                .map(GatewayAccountIdEntity::getGatewayAccountId)
+                .collect(toUnmodifiableList());
+
         assertThat(persistedGatewayIds.size(), is(2));
         assertThat(persistedGatewayIds, hasItems(gatewayAccountId1, gatewayAccountId2));
 
@@ -141,7 +145,12 @@ public class ServiceCreatorTest {
         verify(mockedServiceDao, times(1)).persist(persistedServiceEntity.capture());
 
         assertThat(service.getName(), is(EN_SERVICE_NAME));
-        List<String> persistedGatewayIds = persistedServiceEntity.getValue().getGatewayAccountIds().stream().map(GatewayAccountIdEntity::getGatewayAccountId).collect(toList());
+
+        List<String> persistedGatewayIds = persistedServiceEntity.getValue().getGatewayAccountIds()
+                .stream()
+                .map(GatewayAccountIdEntity::getGatewayAccountId)
+                .collect(toUnmodifiableList());
+ 
         assertThat(persistedGatewayIds.size(), is(2));
         assertThat(persistedGatewayIds, hasItems(gatewayAccountId1, gatewayAccountId1));
         assertThat(service.getGatewayAccountIds(), hasItems(gatewayAccountId1, gatewayAccountId2));

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCompleterTest.java
@@ -28,7 +28,7 @@ import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import static java.util.Arrays.asList;
-import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.core.Is.is;
@@ -93,7 +93,7 @@ public class ServiceInviteCompleterTest {
         ServiceEntity serviceEntity = expectedService.getValue();
         assertThat(serviceEntity.getGatewayAccountIds().stream()
                 .map(GatewayAccountIdEntity::getGatewayAccountId)
-                .collect(toList()), hasItems("2", "1"));
+                .collect(toUnmodifiableList()), hasItems("2", "1"));
         assertThat(serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName(), is(Service.DEFAULT_NAME_VALUE));
         assertThat(serviceEntity.isRedirectToServiceImmediatelyOnTerminalState(), is(false));
         assertThat(serviceEntity.isCollectBillingAddress(), is(true));

--- a/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
@@ -104,9 +104,9 @@ class UserServicesTest {
         UserEntity userEntity1 = aUserEntityWithTrimmings(user1);
         UserEntity userEntity2 = aUserEntityWithTrimmings(user2);
 
-        when(userDao.findByExternalIds(Arrays.asList(user1.getExternalId(), user2.getExternalId()))).thenReturn(Arrays.asList(userEntity1, userEntity2));
+        when(userDao.findByExternalIds(List.of(user1.getExternalId(), user2.getExternalId()))).thenReturn(Arrays.asList(userEntity1, userEntity2));
 
-        List<User> users = userServices.findUsersByExternalIds(Arrays.asList(user1.getExternalId(), user2.getExternalId()));
+        List<User> users = userServices.findUsersByExternalIds(List.of(user1.getExternalId(), user2.getExternalId()));
         assertThat(users.size(), is(2));
 
         assertThat(users.get(0).getExternalId(), is(user1.getExternalId()));
@@ -652,6 +652,25 @@ class UserServicesTest {
 
         verify(userDao, never()).merge(any(UserEntity.class));
         assertThat(result.isPresent(), is(false));
+    }
+
+    @Test
+    void getAdminUserEmailsForGatewayAccountIdsReturnsEachInputGatewayAccountIdMappedToPossiblyEmptyListOfAdminEmails() {
+        when(userDao.getAdminUserEmailsForGatewayAccountIds(List.of("1", "2", "3", "4", "5"))).thenReturn(
+                Map.of(
+                        "1", List.of("john@beatles.test", "paul@beatles.test"),
+                        "3", List.of("george@beatles.test"),
+                        "5", List.of("ringo@beatles.test")
+                ));
+
+        Map<String, List<String>> result = userServices.getAdminUserEmailsForGatewayAccountIds(List.of("1", "2", "3", "4", "5"));
+
+        assertThat(result.size(), is(5));
+        assertThat(result.get("1"), is(List.of("john@beatles.test", "paul@beatles.test")));
+        assertThat(result.get("2"), is(List.of()));
+        assertThat(result.get("3"), is(List.of("george@beatles.test")));
+        assertThat(result.get("4"), is(List.of()));
+        assertThat(result.get("5"), is(List.of("ringo@beatles.test")));
     }
 
     private User aUser() {

--- a/src/test/java/uk/gov/pay/adminusers/utils/ComparatorsTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/ComparatorsTest.java
@@ -4,9 +4,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.pay.adminusers.utils.Comparators.numericallyThenLexicographically;
@@ -18,7 +18,7 @@ public class ComparatorsTest {
     public void shouldOrderNumericStringsInAscendingOrder() {
         List<String> result = Stream.of("1", "6", "4", "10", "5")
                 .sorted(usingNumericComparator())
-                .collect(Collectors.toList());
+                .collect(toUnmodifiableList());
         assertThat(result, is(Arrays.asList("1","4","5","6","10")));
     }
 
@@ -26,7 +26,7 @@ public class ComparatorsTest {
     public void shouldOrderGatewayAccountsIdsNumericallyThenLexicographically() {
         List<String> result = Stream.of("1aaa","1", "6", "cde", "4", "bbb23", "10", "5")
                 .sorted(numericallyThenLexicographically())
-                .collect(Collectors.toList());
+                .collect(toUnmodifiableList());
         assertThat(result, is(Arrays.asList("1","4","5","6","10","1aaa","bbb23","cde")));
     }
 


### PR DESCRIPTION
Replace `Collectors.toList()` with `Collectors.toUnmodifiableList()` and `Collectors.toMap()` with `Collectors.toUnmodifiableMap()` respectively, making adjustments where necessary to handle the fact that the latter methods return unmodifiable collections.

See individual commit messages for details.