### PR TITLE
PP-9541 Add initial agreements permissions

### DIFF
--- a/src/main/resources/migrations/00079_add_agreement_permission.sql
+++ b/src/main/resources/migrations/00079_add_agreement_permission.sql
@@ -1,0 +1,14 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:agreements_read_update_permission
+INSERT INTO  permissions(id, name, description) VALUES ((SELECT MAX(id) + 1 FROM permissions), 'agreements:read', 'View agreements');
+INSERT INTO  permissions(id, name, description) VALUES ((SELECT MAX(id) + 1 FROM permissions), 'agreements:update', 'Update agreements');
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'super-admin'), (SELECT id FROM permissions WHERE name = 'agreements:read'), NOW(), NOW());
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'admin'), (SELECT id FROM permissions WHERE name = 'agreements:read'), NOW(), NOW());
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'view-and-refund'), (SELECT id FROM permissions WHERE name = 'agreements:read'), NOW(), NOW());
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'view-only'), (SELECT id FROM permissions WHERE name = 'agreements:read'), NOW(), NOW());
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'view-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'agreements:read'), NOW(), NOW());
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'view-refund-and-initiate-moto'), (SELECT id FROM permissions WHERE name = 'agreements:read'), NOW(), NOW());
+
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'super-admin'), (SELECT id FROM permissions WHERE name = 'agreements:update'), NOW(), NOW());
+INSERT INTO  role_permission VALUES ((SELECT id FROM roles WHERE name = 'admin'), (SELECT id FROM permissions WHERE name = 'agreements:update'), NOW(), NOW());


### PR DESCRIPTION
Agreements read and update permissions are currently mapped similarly to
the transactions case worker model. As services start using it if they
need more granular permissions this can be reconsidered.