### PR TITLE
PP-9278 Fix deserialisation of SNS message

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/queue/event/EventSubscriberQueue.java
+++ b/src/main/java/uk/gov/pay/adminusers/queue/event/EventSubscriberQueue.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.adminusers.app.config.AdminUsersConfig;
 import uk.gov.pay.adminusers.queue.model.Event;
 import uk.gov.pay.adminusers.queue.model.EventMessage;
+import uk.gov.pay.adminusers.queue.model.SNSMessage;
 import uk.gov.service.payments.commons.queue.exception.QueueException;
 import uk.gov.service.payments.commons.queue.model.QueueMessage;
 import uk.gov.service.payments.commons.queue.sqs.AbstractQueue;
@@ -41,7 +42,8 @@ public class EventSubscriberQueue extends AbstractQueue {
 
     private EventMessage deserializeMessage(QueueMessage queueMessage) {
         try {
-            Event event = objectMapper.readValue(queueMessage.getMessageBody(), Event.class);
+            SNSMessage snsMessage = objectMapper.readValue(queueMessage.getMessageBody(), SNSMessage.class);
+            Event event = objectMapper.readValue(snsMessage.getMessage(), Event.class);
 
             return EventMessage.of(event, queueMessage);
         } catch (IOException e) {

--- a/src/main/java/uk/gov/pay/adminusers/queue/model/SNSMessage.java
+++ b/src/main/java/uk/gov/pay/adminusers/queue/model/SNSMessage.java
@@ -1,0 +1,18 @@
+package uk.gov.pay.adminusers.queue.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SNSMessage {
+    @JsonProperty("Message")
+    private String message;
+
+    public SNSMessage() {
+        // for deserialization
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/queue/event/EventSubscriberQueueTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/queue/event/EventSubscriberQueueTest.java
@@ -64,8 +64,8 @@ class EventSubscriberQueueTest {
         String parentResourceExternalId = "parent-id";
         String eventType = "PAYMENT_CREATED";
 
-        String validJsonMessage = new GsonBuilder().create()
-                .toJson(Map.of(
+        String messageBody = new GsonBuilder().create().toJson(
+                Map.of(
                         "service_id", serviceId,
                         "resource_external_id", resourceExternalId,
                         "parent_resource_external_id", parentResourceExternalId,
@@ -73,6 +73,8 @@ class EventSubscriberQueueTest {
                         "event_details", eventDetails,
                         "ignored_field", "to check we are ignoring fields we don't care about"
                 ));
+        String validJsonMessage = new GsonBuilder().create()
+                .toJson(Map.of("Message", messageBody));
 
         var sendMessageResult = mock(SendMessageResult.class);
         List<QueueMessage> messages = List.of(


### PR DESCRIPTION
Event message is contained as an escaped string inside the "Message" field of an SNS message. Fix deserialisation to deal with this.