### PR TITLE
BAU Ignore dropwizard bump to 2.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,9 @@ updates:
     versions:
     - ">= 4.3.a"
     - "< 4.4"
+  - dependency-name: io.dropwizard/*
+    versions:
+      - ">= 2.1.0"
 - package-ecosystem: docker
   directory: "/"
   schedule:


### PR DESCRIPTION
We have a story to do this update. Stop dropwizard from bumping until
this is done.