### PR TITLE
PP-9234: Remove end to end tests from jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,22 +54,6 @@ pipeline {
         }
       }
     }
-    stage('Tests') {
-      failFast true
-      parallel {
-        stage('End-to-End Tests') {
-            when {
-                anyOf {
-                  branch 'master'
-                  environment name: 'RUN_END_TO_END_ON_PR', value: 'true'
-                }
-            }
-            steps {
-                runAppE2E("adminusers", "card")
-            }
-        }
-      }
-    }
     stage('Docker Tag') {
       steps {
         script {


### PR DESCRIPTION
## WHAT YOU DID
Remove the post-merge end to end tests from Jenkins.

NOTE: This requires https://github.com/alphagov/pay-ci/pull/633 to have been merged and applied prior to this being merged


## How to test

- Check the Jenkinsfile changes have only removed end to end tests

## Code review checklist

### Logging

N/A

### Documentation

N/A