### PR TITLE
PP-7964 Replace Collectors.toMap() with Collectors.toUnmodifiableMap()

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
@@ -26,11 +26,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.function.Function;
 
 import static java.time.ZoneOffset.UTC;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toUnmodifiableList;
+import static java.util.stream.Collectors.toUnmodifiableMap;
 import static javax.persistence.EnumType.STRING;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 
@@ -309,8 +310,7 @@ public class ServiceEntity {
     }
 
     public Map<SupportedLanguage, ServiceNameEntity> getServiceNames() {
-        return serviceNames.stream()
-                .collect(Collectors.toMap(ServiceNameEntity::getLanguage, serviceName -> serviceName));
+        return serviceNames.stream().collect(toUnmodifiableMap(ServiceNameEntity::getLanguage, Function.identity()));
     }
 
     private void populateGatewayAccountIds(List<String> gatewayAccountIds) {

--- a/src/main/java/uk/gov/pay/adminusers/utils/CountryConverter.java
+++ b/src/main/java/uk/gov/pay/adminusers/utils/CountryConverter.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toUnmodifiableMap;
 
 public class CountryConverter {
 
@@ -27,14 +27,15 @@ public class CountryConverter {
     }
 
     private Map<String, String> createMap(String countries) throws IOException {
-        List<List<String>> allCountries = objectMapper.readValue(countries, new TypeReference<List<List<String>>>() {});
+        List<List<String>> allCountries = objectMapper.readValue(countries, new TypeReference<>() {});
         return allCountries.stream()
                 .filter(country -> country.get(1).startsWith("country:"))
-                .collect(toMap(
+                .collect(toUnmodifiableMap(
                         country -> getIsoCode(country.get(1)),
-                        country -> country.get(0)));
+                        country -> country.get(0)
+                ));
     }
-    
+
     private static String getIsoCode(String typeAndIsoCode) {
         return typeAndIsoCode.substring(typeAndIsoCode.indexOf(':') + 1);
     }


### PR DESCRIPTION
Replace `Collectors.toMap()` with `Collectors.toUnmodifiableMap()`.

The returned maps are never modified and will never contain nulls.