### PR TITLE
PP-9281 Fix date format in dispute email

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/queue/event/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/adminusers/queue/event/EventMessageHandler.java
@@ -37,6 +37,8 @@ import static uk.gov.service.payments.logging.LoggingKeys.SERVICE_EXTERNAL_ID;
 
 public class EventMessageHandler {
 
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("d MMMM yyyy"); // 9 March 2022
+    
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final EventSubscriberQueue eventSubscriberQueue;
     private final LedgerService ledgerService;
@@ -44,7 +46,6 @@ public class EventMessageHandler {
     private final ServiceFinder serviceFinder;
     private final UserServices userServices;
     private final ObjectMapper objectMapper;
-    private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd, LLLL yyyy"); // 09, March 2022
 
     @Inject
     public EventMessageHandler(EventSubscriberQueue eventSubscriberQueue, 
@@ -99,8 +100,8 @@ public class EventMessageHandler {
         List<UserEntity> serviceAdmins = userServices.getAdminUsersForService(service);
 
         var epoch = disputeCreatedDetails.getEvidenceDueDate();
-        String formattedDueDate = getZDTForEpoch(epoch).format(dateTimeFormatter);
-        String formattedPayDueDate = getPayDueByDateForEpoch(epoch).format(dateTimeFormatter);
+        String formattedDueDate = getZDTForEpoch(epoch).format(DATE_TIME_FORMATTER);
+        String formattedPayDueDate = getPayDueByDateForEpoch(epoch).format(DATE_TIME_FORMATTER);
 
         var paymentAmountInPounds = convertPenceToPounds.apply(disputeCreatedDetails.getAmount()).toString();
         var disputeFeeInPounds = convertPenceToPounds.apply(disputeCreatedDetails.getFee()).toString();

--- a/src/test/java/uk/gov/pay/adminusers/queue/event/EventMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/queue/event/EventMessageHandlerTest.java
@@ -156,8 +156,8 @@ class EventMessageHandlerTest {
         assertThat(personalisation.get("serviceReference"), is("tx ref"));
         assertThat(personalisation.get("paymentAmount"), is("210.00"));
         assertThat(personalisation.get("disputeFee"), is("15.00"));
-        assertThat(personalisation.get("disputeEvidenceDueDate"), is("07, March 2022"));
-        assertThat(personalisation.get("sendEvidenceToPayDueDate"), is("04, March 2022"));
+        assertThat(personalisation.get("disputeEvidenceDueDate"), is("7 March 2022"));
+        assertThat(personalisation.get("sendEvidenceToPayDueDate"), is("4 March 2022"));
 
         verify(mockLogAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
 


### PR DESCRIPTION
Remove the comma to adhere to the GOV.UK style guide
https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates