### PR TITLE
PP-8695 Remove Deploy step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,13 +84,12 @@ pipeline {
         }
       }
     }
-    stage('Deploy') {
+    stage('Check pact compatability') {
       when {
         branch 'master'
       }
       steps {
         checkPactCompatibility("adminusers", gitCommit(), "test")
-        deployEcs("adminusers")
       }
     }
     stage('Pact Tag') {


### PR DESCRIPTION
Jenkins CI no longer needs to deploy the original ECS version so skip
this step.

## WHAT YOU DID
Removing pact tagging and checking is next