### PR TITLE
[BAU] Speculative fix for Pact Provider Tagging

### DIFF
--- a/.github/workflows/_run-pact-provider-tests.yml
+++ b/.github/workflows/_run-pact-provider-tests.yml
@@ -27,6 +27,9 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+      - name: Get Provider SHA
+        run: |
+          echo ::set-output name=provider-sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/alphagov/pay-adminusers/git/ref/heads/master | jq .object.sha | tr -d '"' )
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
         with:
           repository: alphagov/pay-adminusers
@@ -52,7 +55,7 @@ jobs:
           -DrunContractTests \
           -DCONSUMER="${{ inputs.consumer }}" \
           -DPACT_CONSUMER_TAG="${{ inputs.consumer_tag }}" \
-          -Dpact.provider.version="${{ github.sha }}" \
+          -Dpact.provider.version="${{ steps.get-sha.outputs.provider-sha }}" \
           -Dpact.verifier.publishResults=true \
           -DPACT_BROKER_HOST=pay-pact-broker.cloudapps.digital \
           -DPACT_BROKER_USERNAME="${{ secrets.pact_broker_username }}" \

--- a/.github/workflows/_run-pact-provider-tests.yml
+++ b/.github/workflows/_run-pact-provider-tests.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           repository: alphagov/pay-adminusers
       - name: Get Provider SHA
+        id: get-provider-sha
         run: |
           echo ::set-output name=provider-sha::$(git rev-parse HEAD)
       - name: Set up JDK 11
@@ -55,7 +56,7 @@ jobs:
           -DrunContractTests \
           -DCONSUMER="${{ inputs.consumer }}" \
           -DPACT_CONSUMER_TAG="${{ inputs.consumer_tag }}" \
-          -Dpact.provider.version="${{ steps.get-sha.outputs.provider-sha }}" \
+          -Dpact.provider.version="${{ steps.get-provider-sha.outputs.provider-sha }}" \
           -Dpact.verifier.publishResults=true \
           -DPACT_BROKER_HOST=pay-pact-broker.cloudapps.digital \
           -DPACT_BROKER_USERNAME="${{ secrets.pact_broker_username }}" \

--- a/.github/workflows/_run-pact-provider-tests.yml
+++ b/.github/workflows/_run-pact-provider-tests.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-      - name: Get Provider SHA
-        run: |
-          echo ::set-output name=provider-sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/alphagov/pay-adminusers/git/ref/heads/master | jq .object.sha | tr -d '"' )
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
         with:
           repository: alphagov/pay-adminusers
+      - name: Get Provider SHA
+        run: |
+          echo ::set-output name=provider-sha::$(git rev-parse HEAD)
       - name: Set up JDK 11
         uses: actions/setup-java@f69f00b5e5324696b07f6b1c92f0470a6df00780
         with:


### PR DESCRIPTION
## What?
This is a speculative fix for the Pact Provider tagging issue that we've picked-up. We've discovered that when the workflow is called by other Pact consumers to use Adminusers as the "provider", it re-uses the same Git SHA from the consumer, which is undesired behaviour.

At present, the Checkout Action does not provide an output for this, so we're using a workaround.

## Contributors
Thanks to @jfharden and @katstevens for helping to figure this out.