### PR TITLE
PP-9279 Additional logging, model tests and deserialisation bug fixes

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/queue/event/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/adminusers/queue/event/EventMessageHandler.java
@@ -112,6 +112,10 @@ public class EventMessageHandler {
                     serviceAdmins.stream().map(UserEntity::getEmail).collect(Collectors.toSet()),
                     personalisation
             );
+            logger.info("Processed notification email for disputed transaction",
+                    kv("transaction_id", disputeCreatedEvent.getParentResourceExternalId()),
+                    kv("service_id", service.getId())
+            );
         } else {
             throw new IllegalStateException(format("Service has no Admin users [id: %s]", service.getId()));
         }

--- a/src/main/java/uk/gov/pay/adminusers/queue/model/event/DisputeCreatedDetails.java
+++ b/src/main/java/uk/gov/pay/adminusers/queue/model/event/DisputeCreatedDetails.java
@@ -14,7 +14,7 @@ public class DisputeCreatedDetails {
     private Long paymentAmount;
     @JsonProperty("fee")
     private Long disputeFee;
-    @JsonProperty("evidenceDueDate")
+    @JsonProperty("evidence_due_date")
     private Long disputeEvidenceDueDate;
     
     public DisputeCreatedDetails() {

--- a/src/test/java/uk/gov/pay/adminusers/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/adminusers/TestTemplateResourceLoader.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.adminusers;
+
+import static io.dropwizard.testing.FixtureHelpers.fixture;
+
+public class TestTemplateResourceLoader {
+    private static final String TEMPLATE_BASE_NAME = "templates";
+    
+    public static final String DISPUTE_CREATED_EVENT = TEMPLATE_BASE_NAME + "/events/dispute_created_event.json";
+
+    public static String load(String location) {
+        return fixture(location);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/adminusers/queue/model/event/DisputeCreatedDetailsTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/queue/model/event/DisputeCreatedDetailsTest.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.adminusers.queue.model.event;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.adminusers.queue.model.Event;
+import uk.gov.pay.adminusers.queue.model.EventType;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.adminusers.TestTemplateResourceLoader.DISPUTE_CREATED_EVENT;
+import static uk.gov.pay.adminusers.TestTemplateResourceLoader.load;
+
+class DisputeCreatedDetailsTest {
+    
+    private final ObjectMapper objectMapper = new ObjectMapper(); 
+
+    @Test
+    public void shouldDeserialiseDisputeEvent() throws JsonProcessingException {
+
+        var json = objectMapper.readTree(load(DISPUTE_CREATED_EVENT));
+        var evt = objectMapper.treeToValue(json, Event.class);
+        var disputeCreatedDetails = objectMapper.treeToValue(evt.getEventData(), DisputeCreatedDetails.class);
+        
+        assertThat(evt.getEventType(), is(EventType.DISPUTE_CREATED.name()));
+        assertThat(disputeCreatedDetails.getDisputeFee(), is(1500L));
+        assertThat(disputeCreatedDetails.getPaymentAmount(), is(125000L));
+        assertThat(disputeCreatedDetails.getDisputeEvidenceDueDate(), is(1648745127L));
+    }
+}

--- a/src/test/resources/templates/events/dispute_created_event.json
+++ b/src/test/resources/templates/events/dispute_created_event.json
@@ -1,0 +1,17 @@
+{
+  "event_type": "DISPUTE_CREATED",
+  "service_id": "111111111",
+  "resource_type": "dispute",
+  "event_details": {
+    "amount": 125000,
+    "fee": 1500,
+    "net_amount": 126500,
+    "reason": "fraudulent",
+    "evidence_due_date": 1648745127,
+    "gateway_account_id": "123"
+  },
+  "live": false,
+  "timestamp": "2022-03-17T17:46:01.123456Z",
+  "resource_external_id": "du_abcd",
+  "parent_resource_external_id": "du_efgh"
+}


### PR DESCRIPTION
## WHAT YOU DID

- Added additional logging to the event message handler to log information regarding processed notification emails for disputes
- Fixed a bug in DisputeCreatedDetails where a Json property was incorrectly labelled
- Added missing deserialisation test for Dispute Events
