### PR TITLE
PP-8728 Do not require password and phone for service invite

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -155,7 +155,7 @@
         "filename": "src/main/java/uk/gov/pay/adminusers/model/InviteServiceRequest.java",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 8
+        "line_number": 10
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/model/User.java": [
@@ -336,5 +336,5 @@
       }
     ]
   },
-  "generated_at": "2021-08-13T14:58:44Z"
+  "generated_at": "2021-09-29T14:41:21Z"
 }

--- a/src/main/java/uk/gov/pay/adminusers/model/InviteServiceRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/InviteServiceRequest.java
@@ -2,6 +2,8 @@ package uk.gov.pay.adminusers.model;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import java.util.Optional;
+
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 
 public class InviteServiceRequest extends InviteRequest {
@@ -29,6 +31,10 @@ public class InviteServiceRequest extends InviteRequest {
         this(DEFAULT_ROLE_NAME, password, email, telephoneNumber, randomUuid());
     }
 
+    public InviteServiceRequest(String email) {
+        this(DEFAULT_ROLE_NAME, null, email, null, randomUuid());
+    }
+
     public String getPassword() {
         return password;
     }
@@ -49,9 +55,9 @@ public class InviteServiceRequest extends InviteRequest {
     public static InviteServiceRequest from(JsonNode payload) {
         return new InviteServiceRequest(
                 DEFAULT_ROLE_NAME,
-                payload.get(FIELD_PASSWORD).asText(),
+                Optional.ofNullable(payload.get(FIELD_PASSWORD)).map(JsonNode::asText).orElse(null),
                 payload.get(FIELD_EMAIL).asText(),
-                payload.get(FIELD_TELEPHONE_NUMBER).asText(),
+                Optional.ofNullable(payload.get(FIELD_TELEPHONE_NUMBER)).map(JsonNode::asText).orElse(null),
                 getOrElseRandom(payload.get(FIELD_OTP_KEY))
         );
     }

--- a/src/main/java/uk/gov/pay/adminusers/resources/InviteRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InviteRequestValidator.java
@@ -72,7 +72,7 @@ public class InviteRequestValidator {
     }
 
     public Optional<Errors> validateCreateServiceRequest(JsonNode payload) {
-        Optional<List<String>> missingMandatoryFields = requestValidations.checkExistsAndNotEmpty(payload, InviteServiceRequest.FIELD_EMAIL, InviteServiceRequest.FIELD_TELEPHONE_NUMBER, InviteServiceRequest.FIELD_PASSWORD);
+        Optional<List<String>> missingMandatoryFields = requestValidations.checkExistsAndNotEmpty(payload, InviteServiceRequest.FIELD_EMAIL);
         if (missingMandatoryFields.isPresent()) {
             return Optional.of(Errors.from(missingMandatoryFields.get()));
         }
@@ -87,8 +87,8 @@ public class InviteRequestValidator {
             throw AdminUsersExceptions.invalidPublicSectorEmail(email);
         }
 
-        String telephoneNumber = payload.get(InviteServiceRequest.FIELD_TELEPHONE_NUMBER).asText();
-        if (!TelephoneNumberUtility.isValidPhoneNumber(telephoneNumber)) {
+        JsonNode telephoneNumberJsonNode = payload.get(InviteServiceRequest.FIELD_TELEPHONE_NUMBER);
+        if (telephoneNumberJsonNode != null && !TelephoneNumberUtility.isValidPhoneNumber(telephoneNumberJsonNode.asText())) {
             return Optional.of(Errors.from(format("Field [%s] must be a valid telephone number", InviteServiceRequest.FIELD_TELEPHONE_NUMBER)));
         }
 

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceInviteCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceInviteCreator.java
@@ -90,8 +90,8 @@ public class ServiceInviteCreator {
 
     private Invite constructInviteAndSendEmail(InviteServiceRequest inviteServiceRequest, InviteEntity inviteEntity, Function<InviteEntity, Void> saveOrUpdate) {
         String inviteUrl = format("%s/%s", linksConfig.getSelfserviceInvitesUrl(), inviteEntity.getCode());
-        inviteEntity.setTelephoneNumber(TelephoneNumberUtility.formatToE164(inviteServiceRequest.getTelephoneNumber()));
-        inviteEntity.setPassword(passwordHasher.hash(inviteServiceRequest.getPassword()));
+        Optional.ofNullable(inviteServiceRequest.getTelephoneNumber()).map(TelephoneNumberUtility::formatToE164).ifPresent(inviteEntity::setTelephoneNumber);
+        Optional.ofNullable(inviteServiceRequest.getPassword()).map(passwordHasher::hash).ifPresent(inviteEntity::setPassword);
         saveOrUpdate.apply(inviteEntity);
         sendServiceInviteNotification(inviteEntity, inviteUrl);
         Invite invite = inviteEntity.toInvite();

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteUserRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteUserRequestValidatorTest.java
@@ -302,7 +302,7 @@ class InviteUserRequestValidatorTest {
     }
 
     @Test
-    void shouldSuccess_ifAllFieldsArePresentAndValidEmailDomain() {
+    void validateCreateServiceRequest_shouldSuccess_ifAllFieldsArePresentAndValidEmailDomain() {
         Map<String, String> payload = Map.of("email", "example@example.gov.uk", "telephone_number", "01134960000", "password", "super-secure-password");
         JsonNode payloadNode = objectMapper.valueToTree(payload);
         Optional<Errors> errors = validator.validateCreateServiceRequest(payloadNode);
@@ -311,7 +311,16 @@ class InviteUserRequestValidatorTest {
     }
 
     @Test
-    void shouldFail_ifMissingRequiredField() {
+    void validateCreateServiceRequest_shouldSuccess_ifOnlyEmailFieldIsPresentAndValidEmailDomain() {
+        Map<String, String> payload = Map.of("email", "example@example.gov.uk");
+        JsonNode payloadNode = objectMapper.valueToTree(payload);
+        Optional<Errors> errors = validator.validateCreateServiceRequest(payloadNode);
+
+        assertFalse(errors.isPresent());
+    }
+
+    @Test
+    void validateCreateServiceRequest_shouldFail_ifMissingRequiredField() {
         Map<String, String> payload = Map.of( "telephone_number", "01134960000", "password", "super-secure-password");
         JsonNode payloadNode = objectMapper.valueToTree(payload);
         Optional<Errors> errors = validator.validateCreateServiceRequest(payloadNode);
@@ -322,7 +331,7 @@ class InviteUserRequestValidatorTest {
     }
 
     @Test
-    void shouldFail_ifInvalidEmailFormat() {
+    void validateCreateServiceRequest_shouldFail_ifInvalidEmailFormat() {
         Map<String, String> payload = Map.of( "email", "exampleatexample.com", "telephone_number", "01134960000", "password", "super-secure-password");
         JsonNode payloadNode = objectMapper.valueToTree(payload);
         Optional<Errors> errors = validator.validateCreateServiceRequest(payloadNode);
@@ -333,14 +342,14 @@ class InviteUserRequestValidatorTest {
     }
 
     @Test
-    void shouldFail_ifEmailAddressNotPublicSector() {
+    void validateCreateServiceRequest_shouldFail_ifEmailAddressNotPublicSector() {
         Map<String, String> payload = Map.of( "email", "example@example.com","telephone_number", "01134960000", "password", "super-secure-password");
         JsonNode payloadNode = objectMapper.valueToTree(payload);
         assertThrows(WebApplicationException.class, () -> validator.validateCreateServiceRequest(payloadNode));
     }
 
     @Test
-    void shouldFail_ifTelephoneNumberIsInvalid() {
+    void validateCreateServiceRequest_shouldFail_ifTelephoneNumberIsInvalid() {
         Map<String, String> payload = Map.of( "email", "example@example.gov.uk","telephone_number", "0770090000A", "password", "super-secure-password");
         JsonNode payloadNode = objectMapper.valueToTree(payload);
         Optional<Errors> errors = validator.validateCreateServiceRequest(payloadNode);


### PR DESCRIPTION
Stop requiring a phone number and password to be specified when we get a request from selfservice to create a service invite so that we can eventually only set the phone number and password on the invite after it’s created.

Currently, selfservice’s validation will stop us from ever receiving a request to create a service invite that does not have a phone number and a password.