### PR TITLE
PP-8497 Add webhook permissions for the admin tool

### DIFF
--- a/src/main/resources/migrations/00073_add_webhooks_permission.sql
+++ b/src/main/resources/migrations/00073_add_webhooks_permission.sql
@@ -1,0 +1,9 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:webhooks_permission
+INSERT INTO permissions(id, name, description) VALUES ((SELECT MAX(id) + 1 FROM permissions), 'webhooks:read', 'View webhooks');
+INSERT INTO permissions(id, name, description) VALUES ((SELECT MAX(id) + 1 FROM permissions), 'webhooks:update', 'Update webhooks');
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'admin'), (SELECT id FROM permissions WHERE name = 'webhooks:read'), NOW(), NOW());
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'admin'), (SELECT id FROM permissions WHERE name = 'webhooks:update'), NOW(), NOW());
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'super-admin'), (SELECT id FROM permissions WHERE name = 'webhooks:read'), NOW(), NOW());
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'super-admin'), (SELECT id FROM permissions WHERE name = 'webhooks:update'), NOW(), NOW());


### PR DESCRIPTION
Add `:read` and `:update` permissions for webhooks.

These permissions should be available to users with the `admin` and
`super-admin` roles.