### PR TITLE
PP-9281 Look up service by gateway account id

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/queue/model/Event.java
+++ b/src/main/java/uk/gov/pay/adminusers/queue/model/Event.java
@@ -10,7 +10,6 @@ import java.util.Objects;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Event {
     
-    private String serviceId;
     private String resourceExternalId;
     private String parentResourceExternalId;
     private String eventType;
@@ -20,20 +19,14 @@ public class Event {
         // for deserialization
     }
     
-    public Event(String serviceId,
-                 String resourceExternalId,
+    public Event(String resourceExternalId,
                  String parentResourceExternalId,
                  String eventType,
                  String eventDetails) {
-        this.serviceId = serviceId;
         this.resourceExternalId = resourceExternalId;
         this.parentResourceExternalId = parentResourceExternalId;
         this.eventType = eventType;
         this.eventDetails = eventDetails;
-    }
-
-    public String getServiceId() {
-        return serviceId;
     }
 
     public String getResourceExternalId() {
@@ -55,11 +48,10 @@ public class Event {
     @Override
     public String toString() {
         return "Event{" +
-                "serviceId='" + serviceId + '\'' +
-                ", resourceExternalId='" + resourceExternalId + '\'' +
+                "resourceExternalId='" + resourceExternalId + '\'' +
                 ", parentResourceExternalId='" + parentResourceExternalId + '\'' +
                 ", eventType='" + eventType + '\'' +
-                ", eventDetails=" + eventDetails +
+                ", eventDetails='" + eventDetails + '\'' +
                 '}';
     }
 
@@ -68,11 +60,11 @@ public class Event {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Event event = (Event) o;
-        return Objects.equals(serviceId, event.serviceId) && Objects.equals(resourceExternalId, event.resourceExternalId) && Objects.equals(parentResourceExternalId, event.parentResourceExternalId) && Objects.equals(eventType, event.eventType) && Objects.equals(eventDetails, event.eventDetails);
+        return Objects.equals(resourceExternalId, event.resourceExternalId) && Objects.equals(parentResourceExternalId, event.parentResourceExternalId) && Objects.equals(eventType, event.eventType) && Objects.equals(eventDetails, event.eventDetails);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(serviceId, resourceExternalId, parentResourceExternalId, eventType, eventDetails);
+        return Objects.hash(resourceExternalId, parentResourceExternalId, eventType, eventDetails);
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/queue/model/event/DisputeCreatedDetails.java
+++ b/src/main/java/uk/gov/pay/adminusers/queue/model/event/DisputeCreatedDetails.java
@@ -12,6 +12,7 @@ public class DisputeCreatedDetails {
     private Long amount;
     private Long fee;
     private Long evidenceDueDate;
+    private String gatewayAccountId;
     
     public DisputeCreatedDetails() {
         // empty constructor
@@ -28,4 +29,6 @@ public class DisputeCreatedDetails {
     public long getEvidenceDueDate() {
         return evidenceDueDate;
     }
+    
+    public String getGatewayAccountId() { return gatewayAccountId; }
 }

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/EventFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/EventFixture.java
@@ -4,7 +4,6 @@ import uk.gov.pay.adminusers.queue.model.Event;
 
 public class EventFixture {
     
-    private String serviceId = "a-service-id";
     private String resourceExternalId = "a-resource-external-id";
     private String parentResourceExternalId;
     private String eventType = "AN_EVENT_TYPE";
@@ -15,11 +14,6 @@ public class EventFixture {
     
     public static EventFixture anEventFixture() {
         return new EventFixture();
-    }
-    
-    public EventFixture withServiceId(String serviceId) {
-        this.serviceId = serviceId;
-        return this;
     }
     
     public EventFixture withResourceExternalId(String resourceExternalId) {
@@ -44,7 +38,6 @@ public class EventFixture {
     
     public Event build() {
         return new Event(
-                serviceId,
                 resourceExternalId,
                 parentResourceExternalId,
                 eventType,

--- a/src/test/java/uk/gov/pay/adminusers/queue/event/EventSubscriberQueueTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/queue/event/EventSubscriberQueueTest.java
@@ -68,7 +68,6 @@ class EventSubscriberQueueTest {
         List<EventMessage> eventMessages = eventSubscriberQueue.retrieveEvents();
         assertThat(eventMessages, hasSize(1));
         Event event = eventMessages.get(0).getEvent();
-        assertThat(event.getServiceId(), is("5e0207ee342048d4ac4d1d05dd9ek3js"));
         assertThat(event.getResourceExternalId(), is("dp_1KfoljHj08j2jFuBkNEd89sd"));
         assertThat(event.getParentResourceExternalId(), is("pk8vak8vfiii5hjvqpsa4dsd"));
         assertThat(event.getEventType(), is("DISPUTE_CREATED"));

--- a/src/test/java/uk/gov/pay/adminusers/queue/model/event/DisputeCreatedDetailsTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/queue/model/event/DisputeCreatedDetailsTest.java
@@ -26,5 +26,6 @@ class DisputeCreatedDetailsTest {
         assertThat(disputeCreatedDetails.getFee(), is(1500L));
         assertThat(disputeCreatedDetails.getAmount(), is(125000L));
         assertThat(disputeCreatedDetails.getEvidenceDueDate(), is(1648745127L));
+        assertThat(disputeCreatedDetails.getGatewayAccountId(), is("123"));
     }
 }


### PR DESCRIPTION
Due to issues with how ledger is projecting transactions from events,
there is a bug where the service_id on a transaction is overwritten to
null when an event, such as PAYMENT_INCLUDED_IN_PAYOUT doesn't send a
service_id.

This means that for now at least we have to rely on the
gateway_account_id, which is also sent in the event details to look up
the service.