### PR TITLE
PP-8827: Endpoint to remove user from service

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/app/AdminUsersApp.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/AdminUsersApp.java
@@ -31,6 +31,7 @@ import uk.gov.pay.adminusers.resources.InvalidMerchantDetailsExceptionMapper;
 import uk.gov.pay.adminusers.resources.InviteResource;
 import uk.gov.pay.adminusers.resources.ResetPasswordResource;
 import uk.gov.pay.adminusers.resources.ServiceResource;
+import uk.gov.pay.adminusers.resources.ToolboxEndpointResource;
 import uk.gov.pay.adminusers.resources.UserResource;
 import uk.gov.service.payments.commons.utils.healthchecks.DatabaseHealthCheck;
 import uk.gov.service.payments.commons.utils.metrics.DatabaseMetricsService;
@@ -85,6 +86,7 @@ public class AdminUsersApp extends Application<AdminUsersConfig> {
         environment.healthChecks().register("database", new DatabaseHealthCheck(configuration.getDataSourceFactory()));
         environment.jersey().register(injector.getInstance(UserResource.class));
         environment.jersey().register(injector.getInstance(ServiceResource.class));
+        environment.jersey().register(injector.getInstance(ToolboxEndpointResource.class));
         environment.jersey().register(injector.getInstance(ForgottenPasswordResource.class));
         environment.jersey().register(injector.getInstance(InviteResource.class));
         environment.jersey().register(injector.getInstance(ResetPasswordResource.class));

--- a/src/main/java/uk/gov/pay/adminusers/resources/ToolboxEndpointResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ToolboxEndpointResource.java
@@ -1,0 +1,41 @@
+package uk.gov.pay.adminusers.resources;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.adminusers.service.ServiceServicesFactory;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.Response.Status.NO_CONTENT;
+
+@Path("/v1/api/toolbox")
+public class ToolboxEndpointResource {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ToolboxEndpointResource.class);
+
+    private final ServiceServicesFactory serviceServicesFactory;
+
+    @Inject
+    public ToolboxEndpointResource(ServiceServicesFactory serviceServicesFactory) {
+        this.serviceServicesFactory = serviceServicesFactory;
+    }
+
+    @Path("/services/{serviceExternalId}/users/{userExternalId}")
+    @DELETE
+    @Produces(APPLICATION_JSON)
+    @Consumes(APPLICATION_JSON)
+    public Response removeUserFromService(@PathParam("serviceExternalId") String serviceExternalId,
+                                          @PathParam("userExternalId") String userExternalId) {
+        LOGGER.info("Toolbox DELETE request - serviceExternalId={}, userExternalId={}", serviceExternalId, userExternalId);
+        serviceServicesFactory.serviceUserRemover().remove(userExternalId, serviceExternalId);
+        LOGGER.info("Succeeded toolbox users DELETE request - serviceExternalId={}, userExternalId={}", serviceExternalId, userExternalId);
+        return Response.status(NO_CONTENT).build();
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/resources/ToolboxEndpointResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ToolboxEndpointResource.java
@@ -2,7 +2,7 @@ package uk.gov.pay.adminusers.resources;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.adminusers.service.ServiceServicesFactory;
+import uk.gov.pay.adminusers.service.ServiceUserRemover;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -12,19 +12,23 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 
+import static java.lang.String.format;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.service.payments.logging.LoggingKeys.SERVICE_EXTERNAL_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.USER_EXTERNAL_ID;
 
 @Path("/v1/api/toolbox")
 public class ToolboxEndpointResource {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ToolboxEndpointResource.class);
 
-    private final ServiceServicesFactory serviceServicesFactory;
+    private final ServiceUserRemover serviceUserRemover;
 
     @Inject
-    public ToolboxEndpointResource(ServiceServicesFactory serviceServicesFactory) {
-        this.serviceServicesFactory = serviceServicesFactory;
+    public ToolboxEndpointResource(ServiceUserRemover serviceUserRemover) {
+        this.serviceUserRemover = serviceUserRemover;
     }
 
     @Path("/services/{serviceExternalId}/users/{userExternalId}")
@@ -33,9 +37,13 @@ public class ToolboxEndpointResource {
     @Consumes(APPLICATION_JSON)
     public Response removeUserFromService(@PathParam("serviceExternalId") String serviceExternalId,
                                           @PathParam("userExternalId") String userExternalId) {
-        LOGGER.info("Toolbox DELETE request - serviceExternalId={}, userExternalId={}", serviceExternalId, userExternalId);
-        serviceServicesFactory.serviceUserRemover().remove(userExternalId, serviceExternalId);
-        LOGGER.info("Succeeded toolbox users DELETE request - serviceExternalId={}, userExternalId={}", serviceExternalId, userExternalId);
+        LOGGER.info(format("Toolbox DELETE request - removing user %s from service %s,", serviceExternalId, userExternalId),
+                kv(SERVICE_EXTERNAL_ID, serviceExternalId),
+                kv(USER_EXTERNAL_ID, userExternalId));
+        serviceUserRemover.removeWithoutAdminCheck(userExternalId, serviceExternalId);
+        LOGGER.info(format("Succeeded toolbox users DELETE request - user %s removed from service %s", serviceExternalId, userExternalId),
+                kv(SERVICE_EXTERNAL_ID, serviceExternalId),
+                kv(USER_EXTERNAL_ID, userExternalId));
         return Response.status(NO_CONTENT).build();
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceUserRemover.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceUserRemover.java
@@ -38,7 +38,7 @@ public class ServiceUserRemover {
         serviceRoleDao.remove(userServiceRoleToRemove);
     }
     
-    public void remove(String userExternalId, String serviceExternalId) {
+    public void removeWithoutAdminCheck(String userExternalId, String serviceExternalId) {
 
         LOGGER.info("User remove from toolbox requested - serviceId={}, userId={}", serviceExternalId, userExternalId);
 

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceUserRemover.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceUserRemover.java
@@ -37,6 +37,15 @@ public class ServiceUserRemover {
 
         serviceRoleDao.remove(userServiceRoleToRemove);
     }
+    
+    public void remove(String userExternalId, String serviceExternalId) {
+
+        LOGGER.info("User remove from toolbox requested - serviceId={}, userId={}", serviceExternalId, userExternalId);
+
+        ServiceRoleEntity userServiceRoleToRemove = getServiceRoleEntityOf(userExternalId, serviceExternalId);
+
+        serviceRoleDao.remove(userServiceRoleToRemove);
+    }
 
     private Optional<ServiceRoleEntity> checkRemoverIsAdmin(String removerExternalId, String serviceExternalId) {
         return userDao.findByExternalId(removerExternalId)

--- a/src/test/java/uk/gov/pay/adminusers/resources/ToolboxEndpointResourceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ToolboxEndpointResourceIT.java
@@ -1,0 +1,78 @@
+package uk.gov.pay.adminusers.resources;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.adminusers.model.Role;
+import uk.gov.pay.adminusers.model.Service;
+import uk.gov.pay.adminusers.model.User;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.http.ContentType.JSON;
+import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsIterableContaining.hasItem;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
+import static uk.gov.pay.adminusers.fixtures.RoleDbFixture.roleDbFixture;
+import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
+import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
+
+public class ToolboxEndpointResourceIT extends IntegrationTest {
+
+    private User user;
+    private Role role;
+    private String serviceExternalId;
+    
+    @BeforeEach
+    public void setup() {
+        role = roleDbFixture(databaseHelper).withName("roleView").insertRole();
+        
+        Service service = serviceDbFixture(databaseHelper).insertService();
+        serviceExternalId = service.getExternalId();
+
+        String username = "b" + randomUuid();
+        String email = username + "@example.com";
+        user = userDbFixture(databaseHelper)
+                .withServiceRole(service, role.getId())
+                .withUsername(username)
+                .withEmail(email)
+                .insertUser();
+    }
+    
+    @Test
+    public void should_remove_user_from_service() {
+        List<Map<String, Object>> serviceRoleForUserBefore = databaseHelper.findServiceRoleForUser(user.getId());
+        assertThat(serviceRoleForUserBefore.size(), is(1));
+
+        givenSetup()
+                .when()
+                .accept(JSON)
+                .get(format("/v1/api/services/%s/users", serviceExternalId))
+                .then()
+                .body("$", hasItem(allOf(hasEntry("username", user.getUsername()))));
+
+        givenSetup()
+                .when()
+                .accept(JSON)
+                .delete(format("/v1/api/toolbox/services/%s/users/%s", serviceExternalId, user.getExternalId()))
+                .then()
+                .statusCode(204)
+                .body(emptyString());
+
+        List<Map<String, Object>> serviceRoleForUserAfter = databaseHelper.findServiceRoleForUser(user.getId());
+        assertThat(serviceRoleForUserAfter.isEmpty(), is(true));
+
+        givenSetup()
+                .when()
+                .accept(JSON)
+                .get(format("/v1/api/services/%s/users", serviceExternalId))
+                .then()
+                .body("$", not(hasItem(allOf(hasEntry("username", user.getUsername())))));
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceUserRemoverTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceUserRemoverTest.java
@@ -68,7 +68,7 @@ public class ServiceUserRemoverTest {
 
         when(mockUserDao.findByExternalId(userExternalId)).thenReturn(Optional.of(userToBeRemoved));
 
-        service.remove(userExternalId, serviceExternalId);
+        service.removeWithoutAdminCheck(userExternalId, serviceExternalId);
 
         verify(mockServiceRoleDao).remove(userServiceRole);
     }

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceUserRemoverTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceUserRemoverTest.java
@@ -59,6 +59,21 @@ public class ServiceUserRemoverTest {
     }
 
     @Test
+    public void should_remove_user_from_service_by_toolbox() {
+        String serviceExternalId = "service-external-id-1";
+        String userExternalId = "user-to-be-removed-from-service-1";
+
+        ServiceRoleEntity userServiceRole = aServiceRole(serviceExternalId, 666);
+        UserEntity userToBeRemoved = createUser(userExternalId, userServiceRole);
+
+        when(mockUserDao.findByExternalId(userExternalId)).thenReturn(Optional.of(userToBeRemoved));
+
+        service.remove(userExternalId, serviceExternalId);
+
+        verify(mockServiceRoleDao).remove(userServiceRole);
+    }
+    
+    @Test
     public void remove_shouldThrowNotFoundWebApplicationException_whenUserToBeRemovedDoesNotExist() {
 
         String serviceExternalId = "service-external-id-1";


### PR DESCRIPTION
Given that users need to be in the alphagov organisation in GitHub in order to
be authenticated with toolbox, it should be fairly safe to expose an endpoint
to remove a user from a service without requiring a "GovUkPay-User-Context"
header. Note that the original `DELETE
/v1/api/services/{serviceExternalId}/users/{userExternalId}` endpoint is still
valid and is used by selfservice. In order to make it clear `DELETE
/v1/api/toolbox/services/{serviceExternalId}/users/{userExternalId}` is for
toolbox use only we've placed the implementation in
ToolboxEndpointResource.java for clarity.
