### PR TITLE
BAU: Require unit tests for provider-contract tests

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -13,6 +13,7 @@ jobs:
     uses: ./.github/workflows/run-tests.yml
 
   provider-contract-tests:
+    needs: tests
     uses: alphagov/pay-ci/.github/workflows/_run-provider-contract-tests.yml@master
     secrets:
       pact_broker_username: ${{ secrets.pact_broker_username }}


### PR DESCRIPTION
We only want to publish a successful provider pact if the unit tests have passed.