### PR TITLE
PP-8728 Set phone and password on service invite when sending OTP

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcher.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcher.java
@@ -4,8 +4,10 @@ import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
+import uk.gov.pay.adminusers.utils.telephonenumber.TelephoneNumberUtility;
 
 import java.util.Locale;
+import java.util.Optional;
 
 import static java.lang.String.format;
 import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.SELF_INITIATED_CREATE_NEW_USER_AND_SERVICE;
@@ -15,13 +17,16 @@ public class ServiceOtpDispatcher extends InviteOtpDispatcher {
     private static final Logger LOGGER = LoggerFactory.getLogger(ServiceOtpDispatcher.class);
     private final InviteDao inviteDao;
     private final SecondFactorAuthenticator secondFactorAuthenticator;
+    private final PasswordHasher passwordHasher;
     private final NotificationService notificationService;
 
     @Inject
-    public ServiceOtpDispatcher(InviteDao inviteDao, SecondFactorAuthenticator secondFactorAuthenticator, NotificationService notificationService) {
+    public ServiceOtpDispatcher(InviteDao inviteDao, SecondFactorAuthenticator secondFactorAuthenticator,
+                                PasswordHasher passwordHasher, NotificationService notificationService) {
         super();
         this.inviteDao = inviteDao;
         this.secondFactorAuthenticator = secondFactorAuthenticator;
+        this.passwordHasher = passwordHasher;
         this.notificationService = notificationService;
     }
 
@@ -29,6 +34,16 @@ public class ServiceOtpDispatcher extends InviteOtpDispatcher {
     public boolean dispatchOtp(String inviteCode) {
         return inviteDao.findByCode(inviteCode)
                 .map(inviteEntity -> {
+                    Optional.ofNullable(inviteOtpRequest.getTelephoneNumber())
+                            .map(TelephoneNumberUtility::formatToE164)
+                            .ifPresent(inviteEntity::setTelephoneNumber);
+
+                    Optional.ofNullable(inviteOtpRequest.getPassword())
+                            .map(passwordHasher::hash)
+                            .ifPresent(inviteEntity::setPassword);
+
+                    inviteDao.merge(inviteEntity);
+
                     int newPassCode = secondFactorAuthenticator.newPassCode(inviteEntity.getOtpKey());
                     String passcode = format(Locale.ENGLISH, SIX_DIGITS_WITH_LEADING_ZEROS, newPassCode);
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGenerateOtpIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGenerateOtpIT.java
@@ -69,12 +69,41 @@ public class InviteResourceGenerateOtpIT extends IntegrationTest {
                 .statusCode(BAD_REQUEST.getStatusCode());
     }
 
-
     @Test
     public void generateOtp_shouldSucceed_forServiceInvite_evenWhenTokenIsExpired_sinceItShouldBeValidatedOnGetInvite() {
         givenAnExistingServiceInvite();
         givenSetup()
                 .when()
+                .contentType(ContentType.JSON)
+                .post(format(INVITES_GENERATE_OTP_RESOURCE_URL, code))
+                .then()
+                .statusCode(OK.getStatusCode());
+    }
+
+    @Test
+    public void generateOtp_shouldSucceed_forServiceInvite_whenNoFieldsPresent() throws Exception {
+        givenAnExistingServiceInvite();
+        Map<Object, Object> invitationRequest = emptyMap();
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(invitationRequest))
+                .contentType(ContentType.JSON)
+                .post(format(INVITES_GENERATE_OTP_RESOURCE_URL, code))
+                .then()
+                .statusCode(OK.getStatusCode());
+    }
+
+    @Test
+    public void generateOtp_shouldSucceed_forServiceInvite_whenPasswordAndPhoneNumberPresent() throws Exception {
+        givenAnExistingServiceInvite();
+        Map<Object, Object> invitationRequest = Map.of(
+                "telephone_number", TELEPHONE_NUMBER,
+                "password", PASSWORD);
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(invitationRequest))
                 .contentType(ContentType.JSON)
                 .post(format(INVITES_GENERATE_OTP_RESOURCE_URL, code))
                 .then()
@@ -93,6 +122,7 @@ public class InviteResourceGenerateOtpIT extends IntegrationTest {
         code = InviteDbFixture.inviteDbFixture(databaseHelper)
                 .withEmail(EMAIL)
                 .withOtpKey(OTP_KEY)
+                .expired()
                 .insertServiceInvite();
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/service/InviteRouterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/InviteRouterTest.java
@@ -79,7 +79,7 @@ public class InviteRouterTest {
         String inviteCode = "a-code";
         InviteEntity inviteEntity = anInvite(inviteCode, SERVICE);
         when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
-        when(inviteServiceFactory.dispatchServiceOtp()).thenReturn(new ServiceOtpDispatcher(null, null, null));
+        when(inviteServiceFactory.dispatchServiceOtp()).thenReturn(new ServiceOtpDispatcher(null, null, null, null));
         Optional<Pair<InviteOtpDispatcher, Boolean>> result = inviteRouter.routeOtpDispatch(inviteCode);
 
         assertThat(result.isPresent(), is(true));

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcherTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcherTest.java
@@ -1,18 +1,23 @@
 package uk.gov.pay.adminusers.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.adminusers.model.InviteOtpRequest;
 import uk.gov.pay.adminusers.model.InviteType;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.SELF_INITIATED_CREATE_NEW_USER_AND_SERVICE;
 
@@ -24,13 +29,20 @@ public class ServiceOtpDispatcherTest {
     @Mock
     private SecondFactorAuthenticator secondFactorAuthenticator;
     @Mock
+    private PasswordHasher passwordHasher;
+    @Mock
     private NotificationService notificationService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private ArgumentCaptor<InviteEntity> expectedInvite = ArgumentCaptor.forClass(InviteEntity.class);
 
     private InviteOtpDispatcher serviceOtpDispatcher;
 
     @BeforeEach
     public void before() {
-        serviceOtpDispatcher = new ServiceOtpDispatcher(inviteDao, secondFactorAuthenticator, notificationService);
+        serviceOtpDispatcher = new ServiceOtpDispatcher(inviteDao, secondFactorAuthenticator, passwordHasher, notificationService);
+        serviceOtpDispatcher.withData(InviteOtpRequest.from(objectMapper.valueToTree(Map.of())));
     }
 
     @Test
@@ -50,6 +62,59 @@ public class ServiceOtpDispatcherTest {
         boolean dispatched = serviceOtpDispatcher.dispatchOtp(inviteCode);
 
         assertThat(dispatched,is(true));
+    }
+
+    @Test
+    public void shouldSuccess_whenDispatchServiceOtp_ifInviteEntityExist_butPhoneAndPasswordOnlyInRequest_andUpdateInviteEntityWithPhoneAndPassword() {
+        String inviteCode = "valid-invite-code";
+        InviteEntity inviteEntity = new InviteEntity();
+        inviteEntity.setCode(inviteCode);
+        inviteEntity.setType(InviteType.SERVICE);
+        inviteEntity.setOtpKey("otp-key");
+
+        String telephone = "+447700900000";
+        String password = "random"; // pragma: allowlist secret
+        serviceOtpDispatcher.withData(InviteOtpRequest.from(objectMapper.valueToTree(Map.of("telephone_number", telephone, "password", "random"))));
+
+        when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
+        when(passwordHasher.hash(password)).thenReturn("hashed-password");
+        when(secondFactorAuthenticator.newPassCode("otp-key")).thenReturn(123456);
+        when(notificationService.sendSecondFactorPasscodeSms(telephone, "123456", SELF_INITIATED_CREATE_NEW_USER_AND_SERVICE))
+                .thenReturn("success code from notify");
+        boolean dispatched = serviceOtpDispatcher.dispatchOtp(inviteCode);
+
+        assertThat(dispatched,is(true));
+
+        verify(inviteDao).merge(expectedInvite.capture());
+        assertThat(dispatched, is(true));
+        assertThat(expectedInvite.getValue().getTelephoneNumber(), is(telephone));
+        assertThat(expectedInvite.getValue().getPassword(),is("hashed-password"));
+    }
+
+    @Test
+    public void shouldSuccess_whenDispatchServiceOtp_ifInviteEntityExistWithPassword_butPhoneOnlyInRequest_andUpdateInviteEntityWithPhone() {
+        String inviteCode = "valid-invite-code";
+        InviteEntity inviteEntity = new InviteEntity();
+        inviteEntity.setCode(inviteCode);
+        inviteEntity.setType(InviteType.SERVICE);
+        inviteEntity.setOtpKey("otp-key");
+        inviteEntity.setPassword("hashed-password");
+
+        String telephone = "+447700900000";
+        serviceOtpDispatcher.withData(InviteOtpRequest.from(objectMapper.valueToTree(Map.of("telephone_number", telephone))));
+
+        when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
+        when(secondFactorAuthenticator.newPassCode("otp-key")).thenReturn(123456);
+        when(notificationService.sendSecondFactorPasscodeSms(telephone, "123456", SELF_INITIATED_CREATE_NEW_USER_AND_SERVICE))
+                .thenReturn("success code from notify");
+        boolean dispatched = serviceOtpDispatcher.dispatchOtp(inviteCode);
+
+        assertThat(dispatched,is(true));
+
+        verify(inviteDao).merge(expectedInvite.capture());
+        assertThat(dispatched, is(true));
+        assertThat(expectedInvite.getValue().getTelephoneNumber(), is(telephone));
+        assertThat(expectedInvite.getValue().getPassword(),is("hashed-password"));
     }
 
     @Test


### PR DESCRIPTION
If a request is sent to `/v1/api/invites/{code}/otp/generate` with the following body:

```json
{
  "telephone_number": "07700900000",
  "password": "password123"
}
```

… and the code relates to a service invite (that is, one where the user is signing up on their own initiative without receiving an invitation to join a service) then update the phone number and password on the invite with the provided values before sending the one-time password.

This makes `ServiceOtpDispatcher` behave similarly to `UserOtpDispatcher` (the equivalent for user invites — that is, where
a user is signing up because they have been invited to a service) except the `"telephone_number"` and `"password"` properties are optional for `ServiceOtpDispatcher`.

This prepares us for a world where service invites only have the phone number and password set on them immediately before the one-time password is sent rather than when they’re created.