### PR TITLE
PP-8445 Return default_billing_address_country in service responses

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/model/Service.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Service.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.model.GoLiveStage.NOT_STARTED;
+import static uk.gov.pay.adminusers.persistence.entity.ServiceEntity.DEFAULT_BILLING_ADDRESS_COUNTRY;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
@@ -32,6 +33,7 @@ public class Service {
     private MerchantDetails merchantDetails;
     private boolean redirectToServiceImmediatelyOnTerminalState;
     private boolean collectBillingAddress;
+    private String defaultBillingAddressCountry;
     private GoLiveStage goLiveStage;
     private boolean experimentalFeaturesEnabled;
     private String sector;
@@ -63,6 +65,7 @@ public class Service {
                 serviceName,
                 false,
                 true,
+                DEFAULT_BILLING_ADDRESS_COUNTRY,
                 NOT_STARTED,
                 false,
                 false,
@@ -79,6 +82,7 @@ public class Service {
                                ServiceName serviceName,
                                boolean redirectToServiceImmediatelyOnTerminalState,
                                boolean collectBillingAddress,
+                               String defaultBillingAddressCountry,
                                GoLiveStage goLiveStage,
                                boolean experimentalFeaturesEnabled,
                                boolean agentInitiatedMotoEnabled,
@@ -93,6 +97,7 @@ public class Service {
                 serviceName,
                 redirectToServiceImmediatelyOnTerminalState,
                 collectBillingAddress,
+                defaultBillingAddressCountry,
                 goLiveStage,
                 experimentalFeaturesEnabled,
                 agentInitiatedMotoEnabled,
@@ -109,6 +114,7 @@ public class Service {
                     ServiceName serviceName,
                     boolean redirectToServiceImmediatelyOnTerminalState,
                     boolean collectBillingAddress,
+                    String defaultBillingAddressCountry,
                     GoLiveStage goLiveStage,
                     boolean experimentalFeaturesEnabled,
                     boolean agentInitiatedMotoEnabled,
@@ -122,6 +128,7 @@ public class Service {
         this.externalId = externalId;
         this.redirectToServiceImmediatelyOnTerminalState = redirectToServiceImmediatelyOnTerminalState;
         this.collectBillingAddress = collectBillingAddress;
+        this.defaultBillingAddressCountry = defaultBillingAddressCountry;
         this.serviceName = serviceName;
         this.goLiveStage = goLiveStage;
         this.experimentalFeaturesEnabled = experimentalFeaturesEnabled;
@@ -219,6 +226,15 @@ public class Service {
 
     public void setCollectBillingAddress(boolean collectBillingAddress) {
         this.collectBillingAddress = collectBillingAddress;
+    }
+
+    @JsonProperty("default_billing_address_country")
+    public String getDefaultBillingAddressCountry() {
+        return defaultBillingAddressCountry;
+    }
+
+    public void setDefaultBillingAddressCountry(String defaultBillingAddressCountry) {
+        this.defaultBillingAddressCountry = defaultBillingAddressCountry;
     }
 
     @JsonProperty("current_go_live_stage")

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
@@ -39,6 +39,8 @@ import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 @Table(name = "services")
 @SequenceGenerator(name = "services_seq_gen", sequenceName = "services_id_seq", allocationSize = 1)
 public class ServiceEntity {
+    
+    public static final String DEFAULT_BILLING_ADDRESS_COUNTRY = "GB";
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "services_seq_gen")
@@ -52,6 +54,9 @@ public class ServiceEntity {
 
     @Column(name = "collect_billing_address")
     private boolean collectBillingAddress = true;
+    
+    @Column(name = "default_billing_address_country")
+    private String defaultBillingAddressCountry = DEFAULT_BILLING_ADDRESS_COUNTRY;
 
     @Embedded
     private MerchantDetailsEntity merchantDetailsEntity;
@@ -141,6 +146,14 @@ public class ServiceEntity {
 
     public void setCollectBillingAddress(boolean collectBillingAddress) {
         this.collectBillingAddress = collectBillingAddress;
+    }
+
+    public String getDefaultBillingAddressCountry() {
+        return defaultBillingAddressCountry;
+    }
+
+    public void setDefaultBillingAddressCountry(String defaultBillingAddressCountry) {
+        this.defaultBillingAddressCountry = defaultBillingAddressCountry;
     }
 
     public MerchantDetailsEntity getMerchantDetailsEntity() {
@@ -254,6 +267,7 @@ public class ServiceEntity {
                 ServiceName.from(getServiceNames().values()),
                 this.redirectToServiceImmediatelyOnTerminalState,
                 this.collectBillingAddress,
+                this.defaultBillingAddressCountry,
                 this.currentGoLiveStage,
                 this.experimentalFeaturesEnabled,
                 this.agentInitiatedMotoEnabled,

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoIT.java
@@ -358,6 +358,7 @@ class ServiceDaoIT extends DaoTestBase {
                 is(thatEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName()));
         assertThat(thisEntity.isRedirectToServiceImmediatelyOnTerminalState(), is(thatEntity.isRedirectToServiceImmediatelyOnTerminalState()));
         assertThat(thisEntity.isCollectBillingAddress(), is(thatEntity.isCollectBillingAddress()));
+        assertThat(thisEntity.getDefaultBillingAddressCountry(), is(thatEntity.getDefaultBillingAddressCountry()));
     }
 
     private void assertCustomBranding(ServiceEntity insertedServiceEntity) {

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceCreatorTest.java
@@ -67,6 +67,7 @@ public class ServiceCreatorTest {
         assertThat(service.getName(), is("System Generated"));
         assertThat(service.isRedirectToServiceImmediatelyOnTerminalState(), is(false));
         assertThat(service.isCollectBillingAddress(), is(true));
+        assertThat(service.getDefaultBillingAddressCountry(), is("GB"));
         List<GatewayAccountIdEntity> persistedGatewayIds = persistedServiceEntity.getValue().getGatewayAccountIds();
         assertThat(persistedGatewayIds.size(), is(0));
         assertEnServiceNameMap(service, "System Generated");

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCompleterTest.java
@@ -97,6 +97,7 @@ public class ServiceInviteCompleterTest {
         assertThat(serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName(), is(Service.DEFAULT_NAME_VALUE));
         assertThat(serviceEntity.isRedirectToServiceImmediatelyOnTerminalState(), is(false));
         assertThat(serviceEntity.isCollectBillingAddress(), is(true));
+        assertThat(serviceEntity.getDefaultBillingAddressCountry(), is("GB"));
 
         assertThat(inviteResponse.getInvite().isDisabled(), is(true));
         assertThat(inviteResponse.getInvite().getLinks().size(), is(1));
@@ -128,6 +129,7 @@ public class ServiceInviteCompleterTest {
         assertThat(serviceEntity.getServiceNames().get(SupportedLanguage.ENGLISH).getName(), is(Service.DEFAULT_NAME_VALUE));
         assertThat(serviceEntity.isRedirectToServiceImmediatelyOnTerminalState(), is(false));
         assertThat(serviceEntity.isCollectBillingAddress(), is(true));
+        assertThat(serviceEntity.getDefaultBillingAddressCountry(), is("GB"));
 
         assertThat(inviteResponse.getInvite().isDisabled(), is(true));
         assertThat(inviteResponse.getInvite().getLinks().size(), is(1));

--- a/src/test/java/uk/gov/pay/adminusers/service/UserCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserCreatorTest.java
@@ -92,6 +92,7 @@ public class UserCreatorTest {
         assertThat(service.getGatewayAccountIds(), is(asList("1", "2")));
         assertThat(service.isRedirectToServiceImmediatelyOnTerminalState(), is(false));
         assertThat(service.isCollectBillingAddress(), is(true));
+        assertThat(service.getDefaultBillingAddressCountry(), is("GB"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceCreateTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceCreateTest.java
@@ -116,6 +116,7 @@ public class ServiceResourceCreateTest extends ServiceResourceBaseTest {
         assertThat(json.get("external_id"), is(notNullValue()));
         assertThat(json.get("redirect_to_service_immediately_on_terminal_state"), is(false));
         assertThat(json.get("collect_billing_address"), is(true));
+        assertThat(json.get("default_billing_address_country"), is("GB"));
         assertThat(json.getMap("service_name"), not(hasKey("cy")));
         assertEnServiceNameJson("System Generated", json);
         assertLinks(json.get("external_id"), json);

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceFindTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceFindTest.java
@@ -93,6 +93,7 @@ public class ServiceResourceFindTest extends ServiceResourceBaseTest {
         assertLinks(serviceExternalId, json);
         assertThat(json.get("redirect_to_service_immediately_on_terminal_state"), is(serviceEntity.isRedirectToServiceImmediatelyOnTerminalState()));
         assertThat(json.get("collect_billing_address"), is(serviceEntity.isCollectBillingAddress()));
+        assertThat(json.get("default_billing_address_country"), is(serviceEntity.getDefaultBillingAddressCountry()));
         assertThat(json.get("current_go_live_stage"), is(String.valueOf(serviceEntity.getCurrentGoLiveStage())));
     }
 
@@ -170,6 +171,7 @@ public class ServiceResourceFindTest extends ServiceResourceBaseTest {
         assertLinks(serviceEntity.getExternalId(), json);
         assertThat(json.get("redirect_to_service_immediately_on_terminal_state"), is(serviceEntity.isRedirectToServiceImmediatelyOnTerminalState()));
         assertThat(json.get("collect_billing_address"), is(serviceEntity.isCollectBillingAddress()));
+        assertThat(json.get("default_billing_address_country"), is(serviceEntity.getDefaultBillingAddressCountry()));
         assertThat(json.get("current_go_live_stage"), is(String.valueOf(serviceEntity.getCurrentGoLiveStage())));
         assertThat(json.get("created_date"), is("2020-01-31T12:30:00.000Z"));
         assertThat(json.get("went_live_date"), is("2020-02-01T09:00:00.000Z"));


### PR DESCRIPTION
Read the value from the database and return the field `default_billing_address_country` in the service object in API responses.

Set the default country as "GB" when creating services.