### PR TITLE
PP-8445 Allow PATCH default_billing_address_country

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
@@ -27,6 +27,7 @@ import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_COLLECT_BILLING
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_CURRENT_GO_LIVE_STAGE;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_CURRENT_PSP_TEST_ACCOUNT_STAGE;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_CUSTOM_BRANDING;
+import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_DEFAULT_BILLING_ADDRESS_COUNTRY;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_EXPERIMENTAL_FEATURES_ENABLED;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_GATEWAY_ACCOUNT_IDS;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_INTERNAL;
@@ -76,6 +77,7 @@ public class ServiceUpdateOperationValidator {
                 entry(FIELD_EXPERIMENTAL_FEATURES_ENABLED, singletonList(REPLACE)),
                 entry(FIELD_AGENT_INITIATED_MOTO_ENABLED, singletonList(REPLACE)),
                 entry(FIELD_COLLECT_BILLING_ADDRESS, singletonList(REPLACE)),
+                entry(FIELD_DEFAULT_BILLING_ADDRESS_COUNTRY, singletonList(REPLACE)),
                 entry(FIELD_CURRENT_GO_LIVE_STAGE, singletonList(REPLACE)),
                 entry(FIELD_CURRENT_PSP_TEST_ACCOUNT_STAGE, singletonList(REPLACE)),
                 entry(FIELD_SECTOR, singletonList(REPLACE)),
@@ -136,12 +138,14 @@ public class ServiceUpdateOperationValidator {
             return validateMandatoryBooleanValue(operation);
         } else if (FIELD_COLLECT_BILLING_ADDRESS.equals(path)) {
             return validateMandatoryBooleanValue(operation);
+        } else if (FIELD_DEFAULT_BILLING_ADDRESS_COUNTRY.equals(path)) {
+            return validateCountryCode(operation);
         } else if (FIELD_CURRENT_GO_LIVE_STAGE.equals(path)) {
             return validateCurrentGoLiveStageValue(operation);
         } else if (FIELD_CURRENT_PSP_TEST_ACCOUNT_STAGE.equals(path)){
             return validateCurrentPspTestAccountStageValue(operation);
         } else if (FIELD_SECTOR.equals(path)) {
-            return validateNotNullStringValueWithMaxLength(operation, false, FIELD_SECTOR_MAX_LENGTH);
+            return validateStringValueWithMaxLength(operation, false, FIELD_SECTOR_MAX_LENGTH);
         } else if (FIELD_INTERNAL.equals(path)) {
             return validateMandatoryBooleanValue(operation);
         } else if (FIELD_ARCHIVED.equals(path)) {
@@ -149,21 +153,21 @@ public class ServiceUpdateOperationValidator {
         } else if (FIELD_WENT_LIVE_DATE.equals(path)) {
             return validateZonedDateTimeValue(operation);
         } else if (FIELD_MERCHANT_DETAILS_NAME.equals(path)) {
-            return validateNotNullStringValueWithMaxLength(operation, false, FIELD_MERCHANT_DETAILS_NAME_MAX_LENGTH);
+            return validateStringValueWithMaxLength(operation, false, FIELD_MERCHANT_DETAILS_NAME_MAX_LENGTH);
         } else if (FIELD_MERCHANT_DETAILS_ADDRESS_LINE_1.equals(path)) {
-            return validateNotNullStringValueWithMaxLength(operation, false, FIELD_MERCHANT_DETAILS_ADDRESS_LINE_1_MAX_LENGTH);
+            return validateStringValueWithMaxLength(operation, false, FIELD_MERCHANT_DETAILS_ADDRESS_LINE_1_MAX_LENGTH);
         } else if (FIELD_MERCHANT_DETAILS_ADDRESS_LINE_2.equals(path)) {
-            return validateNotNullStringValueWithMaxLength(operation, true, FIELD_MERCHANT_DETAILS_ADDRESS_LINE_2_MAX_LENGTH);
+            return validateStringValueWithMaxLength(operation, true, FIELD_MERCHANT_DETAILS_ADDRESS_LINE_2_MAX_LENGTH);
         } else if (FIELD_MERCHANT_DETAILS_ADDRESS_CITY.equals(path)) {
-            return validateNotNullStringValueWithMaxLength(operation, false, FIELD_MERCHANT_DETAILS_ADDRESS_CITY_MAX_LENGTH);
+            return validateStringValueWithMaxLength(operation, false, FIELD_MERCHANT_DETAILS_ADDRESS_CITY_MAX_LENGTH);
         } else if (FIELD_MERCHANT_DETAILS_ADDRESS_COUNRTY.equals(path)) {
-            return validateNotNullStringValueWithMaxLength(operation, false, FIELD_MERCHANT_DETAILS_ADDRESS_COUNTRY_CODE_MAX_LENGTH);
+            return validateStringValueWithMaxLength(operation, false, FIELD_MERCHANT_DETAILS_ADDRESS_COUNTRY_CODE_MAX_LENGTH);
         } else if (FIELD_MERCHANT_DETAILS_ADDRESS_POSTCODE.equals(path)) {
-            return validateNotNullStringValueWithMaxLength(operation, false, FIELD_MERCHANT_DETAILS_ADDRESS_POSTCODE_MAX_LENGTH);
+            return validateStringValueWithMaxLength(operation, false, FIELD_MERCHANT_DETAILS_ADDRESS_POSTCODE_MAX_LENGTH);
         } else if (FIELD_MERCHANT_DETAILS_EMAIL.equals(path)) {
-            return validateNotNullStringValueWithMaxLength(operation, true, FIELD_MERCHANT_DETAILS_EMAIL_MAX_LENGTH);
+            return validateStringValueWithMaxLength(operation, true, FIELD_MERCHANT_DETAILS_EMAIL_MAX_LENGTH);
         } else if (FIELD_MERCHANT_DETAILS_TELEPHONE_NUMBER.equals(path)) {
-            return validateNotNullStringValueWithMaxLength(operation, true, FIELD_MERCHANT_DETAILS_TELEPHONE_NUMBER_MAX_LENGTH);
+            return validateStringValueWithMaxLength(operation, true, FIELD_MERCHANT_DETAILS_TELEPHONE_NUMBER_MAX_LENGTH);
         }
 
         return Collections.emptyList();
@@ -176,7 +180,7 @@ public class ServiceUpdateOperationValidator {
 
     private List<String> validateServiceNameValue(JsonNode operation, String path) {
         boolean allowEmpty = !path.endsWith('/' + SupportedLanguage.ENGLISH.toString());
-        return validateNotNullStringValueWithMaxLength(operation, allowEmpty, SERVICE_NAME_MAX_LENGTH);
+        return validateStringValueWithMaxLength(operation, allowEmpty, SERVICE_NAME_MAX_LENGTH);
     }
 
     private List<String> validateMandatoryBooleanValue(JsonNode operation) {
@@ -218,7 +222,7 @@ public class ServiceUpdateOperationValidator {
         return errors;
     }
 
-    private List<String> validateNotNullStringValueWithMaxLength(JsonNode operation, boolean allowEmpty, int maxLength) {
+    private List<String> validateStringValueWithMaxLength(JsonNode operation, boolean allowEmpty, int maxLength) {
         List<String> errors = new ArrayList<>();
         if (allowEmpty) {
             requestValidations.checkExists(operation, FIELD_VALUE).ifPresent(errors::addAll);
@@ -263,6 +267,18 @@ public class ServiceUpdateOperationValidator {
         requestValidations.checkExists(operation, FIELD_VALUE).ifPresent(errors::addAll);
         if (errors.isEmpty()) {
             requestValidations.checkIsZonedDateTime(operation, FIELD_VALUE).ifPresent(errors::addAll);
+        }
+        return errors;
+    }
+    
+    private List<String> validateCountryCode(JsonNode operation) {
+        List<String> errors = new ArrayList<>();
+        if (operation.get(FIELD_VALUE).isNull()) {
+            return errors;
+        }
+        requestValidations.checkIsString(operation, FIELD_VALUE).ifPresent(errors::addAll);
+        if (errors.isEmpty()) {
+            requestValidations.checkMaxLength(operation, 2, FIELD_VALUE).ifPresent(errors::addAll);
         }
         return errors;
     }

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
@@ -34,6 +34,7 @@ public class ServiceUpdater {
     public static final String FIELD_EXPERIMENTAL_FEATURES_ENABLED = "experimental_features_enabled";
     public static final String FIELD_AGENT_INITIATED_MOTO_ENABLED = "agent_initiated_moto_enabled";
     public static final String FIELD_COLLECT_BILLING_ADDRESS = "collect_billing_address";
+    public static final String FIELD_DEFAULT_BILLING_ADDRESS_COUNTRY = "default_billing_address_country";
     public static final String FIELD_CURRENT_GO_LIVE_STAGE = "current_go_live_stage";
     public static final String FIELD_CURRENT_PSP_TEST_ACCOUNT_STAGE = "current_psp_test_account_stage";
     public static final String FIELD_SECTOR = "sector";
@@ -60,6 +61,7 @@ public class ServiceUpdater {
                 entry(FIELD_EXPERIMENTAL_FEATURES_ENABLED, updateExperimentalFeaturesEnabled()),
                 entry(FIELD_AGENT_INITIATED_MOTO_ENABLED, updateAgentInitiatedMotoEnabled()),
                 entry(FIELD_COLLECT_BILLING_ADDRESS, updateCollectBillingAddress()),
+                entry(FIELD_DEFAULT_BILLING_ADDRESS_COUNTRY, updateDefaultBillingAddressCountry()),
                 entry(FIELD_CURRENT_GO_LIVE_STAGE, updateCurrentGoLiveStage()),
                 entry(FIELD_CURRENT_PSP_TEST_ACCOUNT_STAGE, updateCurrentPspTestAccountStage()),
                 entry(FIELD_SECTOR, updateSector()),
@@ -152,6 +154,11 @@ public class ServiceUpdater {
     private BiConsumer<ServiceUpdateRequest, ServiceEntity> updateCollectBillingAddress() {
         return (serviceUpdateRequest, serviceEntity) ->
                 serviceEntity.setCollectBillingAddress(serviceUpdateRequest.valueAsBoolean());
+    }
+    
+    private BiConsumer<ServiceUpdateRequest, ServiceEntity> updateDefaultBillingAddressCountry() {
+        return (serviceUpdateRequest, serviceEntity) ->
+                serviceEntity.setDefaultBillingAddressCountry(serviceUpdateRequest.valueAsString());        
     }
 
     private BiConsumer<ServiceUpdateRequest, ServiceEntity> updateCurrentGoLiveStage() {

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.pay.adminusers.validations.RequestValidations;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -68,7 +69,8 @@ public class ServiceUpdateOperationValidatorTest {
                 new Object[]{"add", "merchant_details/address_country", "any value"},
                 new Object[]{"add", "merchant_details/address_postcode", "any value"},
                 new Object[]{"add", "merchant_details/email", "any value"},
-                new Object[]{"add", "merchant_details/telephone_number", "any value"}
+                new Object[]{"add", "merchant_details/telephone_number", "any value"},
+                new Object[]{"add", "default_billing_address_country", "GB"}
         };
     }
 
@@ -103,6 +105,8 @@ public class ServiceUpdateOperationValidatorTest {
                 new Object[]{"custom_branding", "a string", "Value for path [custom_branding] must be a JSON"},
                 new Object[]{"went_live_date", 42, "Field [value] must be a valid date time with timezone"},
                 new Object[]{"went_live_date", "a string", "Field [value] must be a valid date time with timezone"},
+                new Object[]{"default_billing_address_country", 42, "Field [value] must be a string"},
+                new Object[]{"default_billing_address_country", "too long", "Field [value] must have a maximum length of 2 characters"}
         };
     }
 
@@ -236,18 +240,19 @@ public class ServiceUpdateOperationValidatorTest {
                 new Object[]{"replace", "sector", "local government"},
                 new Object[]{"replace", "internal", true},
                 new Object[]{"replace", "archived", true},
-                new Object[]{"replace", "went_live_date", "2020-01-01T01:01:00Z"}
-
+                new Object[]{"replace", "went_live_date", "2020-01-01T01:01:00Z"},
+                new Object[]{"replace", "default_billing_address_country", null},
+                new Object[]{"replace", "default_billing_address_country", "GB"}
         };
     }
 
     @ParameterizedTest
     @MethodSource("shouldSucceedParams")
     public void shouldSucceed(String operation, String path, Object value) {
-        Map<String, Object> payload = Map.of(
-                "path", path,
-                "op", operation,
-                "value", value);
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("path", path);
+        payload.put("op", operation);
+        payload.put("value", value);
 
         List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
         assertThat(errors.size(), is(0));


### PR DESCRIPTION
PATCH requests to update the service allow 'replace' operations for path 'default_billing_address_country'. Allow the value to be either `null` or a 2 character string.
