### PR TITLE
PP-9279 Log exceptions from Notify better

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
@@ -99,15 +99,19 @@ public class AdminUsersExceptions {
         return buildWebApplicationException(error, CONFLICT.getStatusCode());
     }
 
-    public static WebApplicationException userNotificationError() {
-        return buildWebApplicationException("error sending user notification", INTERNAL_SERVER_ERROR.getStatusCode());
+    public static WebApplicationException userNotificationError(Exception cause) {
+        return buildWebApplicationException("error sending user notification", INTERNAL_SERVER_ERROR.getStatusCode(), cause);
     }
 
     private static WebApplicationException buildWebApplicationException(String error, int status) {
+        return buildWebApplicationException(error, status, null);
+    }
+    
+    private static WebApplicationException buildWebApplicationException(String error, int status, Exception cause) {
         Response response = Response.status(status)
                 .entity(Map.of("errors", List.of(error)))
                 .build();
-        return new WebApplicationException(response);
+        return new WebApplicationException(cause, response);
     }
 
     public static WebApplicationException invalidPublicSectorEmail(String email) {

--- a/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
@@ -79,7 +79,7 @@ public class NotificationService {
         } catch (NotificationClientException e) {
             metricRegistry.counter("notify-operations.sms.failures").inc();
             LOGGER.info("Error sending Sms: " + e.getMessage());
-            throw userNotificationError();
+            throw userNotificationError(e);
         } finally {
             responseTimeStopwatch.stop();
             metricRegistry.histogram("notify-operations.sms.response_time").update(responseTimeStopwatch.elapsed(TimeUnit.MILLISECONDS));
@@ -160,7 +160,8 @@ public class NotificationService {
             return response.getNotificationId().toString();
         } catch (Exception e) {
             metricRegistry.counter("notify-operations.email.failures").inc();
-            throw userNotificationError();
+            LOGGER.info("Error sending email: {}", e.getMessage());
+            throw userNotificationError(e);
         } finally {
             responseTimeStopwatch.stop();
             metricRegistry.histogram("notify-operations.email.response_time").update(responseTimeStopwatch.elapsed(TimeUnit.MILLISECONDS));

--- a/src/test/java/uk/gov/pay/adminusers/service/ExistingUserOtpDispatcherTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ExistingUserOtpDispatcherTest.java
@@ -86,7 +86,7 @@ public class ExistingUserOtpDispatcherTest {
         when(secondFactorAuthenticator.newPassCode(user.getOtpKey())).thenReturn(654321);
 
         when(notificationService.sendSecondFactorPasscodeSms(any(String.class), eq("654321"), eq(SIGN_IN)))
-                .thenThrow(AdminUsersExceptions.userNotificationError());
+                .thenThrow(AdminUsersExceptions.userNotificationError(new Exception("Cause")));
 
         Optional<SecondFactorToken> tokenOptional = existingUserOtpDispatcher.sendSignInOtp(user.getExternalId());
 
@@ -158,7 +158,7 @@ public class ExistingUserOtpDispatcherTest {
         when(secondFactorAuthenticator.newPassCode(user.getProvisionalOtpKey())).thenReturn(654321);
 
         when(notificationService.sendSecondFactorPasscodeSms(any(String.class), eq("654321"), eq(CHANGE_SIGN_IN_2FA_TO_SMS)))
-                .thenThrow(AdminUsersExceptions.userNotificationError());
+                .thenThrow(AdminUsersExceptions.userNotificationError(new Exception("Cause")));
 
         Optional<SecondFactorToken> tokenOptional = existingUserOtpDispatcher.sendChangeSignMethodToSmsOtp(user.getExternalId());
 

--- a/src/test/java/uk/gov/pay/adminusers/service/ForgottenPasswordServicesTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ForgottenPasswordServicesTest.java
@@ -90,7 +90,7 @@ public class ForgottenPasswordServicesTest {
         when(mockUser.getEmail()).thenReturn(email);
         when(userDao.findByUsername(username)).thenReturn(Optional.of(mockUser));
         when(mockNotificationService.sendForgottenPasswordEmail(eq(email), matches("^http://selfservice/reset-password/[0-9a-z]{32}$")))
-                .thenThrow(AdminUsersExceptions.userNotificationError());
+                .thenThrow(AdminUsersExceptions.userNotificationError(new Exception("Cause")));
         doNothing().when(forgottenPasswordDao).persist(any(ForgottenPasswordEntity.class));
 
         forgottenPasswordServices.create(username);

--- a/src/test/java/uk/gov/pay/adminusers/service/InviteServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/InviteServiceTest.java
@@ -235,7 +235,7 @@ public class InviteServiceTest {
         when(mockSecondFactorAuthenticator.newPassCode(otpKey)).thenReturn(passCode);
         when(mockInviteDao.merge(any(InviteEntity.class))).thenReturn(inviteEntity);
         when(mockNotificationService.sendSecondFactorPasscodeSms(eq(TELEPHONE_NUMBER), eq(valueOf(passCode)), eq(SELF_INITIATED_CREATE_NEW_USER_AND_SERVICE)))
-                .thenThrow(AdminUsersExceptions.userNotificationError());
+                .thenThrow(AdminUsersExceptions.userNotificationError(new Exception("Cause")));
 
         inviteService.reGenerateOtp(inviteOtpRequestFrom(inviteCode, TELEPHONE_NUMBER, PLAIN_PASSWORD));
 
@@ -271,7 +271,7 @@ public class InviteServiceTest {
         when(mockSecondFactorAuthenticator.newPassCode(otpKey)).thenReturn(passCode);
         when(mockInviteDao.merge(any(InviteEntity.class))).thenReturn(inviteEntity);
         when(mockNotificationService.sendSecondFactorPasscodeSms(eq(TELEPHONE_NUMBER), eq(valueOf(passCode)),
-                eq(CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE))).thenThrow(AdminUsersExceptions.userNotificationError());
+                eq(CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE))).thenThrow(AdminUsersExceptions.userNotificationError(new Exception("Cause")));
 
         inviteService.reGenerateOtp(inviteOtpRequestFrom(inviteCode, TELEPHONE_NUMBER, PLAIN_PASSWORD));
 

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCreatorTest.java
@@ -105,7 +105,7 @@ public class ServiceInviteCreatorTest {
         when(userDao.findByEmail(email)).thenReturn(Optional.empty());
         when(inviteDao.findByEmail(email)).thenReturn(emptyList());
         when(roleDao.findByRoleName("admin")).thenReturn(Optional.of(roleEntity));
-        when(notificationService.sendServiceInviteEmail(eq(email), anyString())).thenThrow(AdminUsersExceptions.userNotificationError());
+        when(notificationService.sendServiceInviteEmail(eq(email), anyString())).thenThrow(AdminUsersExceptions.userNotificationError(new Exception("Cause")));
         when(linksConfig.getSelfserviceUrl()).thenReturn("http://selfservice");
         when(linksConfig.getSelfserviceInvitesUrl()).thenReturn("http://selfservice/invites");
         Invite invite = serviceInviteCreator.doInvite(request);

--- a/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
@@ -116,7 +116,7 @@ public class UserInviteCreatorTest {
         mockInviteSuccessForNonExistingUserNonExistingInvite();
 
         when(mockNotificationService.sendInviteEmail(eq(senderEmail), eq(email), matches("^http://selfservice/invites/[0-9a-z]{32}$")))
-                .thenThrow(AdminUsersExceptions.userNotificationError());
+                .thenThrow(AdminUsersExceptions.userNotificationError(new Exception("Cause")));
 
         userInviteCreator.doInvite(inviteRequestFrom(senderExternalId, email, roleName));
 
@@ -235,7 +235,7 @@ public class UserInviteCreatorTest {
         InviteEntity anInvite = mockInviteSuccessExistingInvite();
         when(mockNotificationService.sendInviteExistingUserEmail(eq(senderEmail), eq(email), matches("^http://selfservice/invites/[0-9a-z]{32}$"),
                 eq(anInvite.getService().getServiceNames().get(SupportedLanguage.ENGLISH).getName())))
-                .thenThrow(AdminUsersExceptions.userNotificationError());
+                .thenThrow(AdminUsersExceptions.userNotificationError(new Exception("Cause")));
 
         InviteUserRequest inviteUserRequest = inviteRequestFrom(senderExternalId, email, roleName);
         Optional<Invite> invite = userInviteCreator.doInvite(inviteUserRequest);


### PR DESCRIPTION
Log the exception message when sending an email fails.

Pass along the original exception when throwing a
WebApplicationException so that more information gets to Sentry.