### PR TITLE
BAU — Use HTTPS for Bintray repository for GOV.UK Notify dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
             </snapshots>
             <id>bintray-gov-uk-notify-maven</id>
             <name>bintray</name>
-            <url>http://dl.bintray.com/gov-uk-notify/maven</url>
+            <url>https://dl.bintray.com/gov-uk-notify/maven</url>
         </repository>
     </repositories>
     <dependencies>


### PR DESCRIPTION
We will not be using Bintray for long but we should use HTTPS where we can.

This brings adminusers in line with connector and prepares us for Maven 3.8.1, which will refuse to download dependencies over HTTP by default.