### PR TITLE
BAU — Make integration test pass when computer time zone is BST

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/UTCDateTimeConverter.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/UTCDateTimeConverter.java
@@ -4,12 +4,13 @@ import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
 import java.sql.Timestamp;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
 @Converter
 public class UTCDateTimeConverter implements AttributeConverter<ZonedDateTime, Timestamp> {
 
-    public static final ZoneId UTC = ZoneId.of("UTC");
+    public static final ZoneId UTC = ZoneOffset.UTC;
 
     @Override
     public Timestamp convertToDatabaseColumn(ZonedDateTime dateTime) {

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoIT.java
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.postgresql.util.PGobject;
 import uk.gov.pay.adminusers.fixtures.UserDbFixture;
 import uk.gov.pay.adminusers.model.GoLiveStage;
-import uk.gov.pay.adminusers.model.PspTestAccountStage;
 import uk.gov.pay.adminusers.model.Permission;
+import uk.gov.pay.adminusers.model.PspTestAccountStage;
 import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.ServiceName;
@@ -32,10 +32,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import static java.time.ZoneOffset.UTC;
-import static java.time.temporal.ChronoUnit.SECONDS;
 import static java.util.Comparator.comparing;
 import static java.util.stream.IntStream.range;
-import static org.exparity.hamcrest.date.ZonedDateTimeMatchers.within;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasKey;
@@ -168,7 +166,7 @@ class ServiceDaoIT extends DaoTestBase {
         assertTrue(maybeServiceEntity.isPresent());
         ServiceEntity foundServiceEntity = maybeServiceEntity.get();
         assertThat(foundServiceEntity.isExperimentalFeaturesEnabled(), is(true));
-        assertThat(foundServiceEntity.getCreatedDate(), within(5, SECONDS, now));
+        assertThat(foundServiceEntity.getCreatedDate(), is(insertedServiceEntity.getCreatedDate()));
 
         assertServiceEntity(insertedServiceEntity, foundServiceEntity);
 

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/StripeAgreementDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/StripeAgreementDaoIT.java
@@ -9,6 +9,7 @@ import uk.gov.pay.adminusers.persistence.entity.StripeAgreementEntity;
 import javax.persistence.RollbackException;
 import java.sql.Timestamp;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
@@ -82,7 +83,7 @@ public class StripeAgreementDaoIT extends DaoTestBase {
         Service service = serviceDbFixture(databaseHelper)
                 .insertService();
 
-        ZonedDateTime agreementTime = ZonedDateTime.now(ZoneId.of("UTC"));
+        ZonedDateTime agreementTime = ZonedDateTime.now(ZoneOffset.UTC);
         String ipAddress = "192.0.2.0";
         
         stripeAgreementDbFixture(databaseHelper)

--- a/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
@@ -384,10 +384,10 @@ public class DatabaseTestHelper {
                     "id, custom_branding, " +
                     "merchant_name, merchant_telephone_number, merchant_address_line1, merchant_address_line2, merchant_address_city, " +
                     "merchant_address_postcode, merchant_address_country, merchant_email, external_id, redirect_to_service_immediately_on_terminal_state, " +
-                    "current_go_live_stage, experimental_features_enabled, current_psp_test_account_stage) " +
+                    "current_go_live_stage, experimental_features_enabled, current_psp_test_account_stage, created_date) " +
                     "VALUES (:id, :customBranding, :merchantName, :merchantTelephoneNumber, :merchantAddressLine1, :merchantAddressLine2, " +
                     ":merchantAddressCity, :merchantAddressPostcode, :merchantAddressCountry, :merchantEmail, :externalId, :redirectToServiceImmediatelyOnTerminalState, " +
-                    ":currentGoLiveStage, :experimentalFeaturesEnabled, :pspTestAccountStage)")
+                    ":currentGoLiveStage, :experimentalFeaturesEnabled, :pspTestAccountStage, :createdDate)")
                     .bind("id", serviceEntity.getId())
                     .bindBySqlType("customBranding", customBranding, OTHER)
                     .bind("merchantName", merchantDetails.getName())
@@ -403,6 +403,7 @@ public class DatabaseTestHelper {
                     .bind("currentGoLiveStage", serviceEntity.getCurrentGoLiveStage())
                     .bind("experimentalFeaturesEnabled", serviceEntity.isExperimentalFeaturesEnabled())
                     .bind("pspTestAccountStage", serviceEntity.getCurrentPspTestAccountStage())
+                    .bind("createdDate", serviceEntity.getCreatedDate())
                     .execute();
         });
         serviceEntity.getGatewayAccountIds().forEach(gatewayAccount ->


### PR DESCRIPTION
Make `ServiceDaoIT.shouldFindByServiceExternalId()` pass when computer time zone is British Summer Time (+0100).

The test inserts a test into the database, retrieves it using the `ServiceDao` and then asserts that the created date of the service is within 5 seconds of the current time. When the test runs on a computer using BST as its time zone, it fails because the created date is an hour earlier than the actual current time.

For example, if it is 15:00 BST, the test expects the created date of the service to be 14:00 UTC (which is the same time because BST is an hour ahead of UTC). However, the created date is 13:00 UTC.

I am not sure why this is. The service is inserted into the database directly using JDBI. The created date is stored in a column with a type of `TIMESTAMP WITH TIME ZONE` with a default value of `timezone('utc'::text, now())`. The `DatabaseTestHelper` code that inserts the service does not explicitly specify a created date, so the default is used.

For some reason, when the test runs, the created date that gets inserted into the column is an hour earlier than expected. For
example, if it’s currently 15:00 BST, 13:00 UTC gets inserted rather than 14:00 UTC (I have peered into the database while the test is running to verify this).

If I insert a new row into the database using the standard PostgreSQL command line client, the behaviour is as expected: 15:00 BST becomes 14:00 UTC.

Unfortunately, I cannot figure out what’s going wrong. I presume somewhere along the line the BST date is having an hour subtracted to convert it to UTC but then something assumes it’s still UTC and subtracts another hour.

Make the test pass by changing `DatabaseTestHelper` so that it inserts the service into the database with the created date it already has rather than relying on the database column default. The real code (as opposed to the test code) always specifies the created date itself and does not rely on the database column default so this is reasonable. Furthermore, the production servers always run in UTC so nothing like this is likely to happen.

To make this work, change some instances of `ZoneId.of("UTC")` to `ZoneOffset.UTC` because they’re not actually equal to each other (another reason we should use `Instant` instead of `ZonedDateTime` but that’s for another time).