### PR TITLE
PP-8800 add url to update merchant details

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/model/MerchantDetails.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/MerchantDetails.java
@@ -27,6 +27,8 @@ public class MerchantDetails {
     
     private String email;
 
+    private String url;
+
     public MerchantDetails() {
     }
 
@@ -37,7 +39,8 @@ public class MerchantDetails {
                            @JsonProperty("address_city") String addressCity,
                            @JsonProperty("address_postcode") String addressPostcode,
                            @JsonProperty("address_country") String addressCountry,
-                           @JsonProperty("email") String email) {
+                           @JsonProperty("email") String email,
+                           @JsonProperty("url") String url) {
         this.name = name;
         this.telephoneNumber = telephoneNumber;
         this.addressLine1 = addressLine1;
@@ -46,6 +49,7 @@ public class MerchantDetails {
         this.addressPostcode = addressPostcode;
         this.addressCountry = addressCountry;
         this.email = email;
+        this.url = url;
     }
 
     public String getName() {
@@ -77,6 +81,10 @@ public class MerchantDetails {
     }
     
     public String getEmail() { return this.email; }
+
+    public String getUrl() {
+        return url;
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/uk/gov/pay/adminusers/model/UpdateMerchantDetailsRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/UpdateMerchantDetailsRequest.java
@@ -18,6 +18,7 @@ public class UpdateMerchantDetailsRequest {
     private static final String FIELD_ADDRESS_POSTCODE = "address_postcode";
     private static final String FIELD_ADDRESS_COUNTRY = "address_country";
     private static final String FIELD_EMAIL = "email";
+    private static final String FIELD_URL = "url";
 
     private String name;
     private String telephoneNumber;
@@ -27,6 +28,7 @@ public class UpdateMerchantDetailsRequest {
     private String addressPostcode;
     private String addressCountry;
     private String email;
+    private String url;
 
     public static UpdateMerchantDetailsRequest from(JsonNode node) {
         String name = node.get(FIELD_NAME).asText();
@@ -41,9 +43,11 @@ public class UpdateMerchantDetailsRequest {
                 .map(JsonNode::asText)
                 .orElse(null);
         String email = Optional.ofNullable(node.get(FIELD_EMAIL)).map(JsonNode::asText).orElse(null);
+        String url = Optional.ofNullable(node.get(FIELD_URL)).map(JsonNode::asText).orElse(null);
 
         return new UpdateMerchantDetailsRequest(
-                name, telephoneNumber, addressLine1, addressLine2, addressCity, addressPostcode, addressCountry, email
+                name, telephoneNumber, addressLine1, addressLine2, addressCity, addressPostcode,
+                addressCountry, email, url
         );
     }
 
@@ -54,7 +58,8 @@ public class UpdateMerchantDetailsRequest {
                                         @JsonProperty("address_city") String addressCity,
                                         @JsonProperty("address_postcode") String addressPostcode,
                                         @JsonProperty("address_country") String addressCountry,
-                                        @JsonProperty("email") String email) {
+                                        @JsonProperty("email") String email,
+                                        @JsonProperty("url") String url) {
         this.name = name;
         this.telephoneNumber = telephoneNumber;
         this.addressLine1 = addressLine1;
@@ -63,6 +68,7 @@ public class UpdateMerchantDetailsRequest {
         this.addressPostcode = addressPostcode;
         this.addressCountry = addressCountry;
         this.email = email;
+        this.url = url;
     }
 
     public String getName() {
@@ -95,5 +101,9 @@ public class UpdateMerchantDetailsRequest {
 
     public String getEmail() {
         return this.email;
+    }
+
+    public String getUrl() {
+        return this.url;
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/MerchantDetailsEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/MerchantDetailsEntity.java
@@ -34,6 +34,9 @@ public class MerchantDetailsEntity {
     @Column(name = "merchant_email")
     private String email;
 
+    @Column(name = "merchant_url")
+    private String url;
+
     // JPA requires default constructor
     public MerchantDetailsEntity() {
     }
@@ -45,7 +48,8 @@ public class MerchantDetailsEntity {
                                  String addressCity,
                                  String addressPostcode,
                                  String addressCountry,
-                                 String email) {
+                                 String email,
+                                 String url) {
         this.name = name;
         this.telephoneNumber = telephoneNumber;
         this.addressLine1 = addressLine1;
@@ -54,6 +58,7 @@ public class MerchantDetailsEntity {
         this.addressPostcode = addressPostcode;
         this.addressCountryCode = addressCountry;
         this.email = email;
+        this.url = url;
     }
 
     public String getName() {
@@ -120,6 +125,14 @@ public class MerchantDetailsEntity {
         this.email = email;
     }
 
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
     public MerchantDetails toMerchantDetails() {
         return new MerchantDetails(
                 this.name,
@@ -129,7 +142,8 @@ public class MerchantDetailsEntity {
                 this.addressCity,
                 this.addressPostcode,
                 this.addressCountryCode,
-                this.email
+                this.email,
+                this.url
         );
     }
 
@@ -142,7 +156,8 @@ public class MerchantDetailsEntity {
                 updateMerchantDetailsRequest.getAddressCity(),
                 updateMerchantDetailsRequest.getAddressPostcode(),
                 updateMerchantDetailsRequest.getAddressCountry(),
-                updateMerchantDetailsRequest.getEmail());
+                updateMerchantDetailsRequest.getEmail(),
+                updateMerchantDetailsRequest.getUrl());
     }
 
     @Override
@@ -164,7 +179,8 @@ public class MerchantDetailsEntity {
                 && Objects.equals(addressCity, that.addressCity)
                 && Objects.equals(addressPostcode, that.addressPostcode)
                 && Objects.equals(email, that.email)
-                && Objects.equals(addressCountryCode, that.addressCountryCode);
+                && Objects.equals(addressCountryCode, that.addressCountryCode)
+                && Objects.equals(url, that.url);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
@@ -39,6 +39,7 @@ import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_MERCHANT_DETAIL
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_MERCHANT_DETAILS_EMAIL;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_MERCHANT_DETAILS_NAME;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_MERCHANT_DETAILS_TELEPHONE_NUMBER;
+import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_MERCHANT_DETAILS_URL;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_REDIRECT_NAME;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_SECTOR;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_SERVICE_NAME_PREFIX;
@@ -91,7 +92,8 @@ public class ServiceUpdateOperationValidator {
                 entry(FIELD_MERCHANT_DETAILS_ADDRESS_COUNRTY, singletonList(REPLACE)),
                 entry(FIELD_MERCHANT_DETAILS_ADDRESS_POSTCODE, singletonList(REPLACE)),
                 entry(FIELD_MERCHANT_DETAILS_EMAIL, singletonList(REPLACE)),
-                entry(FIELD_MERCHANT_DETAILS_TELEPHONE_NUMBER, singletonList(REPLACE))
+                entry(FIELD_MERCHANT_DETAILS_TELEPHONE_NUMBER, singletonList(REPLACE)),
+                entry(FIELD_MERCHANT_DETAILS_URL, singletonList(REPLACE))
         ));
         Arrays.stream(SupportedLanguage.values()).forEach(lang ->
                 validAttributeUpdateOperations.put(FIELD_SERVICE_NAME_PREFIX + '/' + lang.toString(), singletonList(REPLACE)));

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
@@ -49,6 +49,7 @@ public class ServiceUpdater {
     public static final String FIELD_MERCHANT_DETAILS_ADDRESS_POSTCODE = "merchant_details/address_postcode";
     public static final String FIELD_MERCHANT_DETAILS_EMAIL = "merchant_details/email";
     public static final String FIELD_MERCHANT_DETAILS_TELEPHONE_NUMBER = "merchant_details/telephone_number";
+    public static final String FIELD_MERCHANT_DETAILS_URL = "merchant_details/url";
     private final ServiceDao serviceDao;
     private final Map<String, BiConsumer<ServiceUpdateRequest, ServiceEntity>> attributeUpdaters;
 
@@ -75,7 +76,8 @@ public class ServiceUpdater {
                 entry(FIELD_MERCHANT_DETAILS_ADDRESS_COUNRTY, updateMerchantDetailsAddressCountry()),
                 entry(FIELD_MERCHANT_DETAILS_ADDRESS_POSTCODE, updateMerchantDetailsAddressPostcode()),
                 entry(FIELD_MERCHANT_DETAILS_EMAIL, updateMerchantDetailsEmail()),
-                entry(FIELD_MERCHANT_DETAILS_TELEPHONE_NUMBER, updateMerchantDetailsPhone())
+                entry(FIELD_MERCHANT_DETAILS_TELEPHONE_NUMBER, updateMerchantDetailsPhone()),
+                entry(FIELD_MERCHANT_DETAILS_URL, updateMerchantDetailsUrl())
         ));
 
         Arrays.stream(SupportedLanguage.values())
@@ -229,6 +231,11 @@ public class ServiceUpdater {
     private BiConsumer<ServiceUpdateRequest, ServiceEntity> updateMerchantDetailsPhone() {
         return (serviceUpdateRequest, serviceEntity) ->
                 getOrCreateMerchantDetails(serviceEntity).setTelephoneNumber(serviceUpdateRequest.valueAsString());
+    }
+
+    private BiConsumer<ServiceUpdateRequest, ServiceEntity> updateMerchantDetailsUrl() {
+        return (serviceUpdateRequest, serviceEntity) ->
+                getOrCreateMerchantDetails(serviceEntity).setUrl(serviceUpdateRequest.valueAsString());
     }
 
     private MerchantDetailsEntity getOrCreateMerchantDetails(ServiceEntity serviceEntity) {

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/ServiceDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/ServiceDbFixture.java
@@ -24,7 +24,7 @@ public class ServiceDbFixture {
     private String name = Service.DEFAULT_NAME_VALUE;
     private MerchantDetails merchantDetails = new MerchantDetails(
             "name", null, "line1", null, "city",
-            "postcode", "country", null
+            "postcode", "country", null, null
     );
     private boolean collectBillingAddress = true;
     private boolean experimentalFeaturesEnabled = false;

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoIT.java
@@ -150,6 +150,7 @@ class ServiceDaoIT extends DaoTestBase {
         assertThat(savedService.get(0).get("merchant_address_postcode"), is(merchantDetails.getAddressPostcode()));
         assertThat(savedService.get(0).get("merchant_address_country"), is(merchantDetails.getAddressCountryCode()));
         assertThat(savedService.get(0).get("merchant_email"), is(merchantDetails.getEmail()));
+        assertThat(savedService.get(0).get("merchant_url"), is(merchantDetails.getUrl()));
     }
 
     @Test
@@ -349,6 +350,7 @@ class ServiceDaoIT extends DaoTestBase {
         assertThat(thisEntity.getAddressPostcode(), is(thatEntity.getAddressPostcode()));
         assertThat(thisEntity.getAddressCountryCode(), is(thatEntity.getAddressCountryCode()));
         assertThat(thisEntity.getEmail(), is(thatEntity.getEmail()));
+        assertThat(thisEntity.getUrl(), is(thatEntity.getUrl()));
     }
 
     private void assertServiceEntity(ServiceEntity thisEntity, ServiceEntity thatEntity) {

--- a/src/test/java/uk/gov/pay/adminusers/persistence/entity/MerchantDetailsEntityBuilder.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/entity/MerchantDetailsEntityBuilder.java
@@ -9,6 +9,7 @@ public final class MerchantDetailsEntityBuilder {
     private String addressPostcode = "test-postcode";
     private String addressCountryCode = "GB";
     private String email = "merchant@example.com";
+    private String url = "https://merchant.example.com";
 
     private MerchantDetailsEntityBuilder() {
     }
@@ -57,6 +58,11 @@ public final class MerchantDetailsEntityBuilder {
         return this;
     }
 
+    public MerchantDetailsEntityBuilder withUrl(String url) {
+        this.url = url;
+        return this;
+    }
+
     public MerchantDetailsEntity build() {
         MerchantDetailsEntity merchantDetailsEntity = new MerchantDetailsEntity();
         merchantDetailsEntity.setName(name);
@@ -67,6 +73,7 @@ public final class MerchantDetailsEntityBuilder {
         merchantDetailsEntity.setAddressPostcode(addressPostcode);
         merchantDetailsEntity.setAddressCountryCode(addressCountryCode);
         merchantDetailsEntity.setEmail(email);
+        merchantDetailsEntity.setUrl(url);
         return merchantDetailsEntity;
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/resources/EmailResourceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/EmailResourceIT.java
@@ -27,7 +27,8 @@ public class EmailResourceIT extends IntegrationTest {
                 .withGatewayAccountIds(GATEWAY_ACCOUNT_ID)
                 .withMerchantDetails(new MerchantDetails(
                         "name", "number", "line1", null, "city",
-                        "postcode", "country", "dd-merchant@example.com"
+                        "postcode", "country", "dd-merchant@example.com",
+                        "https://merchant.example.org"
                 ))
                 .insertService();
         String body = mapper.valueToTree(validEmailRequest).toString();

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateIT.java
@@ -3,6 +3,7 @@ package uk.gov.pay.adminusers.resources;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.GoLiveStage;
+import uk.gov.pay.adminusers.model.MerchantDetails;
 
 import java.util.HashMap;
 import java.util.List;
@@ -73,6 +74,28 @@ public class ServiceResourceUpdateIT extends IntegrationTest {
                 .then()
                 .statusCode(200)
                 .body("default_billing_address_country", is(nullValue()));
+    }
+
+    @Test
+    public void shouldUpdateMerchantUrlField() {
+        String serviceExternalId = serviceDbFixture(databaseHelper)
+                .withMerchantDetails(new MerchantDetails(
+                        "name", null, "line1", null, "city",
+                        "postcode", "country", null, "https://www.example.com"))
+                .insertService().getExternalId();
+
+        JsonNode payload = mapper
+                .valueToTree(List.of(
+                        patchRequest("replace", "merchant_details/url", "https://merchant.example.com")));
+
+        givenSetup()
+                .when()
+                .contentType(JSON)
+                .body(payload)
+                .patch(format(SERVICE_RESOURCE, serviceExternalId))
+                .then()
+                .statusCode(200)
+                .body("merchant_details.url", is("https://merchant.example.com"));
     }
 
     private Map<String, Object> patchRequest(String op, String path, Object value) {

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateMerchantDetailsIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateMerchantDetailsIT.java
@@ -34,7 +34,8 @@ public class ServiceResourceUpdateMerchantDetailsIT extends IntegrationTest {
                 "address_city", "city",
                 "address_country", "country",
                 "address_postcode", "postcode",
-                "email", "dd-merchant@example.com");
+                "email", "dd-merchant@example.com",
+                "url", "https://merchant.example.com");
 
         givenSetup()
                 .when()
@@ -51,7 +52,8 @@ public class ServiceResourceUpdateMerchantDetailsIT extends IntegrationTest {
                 .body("merchant_details.address_city", is("city"))
                 .body("merchant_details.address_country", is("country"))
                 .body("merchant_details.address_postcode", is("postcode"))
-                .body("merchant_details.email", is("dd-merchant@example.com"));
+                .body("merchant_details.email", is("dd-merchant@example.com"))
+                .body("merchant_details.url", is("https://merchant.example.com"));
     }
 
     @Test
@@ -81,7 +83,8 @@ public class ServiceResourceUpdateMerchantDetailsIT extends IntegrationTest {
                 .body("merchant_details.address_postcode", is("postcode"))
                 .body("merchant_details", not(hasKey("telephone_number")))
                 .body("merchant_details", not(hasKey("address_line2")))
-                .body("merchant_details", not(hasKey("email")));
+                .body("merchant_details", not(hasKey("email")))
+                .body("merchant_details", not(hasKey("url")));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/service/EmailServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/EmailServiceTest.java
@@ -90,7 +90,8 @@ public class EmailServiceTest {
                 CITY,
                 POSTCODE,
                 ADDRESS_COUNTRY_CODE,
-                MERCHANT_EMAIL
+                MERCHANT_EMAIL,
+                null
         );
         given(mockServiceEntity.getMerchantDetailsEntity()).willReturn(merchantDetails);
         ArgumentCaptor<Map<String, String>> personalisationCaptor = forClass(Map.class);
@@ -122,7 +123,8 @@ public class EmailServiceTest {
                 CITY,
                 POSTCODE,
                 ADDRESS_COUNTRY_CODE,
-                MERCHANT_EMAIL
+                MERCHANT_EMAIL,
+                null
         );
         given(mockServiceEntity.getMerchantDetailsEntity()).willReturn(merchantDetails);
         ArgumentCaptor<Map<String, String>> personalisationCaptor = forClass(Map.class);
@@ -154,7 +156,8 @@ public class EmailServiceTest {
                 CITY,
                 POSTCODE,
                 ADDRESS_COUNTRY_CODE,
-                MERCHANT_EMAIL
+                MERCHANT_EMAIL,
+                null
         );
         given(mockServiceEntity.getMerchantDetailsEntity()).willReturn(merchantDetails);
         ArgumentCaptor<Map<String, String>> personalisationCaptor = forClass(Map.class);
@@ -184,7 +187,8 @@ public class EmailServiceTest {
                 CITY,
                 POSTCODE,
                 ADDRESS_COUNTRY_CODE,
-                MERCHANT_EMAIL
+                MERCHANT_EMAIL,
+                null
         );
 
         given(mockServiceEntity.getMerchantDetailsEntity()).willReturn(merchantDetails);
@@ -216,7 +220,8 @@ public class EmailServiceTest {
                 CITY,
                 POSTCODE,
                 ADDRESS_COUNTRY_CODE,
-                MERCHANT_EMAIL
+                MERCHANT_EMAIL,
+                null
         );
 
         given(mockServiceEntity.getMerchantDetailsEntity()).willReturn(merchantDetails);
@@ -248,7 +253,8 @@ public class EmailServiceTest {
                 CITY,
                 POSTCODE,
                 ADDRESS_COUNTRY_CODE,
-                MERCHANT_EMAIL
+                MERCHANT_EMAIL,
+                null
         );
 
         given(mockServiceEntity.getMerchantDetailsEntity()).willReturn(merchantDetails);
@@ -282,7 +288,8 @@ public class EmailServiceTest {
                 CITY,
                 POSTCODE,
                 ADDRESS_COUNTRY_CODE,
-                MERCHANT_EMAIL
+                MERCHANT_EMAIL,
+                null
         );
 
         given(mockServiceEntity.getMerchantDetailsEntity()).willReturn(merchantDetails);
@@ -308,7 +315,8 @@ public class EmailServiceTest {
                 CITY,
                 POSTCODE,
                 ADDRESS_COUNTRY_CODE,
-                MERCHANT_EMAIL
+                MERCHANT_EMAIL,
+                null
         );
         given(mockServiceEntity.getMerchantDetailsEntity()).willReturn(merchantDetails);
         given(mockCountryConverter.getCountryNameFrom(ADDRESS_COUNTRY_CODE)).willReturn(Optional.empty());

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceUpdaterTest.java
@@ -64,12 +64,13 @@ public class ServiceUpdaterTest {
         String addressPostcode = "something";
         String addressCountry = "something";
         String email = "dd-merchant@example.com";
+        String url = "https://merchant.example.com";
 
         MerchantDetailsEntity toUpdate = new MerchantDetailsEntity(
-                name, telephoneNumber, addressLine1, addressLine2, addressCity, addressPostcode, addressCountry, email
+                name, telephoneNumber, addressLine1, addressLine2, addressCity, addressPostcode, addressCountry, email, url
         );
         UpdateMerchantDetailsRequest request = new UpdateMerchantDetailsRequest(
-                name, telephoneNumber, addressLine1, addressLine2, addressCity, addressPostcode, addressCountry, email
+                name, telephoneNumber, addressLine1, addressLine2, addressCity, addressPostcode, addressCountry, email, url
         );
         ServiceEntity serviceEntity = mock(ServiceEntity.class);
         when(serviceDao.findByExternalId(SERVICE_ID)).thenReturn(of(serviceEntity));
@@ -92,10 +93,10 @@ public class ServiceUpdaterTest {
         String addressPostcode = "something";
         String addressCountry = "something";
         String email = "merchant@example.com";
+        String url = "https://merchant.example.com";
 
-        UpdateMerchantDetailsRequest request = new UpdateMerchantDetailsRequest(
-                name, telephoneNumber, addressLine1, addressLine2, addressCity, addressPostcode, addressCountry, email
-        );
+        UpdateMerchantDetailsRequest request = new UpdateMerchantDetailsRequest(name, telephoneNumber, addressLine1,
+                addressLine2, addressCity, addressPostcode, addressCountry, email, url);
         ServiceEntity serviceEntity = mock(ServiceEntity.class);
 
         when(serviceDao.findByExternalId(NON_EXISTENT_SERVICE_EXTERNAL_ID)).thenReturn(Optional.empty());
@@ -380,6 +381,7 @@ public class ServiceUpdaterTest {
         String addressPostcode = "W10 5LA";
         String email = "someone@example.com";
         String telephoneNumber = "000";
+        String url = "https://merchant.example.com";
 
         List<ServiceUpdateRequest> serviceUpdateRequests = List.of(
                 serviceUpdateRequest("replace", "merchant_details/name", name),
@@ -389,7 +391,8 @@ public class ServiceUpdaterTest {
                 serviceUpdateRequest("replace", "merchant_details/address_country", addressCountry),
                 serviceUpdateRequest("replace", "merchant_details/address_postcode", addressPostcode),
                 serviceUpdateRequest("replace", "merchant_details/email", email),
-                serviceUpdateRequest("replace", "merchant_details/telephone_number", telephoneNumber)
+                serviceUpdateRequest("replace", "merchant_details/telephone_number", telephoneNumber),
+                serviceUpdateRequest("replace", "merchant_details/url", url)
         );
         ServiceEntity serviceEntity = aServiceEntity()
                 .withMerchantDetailsEntity(null)
@@ -400,7 +403,7 @@ public class ServiceUpdaterTest {
         Optional<Service> maybeService = updater.doUpdate(SERVICE_ID, serviceUpdateRequests);
 
         assertThat(maybeService.isPresent(), is(true));
-        verify(serviceDao, times(8)).merge(serviceEntity);
+        verify(serviceDao, times(9)).merge(serviceEntity);
         assertThat(maybeService.get().getMerchantDetails().getName(), is(name));
         assertThat(maybeService.get().getMerchantDetails().getAddressLine1(), is(addressLine1));
         assertThat(maybeService.get().getMerchantDetails().getAddressLine2(), is(addressLine2));
@@ -409,8 +412,8 @@ public class ServiceUpdaterTest {
         assertThat(maybeService.get().getMerchantDetails().getAddressPostcode(), is(addressPostcode));
         assertThat(maybeService.get().getMerchantDetails().getEmail(), is(email));
         assertThat(maybeService.get().getMerchantDetails().getTelephoneNumber(), is(telephoneNumber));
+        assertThat(maybeService.get().getMerchantDetails().getUrl(), is(url));
     }
-
 
     @Test
     public void shouldUpdateMerchantDetailsAddressLine1Successfully_WhenExistingMerchantDetails() {

--- a/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
@@ -210,9 +210,9 @@ public class DatabaseTestHelper {
             return handle.createUpdate("INSERT INTO services(" +
                     "id, custom_branding, " +
                     "merchant_name, merchant_telephone_number, merchant_address_line1, merchant_address_line2, merchant_address_city, " +
-                    "merchant_address_postcode, merchant_address_country, merchant_email, external_id, experimental_features_enabled) " +
+                    "merchant_address_postcode, merchant_address_country, merchant_email, merchant_url, external_id, experimental_features_enabled) " +
                     "VALUES (:id, :customBranding, :merchantName, :merchantTelephoneNumber, :merchantAddressLine1, :merchantAddressLine2, " +
-                    ":merchantAddressCity, :merchantAddressPostcode, :merchantAddressCountry, :merchantEmail, :externalId, :experimentalFeaturesEnabled)")
+                    ":merchantAddressCity, :merchantAddressPostcode, :merchantAddressCountry, :merchantEmail, :merchantUrl, :externalId, :experimentalFeaturesEnabled)")
                     .bind("id", service.getId())
                     .bindBySqlType("customBranding", customBranding, OTHER)
                     .bind("merchantName", merchantDetails.getName())
@@ -223,6 +223,7 @@ public class DatabaseTestHelper {
                     .bind("merchantAddressPostcode", merchantDetails.getAddressPostcode())
                     .bind("merchantAddressCountry", merchantDetails.getAddressCountry())
                     .bind("merchantEmail", merchantDetails.getEmail())
+                    .bind("merchantUrl", merchantDetails.getUrl())
                     .bind("externalId", service.getExternalId())
                     .bind("experimentalFeaturesEnabled", service.isExperimentalFeaturesEnabled())
                     .execute();
@@ -383,10 +384,10 @@ public class DatabaseTestHelper {
             return handle.createUpdate("INSERT INTO services(" +
                     "id, custom_branding, " +
                     "merchant_name, merchant_telephone_number, merchant_address_line1, merchant_address_line2, merchant_address_city, " +
-                    "merchant_address_postcode, merchant_address_country, merchant_email, external_id, redirect_to_service_immediately_on_terminal_state, " +
+                    "merchant_address_postcode, merchant_address_country, merchant_email, merchant_url, external_id, redirect_to_service_immediately_on_terminal_state, " +
                     "current_go_live_stage, experimental_features_enabled, current_psp_test_account_stage, created_date) " +
                     "VALUES (:id, :customBranding, :merchantName, :merchantTelephoneNumber, :merchantAddressLine1, :merchantAddressLine2, " +
-                    ":merchantAddressCity, :merchantAddressPostcode, :merchantAddressCountry, :merchantEmail, :externalId, :redirectToServiceImmediatelyOnTerminalState, " +
+                    ":merchantAddressCity, :merchantAddressPostcode, :merchantAddressCountry, :merchantEmail, :merchantUrl, :externalId, :redirectToServiceImmediatelyOnTerminalState, " +
                     ":currentGoLiveStage, :experimentalFeaturesEnabled, :pspTestAccountStage, :createdDate)")
                     .bind("id", serviceEntity.getId())
                     .bindBySqlType("customBranding", customBranding, OTHER)
@@ -398,6 +399,7 @@ public class DatabaseTestHelper {
                     .bind("merchantAddressPostcode", merchantDetails.getAddressPostcode())
                     .bind("merchantAddressCountry", merchantDetails.getAddressCountryCode())
                     .bind("merchantEmail", merchantDetails.getEmail())
+                    .bind("merchantUrl", merchantDetails.getUrl())
                     .bind("externalId", serviceEntity.getExternalId())
                     .bind("redirectToServiceImmediatelyOnTerminalState", serviceEntity.isRedirectToServiceImmediatelyOnTerminalState())
                     .bind("currentGoLiveStage", serviceEntity.getCurrentGoLiveStage())


### PR DESCRIPTION
## WHAT YOU DID
- Return field in get one service or search services API endpoints
- Accept new field url on PUT /{serviceExternalId}/merchant-details (url is not mandatory)
- Allow patching field url on PATCH /{serviceExternalId}
