### PR TITLE
PP-9259 Enable event processing if flag enabled in config

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/queue/managed/EventSubscriberQueueMessageReceiver.java
+++ b/src/main/java/uk/gov/pay/adminusers/queue/managed/EventSubscriberQueueMessageReceiver.java
@@ -30,7 +30,7 @@ public class EventSubscriberQueueMessageReceiver implements Managed {
     public EventSubscriberQueueMessageReceiver(EventMessageHandler eventMessageHandler, Environment environment,
                                                AdminUsersConfig adminUsersConfig) {
         this.eventMessageHandler = eventMessageHandler;
-        
+
         scheduledExecutorService = environment
                 .lifecycle()
                 .scheduledExecutorService(THREAD_NAME)
@@ -38,6 +38,7 @@ public class EventSubscriberQueueMessageReceiver implements Managed {
                 .build();
 
         EventSubscriberQueueConfig eventSubscriberQueueConfig = adminUsersConfig.getEventSubscriberQueueConfig();
+        queueEnabled = eventSubscriberQueueConfig.getEventSubscriberQueueEnabled();
         queueSchedulerThreadDelayInSeconds = eventSubscriberQueueConfig.getQueueSchedulerThreadDelayInSeconds();
         queueSchedulerShutdownTimeoutInSeconds = eventSubscriberQueueConfig.getQueueSchedulerShutdownTimeoutInSeconds();
     }


### PR DESCRIPTION
The EventSubscriberQueueMessageReceiver wasn't correctly getting the
eventSubscriberQueueEnabled flag from the application configuration to
determine whether to poll for messages.