### PR TITLE
PP-9279 implement dispute handling in Adminusers

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/app/config/NotifyConfiguration.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/NotifyConfiguration.java
@@ -58,6 +58,14 @@ public class NotifyConfiguration extends Configuration {
     @Valid
     @NotNull
     private String liveAccountCreatedEmailTemplateId;
+    
+    @Valid
+    @NotNull
+    private String stripeDisputeCreatedEmailTemplateId;
+    
+    @Valid
+    @NotNull
+    private String notifyEmailReplyToSupportId;
 
     public String getCardApiKey() {
         return cardApiKey;
@@ -109,5 +117,13 @@ public class NotifyConfiguration extends Configuration {
 
     public String getLiveAccountCreatedEmailTemplateId() {
         return liveAccountCreatedEmailTemplateId;
+    }
+
+    public String getStripeDisputeCreatedEmailTemplateId() {
+        return stripeDisputeCreatedEmailTemplateId;
+    }
+
+    public String getNotifyEmailReplyToSupportId() {
+        return notifyEmailReplyToSupportId;
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/client/ledger/model/LedgerTransaction.java
+++ b/src/main/java/uk/gov/pay/adminusers/client/ledger/model/LedgerTransaction.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class LedgerTransaction {
@@ -18,7 +17,12 @@ public class LedgerTransaction {
         // empty constructor
     }
 
-   
+    public LedgerTransaction(String transactionId, String reference) {
+        this.transactionId = transactionId;
+        this.reference = reference;
+    }
+
+
     public String getReference() {
         return reference;
     }

--- a/src/main/java/uk/gov/pay/adminusers/queue/event/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/adminusers/queue/event/EventMessageHandler.java
@@ -1,42 +1,120 @@
 package uk.gov.pay.adminusers.queue.event;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.sentry.Sentry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.adminusers.client.ledger.model.LedgerTransaction;
+import uk.gov.pay.adminusers.client.ledger.service.LedgerService;
+import uk.gov.pay.adminusers.model.Service;
+import uk.gov.pay.adminusers.persistence.entity.UserEntity;
+import uk.gov.pay.adminusers.queue.model.Event;
 import uk.gov.pay.adminusers.queue.model.EventMessage;
+import uk.gov.pay.adminusers.queue.model.EventType;
+import uk.gov.pay.adminusers.queue.model.event.DisputeCreatedDetails;
+import uk.gov.pay.adminusers.service.NotificationService;
+import uk.gov.pay.adminusers.service.ServiceFinder;
+import uk.gov.pay.adminusers.service.UserServices;
 import uk.gov.service.payments.commons.queue.exception.QueueException;
 
 import javax.inject.Inject;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import static java.lang.String.format;
 import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.pay.adminusers.utils.currency.ConvertToCurrency.convertPenceToPounds;
+import static uk.gov.pay.adminusers.utils.date.DisputeEvidenceDueByDateUtil.getPayDueByDateForEpoch;
+import static uk.gov.pay.adminusers.utils.date.DisputeEvidenceDueByDateUtil.getZDTForEpoch;
 
 public class EventMessageHandler {
-    
+
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final EventSubscriberQueue eventSubscriberQueue;
+    private final LedgerService ledgerService;
+    private final NotificationService notificationService;
+    private final ServiceFinder serviceFinder;
+    private final UserServices userServices;
+    private final ObjectMapper objectMapper;
+    private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd, LLLL yyyy"); // 09, March 2022
 
     @Inject
-    public EventMessageHandler(EventSubscriberQueue eventSubscriberQueue) {
+    public EventMessageHandler(EventSubscriberQueue eventSubscriberQueue, 
+                               LedgerService ledgerService, 
+                               NotificationService notificationService, 
+                               ServiceFinder serviceFinder, 
+                               UserServices userServices, 
+                               ObjectMapper objectMapper) {
         this.eventSubscriberQueue = eventSubscriberQueue;
+        this.ledgerService = ledgerService;
+        this.notificationService = notificationService;
+        this.serviceFinder = serviceFinder;
+        this.userServices = userServices;
+        this.objectMapper = objectMapper;
     }
-    
+
     public void processMessages() throws QueueException {
         List<EventMessage> eventMessages = eventSubscriberQueue.retrieveEvents();
         for (EventMessage message : eventMessages) {
             try {
                 logger.info("Retrieved event queue message with id {} for resource external id {}",
                         message.getQueueMessage().getMessageId(), message.getEvent().getResourceExternalId());
-                
+                if (message.getEvent().getEventType().equalsIgnoreCase(EventType.DISPUTE_CREATED.name())) {
+                    handleDisputeCreatedMessage(message.getEvent());
+                } else {
+                    logger.warn("Unknown event type: {}", message.getEvent().getEventType());
+                }
                 eventSubscriberQueue.markMessageAsProcessed(message.getQueueMessage());
             } catch (Exception e) {
                 Sentry.captureException(e);
-                logger.warn("Error during handling the event message",
+                logger.warn("An error occurred handling the event message",
                         kv("sqs_message_id", message.getQueueMessage().getMessageId()),
                         kv("resource_external_id", message.getEvent().getResourceExternalId()),
                         kv("error", e.getMessage())
                 );
             }
         }
+    }
+
+    private void handleDisputeCreatedMessage(Event disputeCreatedEvent) throws JsonProcessingException {
+        var disputeCreatedDetails = objectMapper.treeToValue(disputeCreatedEvent.getEventData(), DisputeCreatedDetails.class);
+
+        Service service = serviceFinder.byExternalId(disputeCreatedEvent.getServiceId())
+                .orElseThrow(() -> new IllegalArgumentException(format("Service not found [id: %s]", disputeCreatedEvent.getServiceId())));
+        LedgerTransaction transaction = ledgerService.getTransaction(disputeCreatedEvent.getParentResourceExternalId())
+                .orElseThrow(() -> new IllegalArgumentException(format("Transaction not found [id: %s]", disputeCreatedEvent.getParentResourceExternalId())));
+        
+        List<UserEntity> serviceAdmins = userServices.getAdminUsersForService(service);
+
+        var epoch = disputeCreatedDetails.getDisputeEvidenceDueDate();
+        String formattedDueDate = getZDTForEpoch(epoch).format(dateTimeFormatter);
+        String formattedPayDueDate = getPayDueByDateForEpoch(epoch).format(dateTimeFormatter);
+
+        var paymentAmountInPounds = convertPenceToPounds.apply(disputeCreatedDetails.getPaymentAmount()).toString();
+        var disputeFeeInPounds = convertPenceToPounds.apply(disputeCreatedDetails.getDisputeFee()).toString();
+
+        Map<String, String> personalisation = Stream.of(new String[][]{
+                {"serviceName", service.getName()},
+                {"paymentExternalId", disputeCreatedEvent.getParentResourceExternalId()},
+                {"serviceReference", transaction.getReference()},
+                {"paymentAmount", paymentAmountInPounds},
+                {"disputeFee", disputeFeeInPounds},
+                {"disputeEvidenceDueDate", formattedDueDate},
+                {"sendEvidenceToPayDueDate", formattedPayDueDate}
+        }).collect(Collectors.toMap(data -> data[0], data -> data[1]));
+
+        if (!serviceAdmins.isEmpty()){
+            notificationService.sendStripeDisputeCreatedEmail(
+                    serviceAdmins.stream().map(UserEntity::getEmail).collect(Collectors.toSet()),
+                    personalisation
+            );
+        } else {
+            throw new IllegalStateException(format("Service has no Admin users [id: %s]", service.getId()));
+        }
+        
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/queue/model/EventType.java
+++ b/src/main/java/uk/gov/pay/adminusers/queue/model/EventType.java
@@ -1,0 +1,6 @@
+package uk.gov.pay.adminusers.queue.model;
+
+
+public enum EventType {
+    DISPUTE_CREATED
+}

--- a/src/main/java/uk/gov/pay/adminusers/queue/model/event/DisputeCreatedDetails.java
+++ b/src/main/java/uk/gov/pay/adminusers/queue/model/event/DisputeCreatedDetails.java
@@ -1,0 +1,41 @@
+package uk.gov.pay.adminusers.queue.model.event;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DisputeCreatedDetails {
+    
+    @JsonProperty("amount")
+    private Long paymentAmount;
+    @JsonProperty("fee")
+    private Long disputeFee;
+    @JsonProperty("evidenceDueDate")
+    private Long disputeEvidenceDueDate;
+    
+    public DisputeCreatedDetails() {
+        // empty constructor
+    }
+
+    public DisputeCreatedDetails(Long paymentAmount, Long disputeFee, Long disputeEvidenceDueDate) {
+        this.paymentAmount = paymentAmount;
+        this.disputeFee = disputeFee;
+        this.disputeEvidenceDueDate = disputeEvidenceDueDate;
+    }
+
+    public Long getPaymentAmount() {
+        return paymentAmount;
+    }
+
+    public Long getDisputeFee() {
+        return disputeFee;
+    }
+
+    public long getDisputeEvidenceDueDate() {
+        return disputeEvidenceDueDate;
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceFinder.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceFinder.java
@@ -21,4 +21,9 @@ public class ServiceFinder {
         return serviceDao.findByGatewayAccountId(gatewayAccountId)
                 .map(serviceEntity -> linksBuilder.decorate(serviceEntity.toService()));
     }
+    
+    public Optional<Service> byExternalId(String externalId) {
+        return serviceDao.findByExternalId(externalId)
+                .map(serviceEntity -> linksBuilder.decorate(serviceEntity.toService()));
+    }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
@@ -8,8 +8,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.adminusers.model.PatchRequest;
 import uk.gov.pay.adminusers.model.SecondFactorMethod;
+import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
+import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 import uk.gov.pay.adminusers.utils.telephonenumber.TelephoneNumberUtility;
 
@@ -19,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.Integer.parseInt;
@@ -264,6 +267,14 @@ public class UserServices {
         }
         
         return Optional.of(linksBuilder.decorate(user.toUser()));
+    }
+    
+    public List<UserEntity> getAdminUsersForService(Service service) {
+        List<UserEntity> serviceUsers = userDao.findByServiceId(service.getId());
+        return serviceUsers.stream().filter(userEntity -> {
+            var hasAdminRole = userEntity.getRoles().stream().filter(RoleEntity::isAdmin).count();
+            return hasAdminRole > 0;
+        }).collect(Collectors.toList());
     }
 
     private void changeUserFeatures(UserEntity userEntity, String features) {

--- a/src/main/java/uk/gov/pay/adminusers/utils/currency/ConvertToCurrency.java
+++ b/src/main/java/uk/gov/pay/adminusers/utils/currency/ConvertToCurrency.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.adminusers.utils.currency;
+
+import java.math.BigDecimal;
+import java.util.function.Function;
+
+public class ConvertToCurrency {
+
+   public static Function<Long, BigDecimal> convertPenceToPounds = pence -> new BigDecimal(pence).movePointLeft(2); 
+}

--- a/src/main/java/uk/gov/pay/adminusers/utils/date/DisputeEvidenceDueByDateUtil.java
+++ b/src/main/java/uk/gov/pay/adminusers/utils/date/DisputeEvidenceDueByDateUtil.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.adminusers.utils.date;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+public class DisputeEvidenceDueByDateUtil {
+    
+    public static ZonedDateTime getZDTForEpoch(Long epoch) {
+        return Instant.ofEpochSecond(epoch).atZone(ZoneOffset.UTC);
+    }
+    
+    public static ZonedDateTime getPayDueByDateForEpoch(Long epoch) {
+        var zdt = getZDTForEpoch(epoch);
+        switch (zdt.getDayOfWeek()) {
+            case MONDAY:
+                return zdt.minusDays(3L);
+            case TUESDAY:
+                return zdt.minusDays(4L);
+            default:
+                return zdt.minusDays(2L);
+        }
+    }
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -82,6 +82,8 @@ notify:
   inviteServiceUserExistsEmailTemplateId: ${NOTIFY_INVITE_SERVICE_USER_EXITS_EMAIL_TEMPLATE_ID:-pay-notify-invite-service-user-exists-email-template-id}
   inviteServiceUserDisabledEmailTemplateId: ${NOTIFY_INVITE_SERVICE_USER_DISABLED_EMAIL_TEMPLATE_ID:-pay-notify-invite-service-user-disabled-email-template-id}
   liveAccountCreatedEmailTemplateId: ${NOTIFY_LIVE_ACCOUNT_CREATED_EMAIL_TEMPLATE_ID:-pay-notify-live-account-created-email-template-id}
+  stripeDisputeCreatedEmailTemplateId: ${NOTIFY_STRIPE_DISPUTE_CREATED_EMAIL_TEMPLATE_ID:-pay-notify-stripe-dispute-created-email-template-id}
+  notifyEmailReplyToSupportId: ${NOTIFY_EMAIL_REPLY_TO_SUPPORT_ID:-pay-notify-email-reply-to-support-id}
 
 notifyDirectDebit:
   mandateCancelledEmailTemplateId: ${NOTIFY_MANDATE_CANCELLED_EMAIL_TEMPLATE_ID:-pay-mandate-cancelled-email-template-id}

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/LedgerTransactionFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/LedgerTransactionFixture.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.adminusers.fixtures;
+
+import uk.gov.pay.adminusers.client.ledger.model.LedgerTransaction;
+
+public class LedgerTransactionFixture {
+
+    private String transactionId;
+    private String reference;
+
+    private LedgerTransactionFixture() {
+    }
+
+    public static LedgerTransactionFixture aLedgerTransactionFixture() {
+        return new LedgerTransactionFixture();
+    }
+
+
+    public LedgerTransactionFixture withTransactionId(String transactionId) {
+        this.transactionId = transactionId;
+        return this;
+    }
+
+    public LedgerTransactionFixture withReference(String reference) {
+        this.reference = reference;
+        return this;
+    }
+
+
+    public LedgerTransaction build() {
+        return new LedgerTransaction(
+                transactionId,
+                reference
+        );
+    }
+    
+    
+}

--- a/src/test/java/uk/gov/pay/adminusers/queue/event/EventMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/queue/event/EventMessageHandlerTest.java
@@ -1,33 +1,106 @@
 package uk.gov.pay.adminusers.queue.event;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.adminusers.client.ledger.model.LedgerTransaction;
+import uk.gov.pay.adminusers.client.ledger.service.LedgerService;
+import uk.gov.pay.adminusers.model.Service;
+import uk.gov.pay.adminusers.model.ServiceName;
+import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 import uk.gov.pay.adminusers.queue.model.Event;
 import uk.gov.pay.adminusers.queue.model.EventMessage;
+import uk.gov.pay.adminusers.queue.model.EventType;
+import uk.gov.pay.adminusers.queue.model.event.DisputeCreatedDetails;
+import uk.gov.pay.adminusers.service.NotificationService;
+import uk.gov.pay.adminusers.service.ServiceFinder;
+import uk.gov.pay.adminusers.service.UserServices;
+import uk.gov.service.payments.commons.queue.exception.QueueException;
 import uk.gov.service.payments.commons.queue.model.QueueMessage;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.EventFixture.anEventFixture;
+import static uk.gov.pay.adminusers.fixtures.LedgerTransactionFixture.aLedgerTransactionFixture;
+import static uk.gov.pay.adminusers.model.Service.DEFAULT_NAME_VALUE;
+import static uk.gov.pay.adminusers.service.UserServicesTest.aUserEntityWithRoleForService;
 
 @ExtendWith(MockitoExtension.class)
 class EventMessageHandlerTest {
 
     @Mock
     private EventSubscriberQueue eventSubscriberQueue;
-    
+
+    @Mock
+    private NotificationService mockNotificationService;
+
+    @Mock
+    private ServiceFinder mockServiceFinder;
+
+    @Mock
+    private UserServices mockUserServices;
+
+    @Mock
+    private LedgerService mockLedgerService;
+
+    @Spy
+    private ObjectMapper objectMapper;
+
+    @Captor
+    ArgumentCaptor<Set<String>> adminEmailsCaptor;
+
+    @Captor
+    ArgumentCaptor<Map<String, String>> personalisationCaptor;
+
     @InjectMocks
-    private EventMessageHandler eventMessageHandler;
+    private EventMessageHandler underTest;
+
+    private Service serv;
+    private LedgerTransaction tx;
+    private List<UserEntity> users;
+    private Event disputeEvent;
 
     @BeforeEach
     void setUp() {
+        serv = Service.from(randomInt(), randomUuid(), new ServiceName(DEFAULT_NAME_VALUE));
+        tx = aLedgerTransactionFixture()
+                .withTransactionId("456")
+                .withReference("tx ref")
+                .build();
+        users = Arrays.asList(
+                aUserEntityWithRoleForService(serv, true, "admin1"),
+                aUserEntityWithRoleForService(serv, true, "admin2")
+        );
+        disputeEvent = anEventFixture()
+                .withEventType(EventType.DISPUTE_CREATED.name())
+                .withEventData(objectMapper.valueToTree(new DisputeCreatedDetails(21000L, 1500L, 1646658000L)))
+                .withServiceId(serv.getExternalId())
+                .withParentResourceExternalId("456")
+                .build();
     }
 
     @Test
@@ -36,9 +109,79 @@ class EventMessageHandlerTest {
         var mockQueueMessage = mock(QueueMessage.class);
         var eventMessage = EventMessage.of(event, mockQueueMessage);
         when(eventSubscriberQueue.retrieveEvents()).thenReturn(List.of(eventMessage));
-                
-        eventMessageHandler.processMessages();
-        
+
+        underTest.processMessages();
+
         verify(eventSubscriberQueue).markMessageAsProcessed(mockQueueMessage);
+    }
+
+    @Test
+    void shouldHandleDisputeCreatedEvent() throws QueueException {
+
+        var mockQueueMessage = mock(QueueMessage.class);
+        var eventMessage = EventMessage.of(disputeEvent, mockQueueMessage);
+        when(eventSubscriberQueue.retrieveEvents()).thenReturn(List.of(eventMessage));
+
+        when(mockServiceFinder.byExternalId(serv.getExternalId())).thenReturn(Optional.of(serv));
+        when(mockLedgerService.getTransaction(tx.getTransactionId())).thenReturn(Optional.of(tx));
+        when(mockUserServices.getAdminUsersForService(serv)).thenReturn(users);
+
+        underTest.processMessages();
+
+        verify(mockNotificationService, atMostOnce()).sendStripeDisputeCreatedEmail(adminEmailsCaptor.capture(), personalisationCaptor.capture());
+
+        var emails = adminEmailsCaptor.getValue();
+        var personalisation = personalisationCaptor.getValue();
+
+        assertThat(emails.size(), is(2));
+        assertThat(emails, hasItems("admin1@service.gov.uk", "admin2@service.gov.uk"));
+        assertThat(personalisation.get("serviceName"), is(serv.getName()));
+        assertThat(personalisation.get("paymentExternalId"), is("456"));
+        assertThat(personalisation.get("serviceReference"), is("tx ref"));
+        assertThat(personalisation.get("paymentAmount"), is("210.00"));
+        assertThat(personalisation.get("disputeFee"), is("15.00"));
+        assertThat(personalisation.get("disputeEvidenceDueDate"), is("07, March 2022"));
+        assertThat(personalisation.get("sendEvidenceToPayDueDate"), is("04, March 2022"));
+    }
+
+    @Test
+    void shouldNotCallNotificationServiceWhenServiceDoesNotExist() throws QueueException {
+        var mockQueueMessage = mock(QueueMessage.class);
+        var eventMessage = EventMessage.of(disputeEvent, mockQueueMessage);
+        when(eventSubscriberQueue.retrieveEvents()).thenReturn(List.of(eventMessage));
+        when(mockServiceFinder.byExternalId(serv.getExternalId())).thenReturn(Optional.empty());
+
+        underTest.processMessages();
+
+        verify(mockNotificationService, never()).sendStripeDisputeCreatedEmail(anySet(), anyMap());
+    }
+
+    @Test
+    void shouldNotCallNotificationServiceWhenTransactionDoesNotExist() throws QueueException {
+
+        var mockQueueMessage = mock(QueueMessage.class);
+        var eventMessage = EventMessage.of(disputeEvent, mockQueueMessage);
+        when(eventSubscriberQueue.retrieveEvents()).thenReturn(List.of(eventMessage));
+        when(mockServiceFinder.byExternalId(serv.getExternalId())).thenReturn(Optional.of(serv));
+        when(mockLedgerService.getTransaction(tx.getTransactionId())).thenReturn(Optional.empty());
+
+        underTest.processMessages();
+
+        verify(mockNotificationService, never()).sendStripeDisputeCreatedEmail(anySet(), anyMap());
+    }
+
+    @Test
+    void shouldNotCallNotificationServiceWhenNoAdminUsersExist() throws QueueException {
+        var mockQueueMessage = mock(QueueMessage.class);
+        var eventMessage = EventMessage.of(disputeEvent, mockQueueMessage);
+        when(eventSubscriberQueue.retrieveEvents()).thenReturn(List.of(eventMessage));
+
+        when(mockServiceFinder.byExternalId(serv.getExternalId())).thenReturn(Optional.of(serv));
+        when(mockLedgerService.getTransaction(tx.getTransactionId())).thenReturn(Optional.of(tx));
+        when(mockUserServices.getAdminUsersForService(serv)).thenReturn(Collections.emptyList());
+
+        underTest.processMessages();
+
+        verify(mockNotificationService, never()).sendStripeDisputeCreatedEmail(anySet(), anyMap());
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/queue/event/EventSubscriberQueueTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/queue/event/EventSubscriberQueueTest.java
@@ -44,7 +44,6 @@ class EventSubscriberQueueTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-
     private EventSubscriberQueue eventSubscriberQueue;
 
     @BeforeEach

--- a/src/test/java/uk/gov/pay/adminusers/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/NotificationServiceTest.java
@@ -11,15 +11,20 @@ import uk.gov.pay.adminusers.app.config.NotifyConfiguration;
 import uk.gov.pay.adminusers.app.config.NotifyDirectDebitConfiguration;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
+import uk.gov.service.notify.SendEmailResponse;
 import uk.gov.service.notify.SendSmsResponse;
 
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId;
@@ -43,6 +48,9 @@ public class NotificationServiceTest {
     private static final String INVITE_USER_EXISTING_EMAIL_TEMPLATE_ID = "invite-user-existing-email-template-id";
     private static final String FORGOTTEN_PASSWORD_EMAIL_TEMPLATE_ID = "forgotten-password-email-template-id";
     
+    private static final String STRIPE_DISPUTE_CREATED_EMAIL_TEMPLATE_ID = "stripe-dispute-created-email-template-id";
+    private static final String NOTIFY_EMAIL_REPLY_TO_SUPPORT_ID = "notify-email-reply-to-support-id";
+    
     @Mock private NotifyClientProvider mockNotifyClientProvider;
     @Mock private NotifyConfiguration mockNotifyConfiguration;
     @Mock private NotifyDirectDebitConfiguration mockNotifyDirectDebitConfiguration;
@@ -50,6 +58,7 @@ public class NotificationServiceTest {
 
     @Mock private NotificationClient mockNotificationClient;
     @Mock private SendSmsResponse mockSendSmsResponse;
+    @Mock private SendEmailResponse mockSendEmailResponse;
 
     private NotificationService notificationService;
 
@@ -66,12 +75,11 @@ public class NotificationServiceTest {
         given(mockNotifyConfiguration.getInviteUserExistingEmailTemplateId()).willReturn(INVITE_USER_EXISTING_EMAIL_TEMPLATE_ID);
         given(mockNotifyConfiguration.getForgottenPasswordEmailTemplateId()).willReturn(FORGOTTEN_PASSWORD_EMAIL_TEMPLATE_ID);
         
+        given(mockNotifyConfiguration.getStripeDisputeCreatedEmailTemplateId()).willReturn(STRIPE_DISPUTE_CREATED_EMAIL_TEMPLATE_ID);
+        given(mockNotifyConfiguration.getNotifyEmailReplyToSupportId()).willReturn(NOTIFY_EMAIL_REPLY_TO_SUPPORT_ID);
+        
         given(mockNotifyClientProvider.get()).willReturn(mockNotificationClient);
-
-        given(mockMetricRegistry.histogram("notify-operations.sms.response_time")).willReturn(mock(Histogram.class));
-
-        given(mockNotificationClient.sendSms(anyString(), anyString(), anyMap(), isNull())).willReturn(mockSendSmsResponse);
-        given(mockSendSmsResponse.getNotificationId()).willReturn(NOTIFICATION_ID);
+        
 
         notificationService = new NotificationService(mockNotifyClientProvider, mockNotifyConfiguration, mockNotifyDirectDebitConfiguration,
                 mockMetricRegistry);
@@ -79,6 +87,10 @@ public class NotificationServiceTest {
 
     @Test
     public void sendSecondFactorPasscodeSmsWithSignInTemplate() throws NotificationClientException {
+        given(mockMetricRegistry.histogram("notify-operations.sms.response_time")).willReturn(mock(Histogram.class));
+        given(mockNotificationClient.sendSms(anyString(), anyString(), anyMap(), isNull())).willReturn(mockSendSmsResponse);
+        given(mockSendSmsResponse.getNotificationId()).willReturn(NOTIFICATION_ID);
+        
         notificationService.sendSecondFactorPasscodeSms(PHONE_NUMBER, OTP, OtpNotifySmsTemplateId.SIGN_IN);
 
         verify(mockNotificationClient).sendSms(SIGN_IN_OTP_SMS_TEMPLATE_ID, PHONE_NUMBER_E164, Map.of("code", OTP), null);
@@ -86,6 +98,10 @@ public class NotificationServiceTest {
 
     @Test
     public void sendSecondFactorPasscodeSmsWithChangeSignIn2faToSmsTemplate() throws NotificationClientException {
+        given(mockMetricRegistry.histogram("notify-operations.sms.response_time")).willReturn(mock(Histogram.class));
+        given(mockNotificationClient.sendSms(anyString(), anyString(), anyMap(), isNull())).willReturn(mockSendSmsResponse);
+        given(mockSendSmsResponse.getNotificationId()).willReturn(NOTIFICATION_ID);
+        
         notificationService.sendSecondFactorPasscodeSms(PHONE_NUMBER, OTP, OtpNotifySmsTemplateId.CHANGE_SIGN_IN_2FA_TO_SMS);
 
         verify(mockNotificationClient).sendSms(CHANGE_SIGN_IN_2FA_TO_SMS_OTP_SMS_TEMPLATE_ID, PHONE_NUMBER_E164, Map.of("code", OTP), null);
@@ -93,6 +109,10 @@ public class NotificationServiceTest {
 
     @Test
     public void sendSecondFactorPasscodeSmsWithSelfInitiatedCreateNewUserAndServiceTemplate() throws NotificationClientException {
+        given(mockMetricRegistry.histogram("notify-operations.sms.response_time")).willReturn(mock(Histogram.class));
+        given(mockNotificationClient.sendSms(anyString(), anyString(), anyMap(), isNull())).willReturn(mockSendSmsResponse);
+        given(mockSendSmsResponse.getNotificationId()).willReturn(NOTIFICATION_ID);
+        
         notificationService.sendSecondFactorPasscodeSms(PHONE_NUMBER, OTP, OtpNotifySmsTemplateId.SELF_INITIATED_CREATE_NEW_USER_AND_SERVICE);
 
         verify(mockNotificationClient).sendSms(SELF_INITIATED_CREATE_USER_AND_SERVICE_OTP_SMS_TEMPLATE_ID, PHONE_NUMBER_E164, Map.of("code", OTP),
@@ -101,10 +121,33 @@ public class NotificationServiceTest {
 
     @Test
     public void sendSecondFactorPasscodeSmsWithCreateUserInResponseToInvitationToServiceTemplate() throws NotificationClientException {
+        given(mockMetricRegistry.histogram("notify-operations.sms.response_time")).willReturn(mock(Histogram.class));
+        given(mockNotificationClient.sendSms(anyString(), anyString(), anyMap(), isNull())).willReturn(mockSendSmsResponse);
+        given(mockSendSmsResponse.getNotificationId()).willReturn(NOTIFICATION_ID);
+        
         notificationService.sendSecondFactorPasscodeSms(PHONE_NUMBER, OTP, OtpNotifySmsTemplateId.CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE);
 
         verify(mockNotificationClient).sendSms(CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE_OTP_SMS_TEMPLATE_ID, PHONE_NUMBER_E164, Map.of("code", OTP),
                 null);    
+    }
+    
+    @Test
+    public void sendEmailWithStripeDisputeCreatedEmailTemplateId() throws NotificationClientException {
+        given(mockMetricRegistry.histogram("notify-operations.email.response_time")).willReturn(mock(Histogram.class));
+        given(mockNotificationClient.sendEmail(anyString(), anyString(), anyMap(), isNull(), anyString())).willReturn(mockSendEmailResponse);
+        given(mockSendEmailResponse.getNotificationId()).willReturn(NOTIFICATION_ID);
+        
+        var addresses = Stream.of("email1@service.gov.uk", "email2@service.gov.uk")
+                .collect(Collectors.toSet());
+        var personalisation = Stream.of(new String[][] {
+                { "k1", "v1" },
+                { "k2", "v2" }
+        }).collect(Collectors.toMap(data -> data[0], data -> data[1]));
+        
+        notificationService.sendStripeDisputeCreatedEmail(addresses, personalisation);
+        
+        verify(mockNotificationClient).sendEmail(STRIPE_DISPUTE_CREATED_EMAIL_TEMPLATE_ID, "email1@service.gov.uk", personalisation, null, NOTIFY_EMAIL_REPLY_TO_SUPPORT_ID);
+        verify(mockNotificationClient).sendEmail(STRIPE_DISPUTE_CREATED_EMAIL_TEMPLATE_ID, "email2@service.gov.uk", personalisation, null, NOTIFY_EMAIL_REPLY_TO_SUPPORT_ID);
     }
 
 }

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceFinderTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceFinderTest.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 
 @ExtendWith(MockitoExtension.class)
 public class ServiceFinderTest {
@@ -39,6 +40,22 @@ public class ServiceFinderTest {
         when(serviceDao.findByGatewayAccountId(gatewayAccountId)).thenReturn(Optional.of(serviceEntity));
 
         Optional<Service> serviceOptional = serviceFinder.byGatewayAccountId(gatewayAccountId);
+
+        assertThat(serviceOptional.isPresent(), is(true));
+        assertThat(serviceOptional.get().getGatewayAccountIds().get(0), is(gatewayAccountId));
+    }
+
+    @Test
+    public void shouldReturnService_ifFoundByExternalId() {
+        String gatewayAccountId = "1";
+        String externalId = randomUuid();
+        ServiceEntity serviceEntity = new ServiceEntity();
+        serviceEntity.addOrUpdateServiceName(ServiceNameEntity.from(SupportedLanguage.ENGLISH, Service.DEFAULT_NAME_VALUE));
+        serviceEntity.addGatewayAccountIds(gatewayAccountId);
+        serviceEntity.setExternalId(externalId);
+        when(serviceDao.findByExternalId(externalId)).thenReturn(Optional.of(serviceEntity));
+
+        Optional<Service> serviceOptional = serviceFinder.byExternalId(externalId);
 
         assertThat(serviceOptional.isPresent(), is(true));
         assertThat(serviceOptional.get().getGatewayAccountIds().get(0), is(gatewayAccountId));

--- a/src/test/java/uk/gov/pay/adminusers/utils/currency/ConvertToCurrencyTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/currency/ConvertToCurrencyTest.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.adminusers.utils.currency;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.adminusers.utils.currency.ConvertToCurrency.convertPenceToPounds;
+
+class ConvertToCurrencyTest {
+
+
+    @ParameterizedTest
+    @MethodSource("penceProvider")
+    void shouldCorrectlyCalculateConvertPenceToPounds(Long pence, String expected) {
+        assertThat(convertPenceToPounds.apply(pence).toString(), is(expected));
+    }
+
+    private static Stream<Arguments> penceProvider() {
+        return Stream.of(
+                Arguments.of(123L, "1.23"),
+                Arguments.of(12000L, "120.00"),
+                Arguments.of(1L, "0.01"),
+                Arguments.of(0L, "0.00"),
+                Arguments.of(-1500L, "-15.00")
+        );
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/utils/date/DisputeEvidenceDueByDateUtilTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/date/DisputeEvidenceDueByDateUtilTest.java
@@ -1,0 +1,42 @@
+package uk.gov.pay.adminusers.utils.date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.adminusers.utils.date.DisputeEvidenceDueByDateUtil.getPayDueByDateForEpoch;
+import static uk.gov.pay.adminusers.utils.date.DisputeEvidenceDueByDateUtil.getZDTForEpoch;
+
+class DisputeEvidenceDueByDateUtilTest {
+    
+    @Test
+    void shouldReturnZonedDateTimeForEpoch() {
+        var expectedZDT = Instant.ofEpochSecond(1646830800).atZone(ZoneOffset.UTC);
+        assertThat(getZDTForEpoch(1646830800L), is(expectedZDT));
+    }
+
+    @ParameterizedTest
+    @MethodSource("epochProvider")
+    void shouldCorrectlyCalculatePayDueByDate(Long epoch, DayOfWeek expected) {
+        assertThat(getPayDueByDateForEpoch(epoch).getDayOfWeek(), is(expected));
+    }
+
+    private static Stream<Arguments> epochProvider() {
+        return Stream.of(
+                Arguments.of(1646658000L, DayOfWeek.FRIDAY), // Monday, 7 March 2022 13:00:00
+                Arguments.of(1646744400L, DayOfWeek.FRIDAY), //  Tuesday, 8 March 2022 13:00:00
+                Arguments.of(1646830800L, DayOfWeek.MONDAY), //  Wednesday, 9 March 2022 13:00:00
+                Arguments.of(1646917200L, DayOfWeek.TUESDAY), // Thursday, 10 March 2022 13:00:00
+                Arguments.of(1647003600L, DayOfWeek.WEDNESDAY) // Friday, 11 March 2022 13:00:00
+        );
+    }
+}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -71,6 +71,8 @@ notify:
   inviteServiceUserExistsEmailTemplateId: ${NOTIFY_INVITE_SERVICE_USER_EXITS_EMAIL_TEMPLATE_ID:-pay-notify-invite-service-user-exists-email-template-id}
   inviteServiceUserDisabledEmailTemplateId: ${NOTIFY_INVITE_SERVICE_USER_DISABLED_EMAIL_TEMPLATE_ID:-pay-notify-invite-service-user-disabled-email-template-id}
   liveAccountCreatedEmailTemplateId: ${NOTIFY_LIVE_ACCOUNT_CREATED_EMAIL_TEMPLATE_ID:-pay-notify-live-account-created-email-template-id}
+  stripeDisputeCreatedEmailTemplateId: ${NOTIFY_STRIPE_DISPUTE_CREATED_EMAIL_TEMPLATE_ID:-pay-notify-stripe-dispute-created-email-template-id}
+  notifyEmailReplyToSupportId: ${NOTIFY_EMAIL_REPLY_TO_SUPPORT_ID:-pay-notify-email-reply-to-support-id}
 
 notifyDirectDebit:
   mandateCancelledEmailTemplateId: ${NOTIFY_MANDATE_CANCELLED_EMAIL_TEMPLATE_ID:-pay-mandate-cancelled-email-template-id}


### PR DESCRIPTION
## WHAT YOU DID

Added a new handler method to the EventMessageHandler to process Dispute events. Adminusers now contacts Ledger for the transaction reference related to the dispute, looks up the service, identifies the admin users and constructs the relevant details before sending an email using the new dispute template in Notify.

The template ids in the application config have been updated to include the new template id and the support reply address id, the notification service has been updated to support including an alternative reply address.
