### PR TITLE
PP-9443 New toolbox search endpoint for services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,7 @@ target
 
 bin
 
+dependency-reduced-pom.xml
+
 .DS_Store
 /pacts/

--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -371,6 +371,33 @@ paths:
       summary: Get all services
       tags:
       - Services
+  /v1/api/services/search:
+    post:
+      description: This endpoint returns a list of services using lexical meaning
+        to determine a match to the search criteria
+      operationId: searchServices
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+              example:
+                service_name: service name
+                service_merchant_name: service merchant name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Service'
+          description: OK
+        "400":
+          description: Invalid JSON payload
+      summary: Search services by name or merchant name
+      tags:
+      - Toolbox
   /v1/api/services/{serviceExternalId}:
     get:
       operationId: findService

--- a/src/main/java/uk/gov/pay/adminusers/model/ServiceSearchRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/ServiceSearchRequest.java
@@ -1,0 +1,42 @@
+package uk.gov.pay.adminusers.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class ServiceSearchRequest {
+
+    private static final String FIELD_SERVICE_NAME = "service_name";
+    private static final String FIELD_SERVICE_MERCHANT_NAME = "service_merchant_name";
+
+    private final String serviceNameSearchString;
+    private final String serviceMerchantNameSearchString;
+
+    public ServiceSearchRequest(String serviceName, String serviceMerchantName) {
+        this.serviceNameSearchString = serviceName;
+        this.serviceMerchantNameSearchString = serviceMerchantName;
+    }
+
+    public static ServiceSearchRequest from(JsonNode payload) {
+        String serviceName = Optional.ofNullable(payload.get(FIELD_SERVICE_NAME))
+                .map(JsonNode::asText)
+                .orElse("");
+        String serviceOrg = Optional.ofNullable(payload.get(FIELD_SERVICE_MERCHANT_NAME))
+                .map(JsonNode::asText)
+                .orElse("");
+        return new ServiceSearchRequest(serviceName, serviceOrg);
+    }
+
+    public String getServiceNameSearchString() {
+        return serviceNameSearchString;
+    }
+
+    public String getServiceMerchantNameSearchString() {
+        return serviceMerchantNameSearchString;
+    }
+
+    public Map<String, String> toMap() {
+        return Map.of(FIELD_SERVICE_NAME, serviceNameSearchString, FIELD_SERVICE_MERCHANT_NAME, serviceMerchantNameSearchString);
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/persistence/dao/ServiceDao.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/dao/ServiceDao.java
@@ -24,6 +24,22 @@ public class ServiceDao extends JpaDao<ServiceEntity> {
                 .createQuery(query, ServiceEntity.class)
                 .getResultList();
     }
+    
+    @SuppressWarnings("unchecked")
+    public List<ServiceEntity> findByENServiceName(String searchString) {
+        String query = "SELECT * FROM services s WHERE s.id IN (SELECT service_id FROM service_names sn WHERE to_tsvector('english', sn.name) @@ plainto_tsquery('english', ?) AND sn.language = 'en')";
+        return entityManager.get().createNativeQuery(query, ServiceEntity.class)
+                .setParameter(1, searchString)
+                .getResultList();
+    }
+    
+    @SuppressWarnings("unchecked")
+    public List<ServiceEntity> findByServiceMerchantName(String searchString) {
+        String query = "SELECT * FROM services s WHERE to_tsvector('english', s.merchant_name) @@ plainto_tsquery('english', ?)";
+        return entityManager.get().createNativeQuery(query, ServiceEntity.class)
+                .setParameter(1, searchString)
+                .getResultList();
+    }
 
     public Optional<ServiceEntity> findByGatewayAccountId(String gatewayAccountId) {
 

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceFinder.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceFinder.java
@@ -2,9 +2,17 @@ package uk.gov.pay.adminusers.service;
 
 import com.google.inject.Inject;
 import uk.gov.pay.adminusers.model.Service;
+import uk.gov.pay.adminusers.model.ServiceSearchRequest;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
+import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public class ServiceFinder {
 
@@ -25,5 +33,18 @@ public class ServiceFinder {
     public Optional<Service> byExternalId(String externalId) {
         return serviceDao.findByExternalId(externalId)
                 .map(serviceEntity -> linksBuilder.decorate(serviceEntity.toService()));
+    }
+    
+    public Map<String, List<?>> bySearchRequest(ServiceSearchRequest request) {
+        var servicesByName = !isBlank(request.getServiceNameSearchString()) ? streamServiceEntitiesToServices(serviceDao
+                .findByENServiceName(request.getServiceNameSearchString())) : Collections.emptyList();
+        var servicesByMerchantName = !isBlank(request.getServiceMerchantNameSearchString()) ? streamServiceEntitiesToServices(serviceDao
+                .findByServiceMerchantName(request.getServiceMerchantNameSearchString())) : Collections.emptyList();
+        return Map.of("name_results", servicesByName, "merchant_results", servicesByMerchantName);
+    }
+    
+    private List<Service> streamServiceEntitiesToServices (List<ServiceEntity> serviceEntities) {
+        return serviceEntities.stream().map(serviceEntity -> linksBuilder.decorate(serviceEntity.toService()))
+                .collect(Collectors.toUnmodifiableList());
     }
 }

--- a/src/main/resources/migrations/00077_alter_table_service_names_add_fts_index.sql
+++ b/src/main/resources/migrations/00077_alter_table_service_names_add_fts_index.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_fts_index_for_service_names_on_name
+CREATE INDEX name_fts_index on service_names using gin (to_tsvector('english', name));

--- a/src/main/resources/migrations/00078_alter_table_services_add_fts_index.sql
+++ b/src/main/resources/migrations/00078_alter_table_services_add_fts_index.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_fts_index_for_services_on_merchant_name
+CREATE INDEX merchant_name_fts_index on services using gin (to_tsvector('english', merchant_name));

--- a/src/test/java/uk/gov/pay/adminusers/model/ServiceSearchRequestTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/ServiceSearchRequestTest.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.adminusers.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.core.Is.is;
+
+class ServiceSearchRequestTest {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void shouldDeserialiseCorrectly() throws JsonProcessingException {
+        var searchRequest = ServiceSearchRequest.from(mapper.readTree("{\"service_name\": \"serv name\", \"service_merchant_name\": \"merchant name\"}"));
+        assertThat(searchRequest.getServiceNameSearchString(), is("serv name"));
+        assertThat(searchRequest.getServiceMerchantNameSearchString(), is("merchant name"));
+    }
+
+    @Test
+    void shouldSetDefaultEmptyStrings_onMalformedJSON() throws JsonProcessingException {
+        var searchRequest = ServiceSearchRequest.from(mapper.readTree("{\"random_key\": \"random val\", \"random_key2\": \"random val\"}"));
+        assertThat(searchRequest.getServiceNameSearchString(), is(""));
+        assertThat(searchRequest.getServiceMerchantNameSearchString(), is(""));
+    }
+
+    @Test
+    void shouldReturnMapOfValues() throws JsonProcessingException {
+        var searchRequest = ServiceSearchRequest.from(mapper.readTree("{\"service_name\": \"serv name\", \"service_merchant_name\": \"merchant name\"}"));
+        var mapOfRequest = searchRequest.toMap();
+        mapOfRequest.keySet().forEach(key -> assertThat(mapOfRequest.get(key), anyOf(equalTo("serv name"), equalTo("merchant name"))));
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceFinderTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceFinderTest.java
@@ -6,15 +6,25 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.adminusers.model.Service;
+import uk.gov.pay.adminusers.model.ServiceSearchRequest;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
+import uk.gov.pay.adminusers.persistence.entity.ServiceEntityBuilder;
 import uk.gov.pay.adminusers.persistence.entity.service.ServiceNameEntity;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 
@@ -61,6 +71,66 @@ public class ServiceFinderTest {
         assertThat(serviceOptional.get().getGatewayAccountIds().get(0), is(gatewayAccountId));
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldReturnServices_whenSearchingByServiceName() {
+        var serviceEntities = generateServiceEntities("serv 1", "serv 2");
+        when(serviceDao.findByENServiceName("serv")).thenReturn(serviceEntities);
+        var searchRequest = new ServiceSearchRequest("serv", "");
+        var results = serviceFinder.bySearchRequest(searchRequest);
+        var servicesByName = (List<Service>) results.get("name_results");
+        var servicesByMerchant = (List<Service>) serviceFinder.bySearchRequest(searchRequest).get("merchant_results");
+        assertThat(servicesByName.size(), is(2));
+        assertThat(servicesByName.stream().map(Service::getName).collect(Collectors.toSet()), containsInAnyOrder("serv 1", "serv 2"));
+        assertThat(servicesByMerchant, is(empty()));
+        verify(serviceDao, never()).findByServiceMerchantName(anyString());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldReturnServices_whenSearchingByServiceMerchantName() {
+        var serviceEntities = generateServiceEntities("serv 3", "serv 4");
+        when(serviceDao.findByServiceMerchantName("merchant name")).thenReturn(serviceEntities);
+        var searchRequest = new ServiceSearchRequest("", "merchant name");
+        var results = serviceFinder.bySearchRequest(searchRequest);
+        var servicesByName = (List<Service>) results.get("name_results");
+        var servicesByMerchant = (List<Service>) serviceFinder.bySearchRequest(searchRequest).get("merchant_results");
+        assertThat(servicesByMerchant.size(), is(2));
+        assertThat(servicesByMerchant.stream().map(Service::getName).collect(Collectors.toSet()), containsInAnyOrder("serv 3", "serv 4"));
+        assertThat(servicesByName, is(empty()));
+        verify(serviceDao, never()).findByENServiceName(anyString());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldReturnServices_whenSearchingByServiceNameAndMerchantName() {
+        var serviceEntities1 = generateServiceEntities("serv 1", "serv 2");
+        var serviceEntities2 = generateServiceEntities("serv 3", "serv 4");
+        when(serviceDao.findByENServiceName("serv")).thenReturn(serviceEntities1);
+        when(serviceDao.findByServiceMerchantName("merchant name")).thenReturn(serviceEntities2);
+        var searchRequest = new ServiceSearchRequest("serv", "merchant name");
+        var results = serviceFinder.bySearchRequest(searchRequest);
+        var servicesByName = (List<Service>) results.get("name_results");
+        var servicesByMerchant = (List<Service>) serviceFinder.bySearchRequest(searchRequest).get("merchant_results");
+        assertThat(servicesByName.size(), is(2));
+        assertThat(servicesByMerchant.size(), is(2));
+        assertThat(servicesByName.stream().map(Service::getName).collect(Collectors.toSet()), containsInAnyOrder("serv 1", "serv 2"));
+        assertThat(servicesByMerchant.stream().map(Service::getName).collect(Collectors.toSet()), containsInAnyOrder("serv 3", "serv 4"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldReturnEmptyLists_whenSearchRequestParamsAreBlank() {
+        var searchRequest = new ServiceSearchRequest("", "");
+        var results = serviceFinder.bySearchRequest(searchRequest);
+        var servicesByName = (List<Service>) results.get("name_results");
+        var servicesByMerchant = (List<Service>) serviceFinder.bySearchRequest(searchRequest).get("merchant_results");
+        verify(serviceDao, never()).findByENServiceName(anyString());
+        verify(serviceDao, never()).findByServiceMerchantName(anyString());
+        assertThat(servicesByName, is(empty()));
+        assertThat(servicesByMerchant, is(empty()));
+    }
+
     @Test
     public void shouldReturnEmpty_ifNotFound() {
         String gatewayAccountId = "1";
@@ -68,6 +138,16 @@ public class ServiceFinderTest {
         Optional<Service> serviceOptional = serviceFinder.byGatewayAccountId(gatewayAccountId);
 
         assertThat(serviceOptional.isPresent(), is(false));
+    }
+
+    private static List<ServiceEntity> generateServiceEntities(String... names) {
+        var serviceEntities = new ArrayList<ServiceEntity>();
+        for (String name : names) {
+            serviceEntities.add(ServiceEntityBuilder.aServiceEntity()
+                    .withServiceNameEntity(SupportedLanguage.ENGLISH, name)
+                    .build());
+        }
+        return serviceEntities;
     }
 
 }

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceSearchTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceSearchTest.java
@@ -1,0 +1,141 @@
+package uk.gov.pay.adminusers.unit.service;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import io.dropwizard.testing.junit5.ResourceExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
+import uk.gov.pay.adminusers.persistence.dao.UserDao;
+import uk.gov.pay.adminusers.persistence.entity.MerchantDetailsEntityBuilder;
+import uk.gov.pay.adminusers.persistence.entity.ServiceEntityBuilder;
+import uk.gov.pay.adminusers.resources.GovUkPayAgreementRequestValidator;
+import uk.gov.pay.adminusers.resources.ServiceRequestValidator;
+import uk.gov.pay.adminusers.resources.ServiceResource;
+import uk.gov.pay.adminusers.service.GovUkPayAgreementService;
+import uk.gov.pay.adminusers.service.SendLiveAccountCreatedEmailService;
+import uk.gov.pay.adminusers.service.ServiceFinder;
+import uk.gov.pay.adminusers.service.ServiceServicesFactory;
+import uk.gov.pay.adminusers.service.StripeAgreementService;
+import uk.gov.pay.adminusers.validations.RequestValidations;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.List;
+
+import static io.dropwizard.testing.FixtureHelpers.fixture;
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
+import static uk.gov.pay.adminusers.resources.ServiceRequestValidator.SERVICE_SEARCH_LENGTH_ERR_MSG;
+import static uk.gov.pay.adminusers.resources.ServiceRequestValidator.SERVICE_SEARCH_SPECIAL_CHARS_ERR_MSG;
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(DropwizardExtensionsSupport.class)
+public class ServiceResourceSearchTest extends ServiceResourceBaseTest {
+
+    // mocks
+    private static final ServiceDao mockServiceDao = mock(ServiceDao.class);
+    private static final UserDao mockUserDao = mock(UserDao.class);
+    private static final StripeAgreementService mockStripeAgreementService = mock(StripeAgreementService.class);
+    private static final GovUkPayAgreementService mockAgreementService = mock(GovUkPayAgreementService.class);
+    private static final SendLiveAccountCreatedEmailService mockSendLiveAccountCreatedEmailService = mock(SendLiveAccountCreatedEmailService.class);
+    private static final ServiceServicesFactory mockedServicesFactory = mock(ServiceServicesFactory.class);
+    private static final GovUkPayAgreementRequestValidator mockPayAgreementRequestValidator = mock(GovUkPayAgreementRequestValidator.class);
+    // --
+
+    private static final ServiceRequestValidator serviceRequestValidator = new ServiceRequestValidator(new RequestValidations(), null);
+    private static final ServiceFinder serviceFinder = new ServiceFinder(mockedServiceDao, LINKS_BUILDER);
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    public static final ResourceExtension underTest = ResourceExtension.builder()
+            .addResource(new ServiceResource(
+                    mockUserDao,
+                    mockServiceDao,
+                    LINKS_BUILDER,
+                    serviceRequestValidator,
+                    mockedServicesFactory,
+                    mockStripeAgreementService,
+                    mockPayAgreementRequestValidator,
+                    mockAgreementService,
+                    mockSendLiveAccountCreatedEmailService))
+            .build();
+
+    @BeforeEach
+    public void setUp() {
+        given(mockedServicesFactory.serviceFinder()).willReturn(serviceFinder);
+    }
+
+    @Test
+    public void shouldOK_andReturnServices_whenMatches() throws JsonProcessingException {
+        var payload = fixture("fixtures/resource/service/post/service-search-request.json");
+        var serviceExternalId = randomUuid();
+        var merchantDetailsEntity = MerchantDetailsEntityBuilder.aMerchantDetailsEntity()
+                .withName("Government Bakery Office")
+                .build();
+        var serviceEntity = ServiceEntityBuilder.aServiceEntity()
+                .withExternalId(serviceExternalId)
+                .withMerchantDetailsEntity(merchantDetailsEntity)
+                .withServiceNameEntity(SupportedLanguage.ENGLISH, "GOV.UK Cake Service")
+                .build();
+
+        given(mockedServiceDao.findByENServiceName("cake")).willReturn(List.of(serviceEntity));
+        given(mockedServiceDao.findByServiceMerchantName("bakery")).willReturn(List.of(serviceEntity));
+
+        var response = underTest.target("/v1/api/services/search").request().post(Entity.json(payload));
+
+        assertThat(response.getStatus(), is(200));
+        var json = mapper.readTree(response.readEntity(String.class));
+        assertThat(json.get("name_results").size(), is(1));
+        assertThat(json.get("merchant_results").size(), is(1));
+        assertThat(json.get("name_results").get(0).get("external_id").asText(), is(serviceExternalId));
+        assertThat(json.get("name_results").get(0).get("name").asText(), is("GOV.UK Cake Service"));
+        assertThat(json.get("merchant_results").get(0).get("external_id").asText(), is(serviceExternalId));
+        assertThat(json.get("merchant_results").get(0).get("merchant_details").get("name").asText(), is("Government Bakery Office"));
+    }
+
+    @Test
+    public void shouldOK_andReturnEmptyResult_whenNoMatches() throws JsonProcessingException {
+        var payload = fixture("fixtures/resource/service/post/service-search-request.json");
+
+        given(mockedServiceDao.findByENServiceName("cake")).willReturn(Collections.emptyList());
+        given(mockedServiceDao.findByServiceMerchantName("bakery")).willReturn(Collections.emptyList());
+
+        var response = underTest.target("/v1/api/services/search").request().post(Entity.json(payload));
+
+        assertThat(response.getStatus(), is(200));
+        var json = mapper.readTree(response.readEntity(String.class));
+        assertThat(json.get("name_results").size(), is(0));
+        assertThat(json.get("merchant_results").size(), is(0));
+    }
+
+    @Test
+    public void shouldError_whenRequestValidationFails() throws JsonProcessingException {
+        var payload = "{\"service_name\": \"!@£$%^\", \"service_merchant_name\": \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}";
+
+        Response response = underTest.target("/v1/api/services/search").request().post(Entity.json(payload));
+
+        assertThat(response.getStatus(), is(400));
+        JsonNode json = mapper.readTree(response.readEntity(String.class));
+        assertThat(json.get("errors").size(), is(2));
+        var errors = List.of(json.get("errors").get(0).asText(), json.get("errors").get(1).asText());
+        errors.forEach(err -> assertThat(err, anyOf(equalTo(SERVICE_SEARCH_LENGTH_ERR_MSG), equalTo(SERVICE_SEARCH_SPECIAL_CHARS_ERR_MSG))));
+        verify(mockServiceDao, never()).findByServiceMerchantName(anyString());
+        verify(mockServiceDao, never()).findByENServiceName(anyString());
+    }
+
+}

--- a/src/test/resources/fixtures/resource/service/post/service-search-request.json
+++ b/src/test/resources/fixtures/resource/service/post/service-search-request.json
@@ -1,0 +1,4 @@
+{
+  "service_name": "cake",
+  "service_merchant_name": "bakery"
+}


### PR DESCRIPTION
## WHAT YOU DID
- added a new POST endpoint for looking up services by their name or associated merchant name
- created two new indices on the `service_names` and `services` tables to improve text search performance on the `name` and `merchant_name` columns
- created new lexeme based vector queries to provide text search in the service dao
