### PR TITLE
ZD4919143 Add `achievingforchildren.org.uk` domain to email allow list

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/utils/email/EmailValidator.java
@@ -17,6 +17,7 @@ public class EmailValidator {
     private static final List<String> PUBLIC_SECTOR_EMAIL_DOMAIN_REGEX_PATTERNS_IN_ASCENDING_ORDER = List.of(
             "acas.org.uk",
             "accessplanit.com",
+            "achievingforchildren.org.uk",
             "assembly.wales",
             "beechpc.com",
             "bl.uk",

--- a/src/test/java/uk/gov/pay/adminusers/utils/email/EmailValidatorIsPublicSectorEmailTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/email/EmailValidatorIsPublicSectorEmailTest.java
@@ -48,6 +48,7 @@ class EmailValidatorIsPublicSectorEmailTest {
                 // all valid emails with domains
                 {"valid@acas.org.uk", true},
                 {"valid@accessplanit.com", true},
+                {"valid@achievingforchildren.org.uk", true},
                 {"valid@assembly.wales", true},
                 {"valid@beechpc.com", true},
                 {"valid@bl.uk", true},
@@ -96,6 +97,7 @@ class EmailValidatorIsPublicSectorEmailTest {
                 // all valid emails with subdomains
                 {"valid@subdomain.acas.org.uk", true},
                 {"valid@subdomain.accessplanit.com", true},
+                {"valid@subdomain.achievingforchildren.org.uk", true},
                 {"valid@subdomain.assembly.wales", true},
                 {"valid@subdomain.beechpc.com", true},
                 {"valid@subdomain.bl.uk", true},


### PR DESCRIPTION
Allow emails from the domain achievingforchildren.org.uk to create
accounts. Reference ZD#4919143.