### PR TITLE
PP-8263 Update the `pre-commit` and `detect-secrets` setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,3 @@ bin
 
 .DS_Store
 /pacts/
-.pre-commit-config.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: https://github.com/Yelp/detect-secrets
+  rev: f6027a0521e044ba46e54611cabd787b7a88d1a9 
+  hooks:
+    - id: detect-secrets
+      args: ['--baseline', '.secrets.baseline']
+      exclude: package.lock.json

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,19 +1,15 @@
 {
-  "exclude": {
-    "files": null,
-    "lines": null
-  },
-  "generated_at": "2021-02-09T12:03:07Z",
+  "version": "1.1.0",
   "plugins_used": [
-    {
-      "name": "AWSKeyDetector"
-    },
     {
       "name": "ArtifactoryDetector"
     },
     {
-      "base64_limit": 4.5,
-      "name": "Base64HighEntropyString"
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
     },
     {
       "name": "BasicAuthDetector"
@@ -22,8 +18,8 @@
       "name": "CloudantDetector"
     },
     {
-      "hex_limit": 3,
-      "name": "HexHighEntropyString"
+      "name": "HexHighEntropyString",
+      "limit": 3
     },
     {
       "name": "IbmCloudIamDetector"
@@ -35,8 +31,8 @@
       "name": "JwtTokenDetector"
     },
     {
-      "keyword_exclude": null,
-      "name": "KeywordDetector"
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
     },
     {
       "name": "MailchimpDetector"
@@ -57,199 +53,288 @@
       "name": "TwilioKeyDetector"
     }
   ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
   "results": {
+    ".pre-commit-config.yaml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "d8371c23f86b4df4be2854848f6f28f13d7582f5",
+        "is_verified": false,
+        "line_number": 3
+      }
+    ],
     "dev.yml": [
       {
+        "type": "Secret Keyword",
+        "filename": "dev.yml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 8,
-        "type": "Secret Keyword"
+        "is_secret": false
       },
       {
+        "type": "Secret Keyword",
+        "filename": "dev.yml",
         "hashed_secret": "0838dfce4c5ff12e20d5509df30db2851cbfae29",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 16,
-        "type": "Secret Keyword"
+        "is_secret": false
       }
     ],
     "docs/api_specification.md": [
       {
+        "type": "Secret Keyword",
+        "filename": "docs/api_specification.md",
         "hashed_secret": "0ea7458942ab65e0a340cf4fd28ca00d93c494f3",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 1126,
-        "type": "Secret Keyword"
+        "line_number": 227,
+        "is_secret": false
+      }
+    ],
+    "src/main/java/uk/gov/pay/adminusers/model/CreateUserRequest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/main/java/uk/gov/pay/adminusers/model/CreateUserRequest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 24
+      }
+    ],
+    "src/main/java/uk/gov/pay/adminusers/model/InviteOtpRequest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/main/java/uk/gov/pay/adminusers/model/InviteOtpRequest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 11
+      }
+    ],
+    "src/main/java/uk/gov/pay/adminusers/model/InviteServiceRequest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/main/java/uk/gov/pay/adminusers/model/InviteServiceRequest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
+    "src/main/java/uk/gov/pay/adminusers/model/User.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/main/java/uk/gov/pay/adminusers/model/User.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 20
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/resources/ResetPasswordResource.java": [
       {
+        "type": "Secret Keyword",
+        "filename": "src/main/java/uk/gov/pay/adminusers/resources/ResetPasswordResource.java",
         "hashed_secret": "f054ffc85b4c1615a7190ea0b248564bb1e9f9ab",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 28,
-        "type": "Secret Keyword"
+        "is_secret": false
+      }
+    ],
+    "src/main/java/uk/gov/pay/adminusers/service/ForgottenPasswordServices.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/main/java/uk/gov/pay/adminusers/service/ForgottenPasswordServices.java",
+        "hashed_secret": "d1a207b38c8b705457e740a084bcf96d959ea01e",
+        "is_verified": false,
+        "line_number": 23
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java": [
       {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java",
         "hashed_secret": "95578813f8acdd659caf14acd19b09c875addbb6",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 27,
-        "type": "Secret Keyword"
+        "is_secret": false
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/pact/ContractTest.java": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/adminusers/pact/ContractTest.java",
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 179,
-        "type": "Hex High Entropy String"
+        "line_number": 132,
+        "is_secret": false
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGenerateOtpIT.java": [
       {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGenerateOtpIT.java",
         "hashed_secret": "833b5c8e76b19b617849d9a67a5980f08c784882",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 24,
-        "type": "Secret Keyword"
+        "is_secret": false
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpIT.java": [
       {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpIT.java",
         "hashed_secret": "833b5c8e76b19b617849d9a67a5980f08c784882",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 36,
-        "type": "Secret Keyword"
+        "is_secret": false
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceServiceCompleteIT.java": [
       {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceServiceCompleteIT.java",
         "hashed_secret": "969c35357bb1a825bf84783da60799e29511e357",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 161,
-        "type": "Secret Keyword"
+        "line_number": 32,
+        "is_secret": false
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceUserCompleteIT.java": [
       {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceUserCompleteIT.java",
         "hashed_secret": "969c35357bb1a825bf84783da60799e29511e357",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 77,
-        "type": "Secret Keyword"
+        "line_number": 24,
+        "is_secret": false
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/resources/ResetPasswordResourceIT.java": [
       {
-        "hashed_secret": "094bcf822fe17528e869a48e0349a573a2ade3f7",
-        "is_secret": false,
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/adminusers/resources/ResetPasswordResourceIT.java",
+        "hashed_secret": "ff667b1e79f00abb68c320a096f851ce96b5de4d",
         "is_verified": false,
-        "line_number": 22,
-        "type": "Secret Keyword"
-      },
-      {
-        "hashed_secret": "8453a8fb1e58bf32d2d8add04f6613b16c1ab060",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 37,
-        "type": "Secret Keyword"
+        "line_number": 22
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceGovUkPayAgreementResourceIT.java": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceGovUkPayAgreementResourceIT.java",
         "hashed_secret": "c3a8fcf85a56dee95cff4ce7adf0bb9a4c18f747",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 59,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationIT.java": [
       {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationIT.java",
         "hashed_secret": "95578813f8acdd659caf14acd19b09c875addbb6",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 60,
-        "type": "Secret Keyword"
+        "is_secret": false
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/service/InviteServiceTest.java": [
       {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/adminusers/service/InviteServiceTest.java",
         "hashed_secret": "7300c52390b4026eb1a60642b0eabfb54475c21b",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 48,
-        "type": "Secret Keyword"
-      }
-    ],
-    "src/test/java/uk/gov/pay/adminusers/service/LinksBuilderTest.java": [
-      {
-        "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 44,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/service/ResetPasswordServiceTest.java": [
       {
-        "hashed_secret": "95b0665e64fa24c375f1db3797739dc833a01be1",
-        "is_secret": false,
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/adminusers/service/ResetPasswordServiceTest.java",
+        "hashed_secret": "5053b136c26f8299a405a678db8dce5f7b1e8ec6",
         "is_verified": false,
-        "line_number": 47,
-        "type": "Secret Keyword"
+        "line_number": 47
       },
       {
-        "hashed_secret": "99ad5e4243491c6f2fec2107f05654c28d9994df",
-        "is_secret": false,
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/adminusers/service/ResetPasswordServiceTest.java",
+        "hashed_secret": "a462122dfd9d77573fa7911b6faa08695ec46af4",
         "is_verified": false,
-        "line_number": 60,
-        "type": "Secret Keyword"
+        "line_number": 60
       },
       {
-        "hashed_secret": "e24114b7e08681dc91c43a0a76e8b7c14f8c2fb8",
-        "is_secret": false,
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/adminusers/service/ResetPasswordServiceTest.java",
+        "hashed_secret": "41f643584ba9f2528ada5b9e9bb4ab0751061fe3",
         "is_verified": false,
-        "line_number": 61,
-        "type": "Secret Keyword"
+        "line_number": 61
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/service/SecondFactorAuthenticatorTest.java": [
       {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/adminusers/service/SecondFactorAuthenticatorTest.java",
         "hashed_secret": "e9fe51f94eadabf54dbf2fbbd57188b9abee436e",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 27,
-        "type": "Secret Keyword"
+        "is_secret": false
       },
       {
-        "hashed_secret": "364421c69e6766dab11ec8ce2e41943fb2f4f4ca",
-        "is_secret": false,
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/adminusers/service/SecondFactorAuthenticatorTest.java",
+        "hashed_secret": "2174f260cabfeea993f19836ba27844cb85e5d66",
         "is_verified": false,
-        "line_number": 28,
-        "type": "Secret Keyword"
+        "line_number": 28
       }
     ],
     "src/test/resources/config/test-it-config.yaml": [
       {
+        "type": "Secret Keyword",
+        "filename": "src/test/resources/config/test-it-config.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
-        "type": "Secret Keyword"
+        "is_secret": false
       }
     ]
   },
-  "version": "0.13.1",
-  "word_list": {
-    "file": null,
-    "hash": null
-  }
+  "generated_at": "2021-08-13T14:58:44Z"
 }


### PR DESCRIPTION
## What you did
- Add a local `.pre-commit.yaml`
  - This will run `detect-secrets` when you try to commit a file.
- Update the existing `.secrets.baseline` file
  - To ignore the SHA specified in the `.pre-commit.yaml`

## How to test

- Maake sure the `.pre-commit.yaml` has been added.
- Make sure the `.secrets.baseline` has been updated.
  - This file is automatically updated by using `detect-secrets`.