### PR TITLE
PP-9576 add env vars for dispute updates

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/app/config/NotifyConfiguration.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/NotifyConfiguration.java
@@ -4,6 +4,7 @@ import io.dropwizard.Configuration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import java.time.Instant;
 
 public class NotifyConfiguration extends Configuration {
 
@@ -62,10 +63,30 @@ public class NotifyConfiguration extends Configuration {
     @Valid
     @NotNull
     private String stripeDisputeCreatedEmailTemplateId;
+
+    @Valid
+    @NotNull
+    private String stripeDisputeLostEmailTemplateId;
+
+    @Valid
+    @NotNull
+    private String stripeDisputeUpdatedEmailTemplateId;
+
+    @Valid
+    @NotNull
+    private String stripeDisputeWonEmailTemplateId;
     
     @Valid
     @NotNull
     private String notifyEmailReplyToSupportId;
+
+    @Valid
+    @NotNull
+    private long enableEmailsNotificationsForLivePaymentsDisputeUpdatesFrom;
+
+    @Valid
+    @NotNull
+    private long enableEmailsNotificationsForTestPaymentsDisputeUpdatesFrom;
 
     public String getCardApiKey() {
         return cardApiKey;
@@ -123,7 +144,27 @@ public class NotifyConfiguration extends Configuration {
         return stripeDisputeCreatedEmailTemplateId;
     }
 
+    public String getStripeDisputeLostEmailTemplateId() {
+        return stripeDisputeLostEmailTemplateId;
+    }
+
+    public String getStripeDisputeUpdatedEmailTemplateId() {
+        return stripeDisputeUpdatedEmailTemplateId;
+    }
+
+    public String getStripeDisputeWonEmailTemplateId() {
+        return stripeDisputeWonEmailTemplateId;
+    }
+
     public String getNotifyEmailReplyToSupportId() {
         return notifyEmailReplyToSupportId;
+    }
+
+    public Instant getEnableEmailsNotificationsForLivePaymentsDisputeUpdatesFrom() {
+        return Instant.ofEpochSecond(enableEmailsNotificationsForLivePaymentsDisputeUpdatesFrom);
+    }
+
+    public Instant getEnableEmailsNotificationsForTestPaymentsDisputeUpdatesFrom() {
+        return Instant.ofEpochSecond(enableEmailsNotificationsForTestPaymentsDisputeUpdatesFrom);
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
@@ -6,18 +6,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.adminusers.app.config.NotifyConfiguration;
 import uk.gov.pay.adminusers.app.config.NotifyDirectDebitConfiguration;
-import uk.gov.pay.adminusers.model.PaymentType;
 import uk.gov.pay.adminusers.utils.telephonenumber.TelephoneNumberUtility;
 import uk.gov.service.notify.NotificationClientException;
 import uk.gov.service.notify.SendEmailResponse;
 import uk.gov.service.notify.SendSmsResponse;
 
+import java.time.Instant;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
-import static uk.gov.pay.adminusers.model.PaymentType.CARD;
 import static uk.gov.pay.adminusers.model.Service.DEFAULT_NAME_VALUE;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.userNotificationError;
 
@@ -40,7 +39,12 @@ public class NotificationService {
     private final String inviteExistingUserEmailTemplateId;
 
     private final String stripeDisputeCreatedEmailTemplateId;
+    private final String stripeDisputeLostEmailTemplateId;
+    private final String stripeDisputeUpdatedEmailTemplateId;
+    private final String stripeDisputeWonEmailTemplateId;
     private final String notifyEmailReplyToSupportId;
+    private final Instant emailsNotificationsForLivePaymentsDisputeUpdatesFrom;
+    private final Instant emailsNotificationsForTestPaymentsDisputeUpdatesFrom;
 
     public NotificationService(NotifyClientProvider notifyClientProvider,
                                NotifyConfiguration notifyConfiguration,
@@ -61,7 +65,12 @@ public class NotificationService {
         this.forgottenPasswordEmailTemplateId = notifyConfiguration.getForgottenPasswordEmailTemplateId();
         
         this.stripeDisputeCreatedEmailTemplateId = notifyConfiguration.getStripeDisputeCreatedEmailTemplateId();
+        this.stripeDisputeLostEmailTemplateId = notifyConfiguration.getStripeDisputeLostEmailTemplateId();
+        this.stripeDisputeUpdatedEmailTemplateId = notifyConfiguration.getStripeDisputeUpdatedEmailTemplateId();
+        this.stripeDisputeWonEmailTemplateId = notifyConfiguration.getStripeDisputeWonEmailTemplateId();
         this.notifyEmailReplyToSupportId = notifyConfiguration.getNotifyEmailReplyToSupportId();
+        this.emailsNotificationsForLivePaymentsDisputeUpdatesFrom = notifyConfiguration.getEnableEmailsNotificationsForLivePaymentsDisputeUpdatesFrom();
+        this.emailsNotificationsForTestPaymentsDisputeUpdatesFrom = notifyConfiguration.getEnableEmailsNotificationsForTestPaymentsDisputeUpdatesFrom();
 
         this.metricRegistry = metricRegistry;
     }
@@ -149,6 +158,18 @@ public class NotificationService {
         emailAddresses.forEach(email -> sendEmail(stripeDisputeCreatedEmailTemplateId, email, personalisation, notifyEmailReplyToSupportId));
     }
 
+    public void sendStripeDisputeLostEmail(Set<String> emailAddresses, Map<String, String> personalisation) {
+        emailAddresses.forEach(email -> sendEmail(stripeDisputeLostEmailTemplateId, email, personalisation, notifyEmailReplyToSupportId));
+    }
+
+    public void sendStripeDisputeUpdatedEmail(Set<String> emailAddresses, Map<String, String> personalisation) {
+        emailAddresses.forEach(email -> sendEmail(stripeDisputeUpdatedEmailTemplateId, email, personalisation, notifyEmailReplyToSupportId));
+    }
+
+    public void sendStripeDisputeWonEmail(Set<String> emailAddresses, Map<String, String> personalisation) {
+        emailAddresses.forEach(email -> sendEmail(stripeDisputeWonEmailTemplateId, email, personalisation, notifyEmailReplyToSupportId));
+    }
+
     public String sendEmail(final String templateId, final String email, final Map<String, String> personalisation) {
        return sendEmail(templateId, email, personalisation, null);
     }
@@ -187,4 +208,11 @@ public class NotificationService {
         SIGN_IN, CHANGE_SIGN_IN_2FA_TO_SMS, SELF_INITIATED_CREATE_NEW_USER_AND_SERVICE, CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE;
     }
 
+    public Instant getEmailsNotificationsForLivePaymentsDisputeUpdatesFrom() {
+        return emailsNotificationsForLivePaymentsDisputeUpdatesFrom;
+    }
+
+    public Instant getEmailsNotificationsForTestPaymentsDisputeUpdatesFrom() {
+        return emailsNotificationsForTestPaymentsDisputeUpdatesFrom;
+    }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -83,7 +83,12 @@ notify:
   inviteServiceUserDisabledEmailTemplateId: ${NOTIFY_INVITE_SERVICE_USER_DISABLED_EMAIL_TEMPLATE_ID:-pay-notify-invite-service-user-disabled-email-template-id}
   liveAccountCreatedEmailTemplateId: ${NOTIFY_LIVE_ACCOUNT_CREATED_EMAIL_TEMPLATE_ID:-pay-notify-live-account-created-email-template-id}
   stripeDisputeCreatedEmailTemplateId: ${NOTIFY_STRIPE_DISPUTE_CREATED_EMAIL_TEMPLATE_ID:-pay-notify-stripe-dispute-created-email-template-id}
+  stripeDisputeLostEmailTemplateId: ${NOTIFY_STRIPE_DISPUTE_LOST_EMAIL_TEMPLATE_ID:-pay-notify-stripe-dispute-lost-email-template-id}
+  stripeDisputeUpdatedEmailTemplateId: ${NOTIFY_STRIPE_DISPUTE_UPDATED_EMAIL_TEMPLATE_ID:-pay-notify-stripe-dispute-updated-email-template-id}
+  stripeDisputeWonEmailTemplateId: ${NOTIFY_STRIPE_DISPUTE_WON_EMAIL_TEMPLATE_ID:-pay-notify-stripe-dispute-won-email-template-id}
   notifyEmailReplyToSupportId: ${NOTIFY_EMAIL_REPLY_TO_SUPPORT_ID:-pay-notify-email-reply-to-support-id}
+  enableEmailsNotificationsForLivePaymentsDisputeUpdatesFrom: ${ENABLE_EMAILS_NOTIFICATIONS_FOR_LIVE_PAYMENTS_DISPUTE_UPDATES:-1672531201}
+  enableEmailsNotificationsForTestPaymentsDisputeUpdatesFrom: ${ENABLE_EMAILS_NOTIFICATIONS_FOR_TEST_PAYMENTS_DISPUTE_UPDATES:-1672531201}
 
 notifyDirectDebit:
   mandateCancelledEmailTemplateId: ${NOTIFY_MANDATE_CANCELLED_EMAIL_TEMPLATE_ID:-pay-mandate-cancelled-email-template-id}

--- a/src/test/java/uk/gov/pay/adminusers/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/NotificationServiceTest.java
@@ -20,11 +20,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId;
@@ -49,6 +47,9 @@ public class NotificationServiceTest {
     private static final String FORGOTTEN_PASSWORD_EMAIL_TEMPLATE_ID = "forgotten-password-email-template-id";
     
     private static final String STRIPE_DISPUTE_CREATED_EMAIL_TEMPLATE_ID = "stripe-dispute-created-email-template-id";
+    private static final String STRIPE_DISPUTE_LOST_EMAIL_TEMPLATE_ID = "stripe-dispute-lost-email-template-id";
+    private static final String STRIPE_DISPUTE_UPDATED_EMAIL_TEMPLATE_ID = "stripe-dispute-updated-email-template-id";
+    private static final String STRIPE_DISPUTE_WON_EMAIL_TEMPLATE_ID = "stripe-dispute-won-email-template-id";
     private static final String NOTIFY_EMAIL_REPLY_TO_SUPPORT_ID = "notify-email-reply-to-support-id";
     
     @Mock private NotifyClientProvider mockNotifyClientProvider;
@@ -76,6 +77,9 @@ public class NotificationServiceTest {
         given(mockNotifyConfiguration.getForgottenPasswordEmailTemplateId()).willReturn(FORGOTTEN_PASSWORD_EMAIL_TEMPLATE_ID);
         
         given(mockNotifyConfiguration.getStripeDisputeCreatedEmailTemplateId()).willReturn(STRIPE_DISPUTE_CREATED_EMAIL_TEMPLATE_ID);
+        given(mockNotifyConfiguration.getStripeDisputeLostEmailTemplateId()).willReturn(STRIPE_DISPUTE_LOST_EMAIL_TEMPLATE_ID);
+        given(mockNotifyConfiguration.getStripeDisputeUpdatedEmailTemplateId()).willReturn(STRIPE_DISPUTE_UPDATED_EMAIL_TEMPLATE_ID);
+        given(mockNotifyConfiguration.getStripeDisputeWonEmailTemplateId()).willReturn(STRIPE_DISPUTE_WON_EMAIL_TEMPLATE_ID);
         given(mockNotifyConfiguration.getNotifyEmailReplyToSupportId()).willReturn(NOTIFY_EMAIL_REPLY_TO_SUPPORT_ID);
         
         given(mockNotifyClientProvider.get()).willReturn(mockNotificationClient);
@@ -150,4 +154,60 @@ public class NotificationServiceTest {
         verify(mockNotificationClient).sendEmail(STRIPE_DISPUTE_CREATED_EMAIL_TEMPLATE_ID, "email2@service.gov.uk", personalisation, null, NOTIFY_EMAIL_REPLY_TO_SUPPORT_ID);
     }
 
+    @Test
+    public void sendEmailWithStripeDisputeLostEmailTemplateId() throws NotificationClientException {
+        given(mockMetricRegistry.histogram("notify-operations.email.response_time")).willReturn(mock(Histogram.class));
+        given(mockNotificationClient.sendEmail(anyString(), anyString(), anyMap(), isNull(), anyString())).willReturn(mockSendEmailResponse);
+        given(mockSendEmailResponse.getNotificationId()).willReturn(NOTIFICATION_ID);
+
+        var addresses = Stream.of("email1@service.gov.uk", "email2@service.gov.uk")
+                .collect(Collectors.toSet());
+        var personalisation = Stream.of(new String[][] {
+                { "k1", "v1" },
+                { "k2", "v2" }
+        }).collect(Collectors.toMap(data -> data[0], data -> data[1]));
+
+        notificationService.sendStripeDisputeLostEmail(addresses, personalisation);
+
+        verify(mockNotificationClient).sendEmail(STRIPE_DISPUTE_LOST_EMAIL_TEMPLATE_ID, "email1@service.gov.uk", personalisation, null, NOTIFY_EMAIL_REPLY_TO_SUPPORT_ID);
+        verify(mockNotificationClient).sendEmail(STRIPE_DISPUTE_LOST_EMAIL_TEMPLATE_ID, "email2@service.gov.uk", personalisation, null, NOTIFY_EMAIL_REPLY_TO_SUPPORT_ID);
+    }
+
+    @Test
+    public void sendEmailWithStripeDisputeUpdatedEmailTemplateId() throws NotificationClientException {
+        given(mockMetricRegistry.histogram("notify-operations.email.response_time")).willReturn(mock(Histogram.class));
+        given(mockNotificationClient.sendEmail(anyString(), anyString(), anyMap(), isNull(), anyString())).willReturn(mockSendEmailResponse);
+        given(mockSendEmailResponse.getNotificationId()).willReturn(NOTIFICATION_ID);
+
+        var addresses = Stream.of("email1@service.gov.uk", "email2@service.gov.uk")
+                .collect(Collectors.toSet());
+        var personalisation = Stream.of(new String[][] {
+                { "k1", "v1" },
+                { "k2", "v2" }
+        }).collect(Collectors.toMap(data -> data[0], data -> data[1]));
+
+        notificationService.sendStripeDisputeUpdatedEmail(addresses, personalisation);
+
+        verify(mockNotificationClient).sendEmail(STRIPE_DISPUTE_UPDATED_EMAIL_TEMPLATE_ID, "email1@service.gov.uk", personalisation, null, NOTIFY_EMAIL_REPLY_TO_SUPPORT_ID);
+        verify(mockNotificationClient).sendEmail(STRIPE_DISPUTE_UPDATED_EMAIL_TEMPLATE_ID, "email2@service.gov.uk", personalisation, null, NOTIFY_EMAIL_REPLY_TO_SUPPORT_ID);
+    }
+
+    @Test
+    public void sendEmailWithStripeDisputeWonEmailTemplateId() throws NotificationClientException {
+        given(mockMetricRegistry.histogram("notify-operations.email.response_time")).willReturn(mock(Histogram.class));
+        given(mockNotificationClient.sendEmail(anyString(), anyString(), anyMap(), isNull(), anyString())).willReturn(mockSendEmailResponse);
+        given(mockSendEmailResponse.getNotificationId()).willReturn(NOTIFICATION_ID);
+
+        var addresses = Stream.of("email1@service.gov.uk", "email2@service.gov.uk")
+                .collect(Collectors.toSet());
+        var personalisation = Stream.of(new String[][] {
+                { "k1", "v1" },
+                { "k2", "v2" }
+        }).collect(Collectors.toMap(data -> data[0], data -> data[1]));
+
+        notificationService.sendStripeDisputeWonEmail(addresses, personalisation);
+
+        verify(mockNotificationClient).sendEmail(STRIPE_DISPUTE_WON_EMAIL_TEMPLATE_ID, "email1@service.gov.uk", personalisation, null, NOTIFY_EMAIL_REPLY_TO_SUPPORT_ID);
+        verify(mockNotificationClient).sendEmail(STRIPE_DISPUTE_WON_EMAIL_TEMPLATE_ID, "email2@service.gov.uk", personalisation, null, NOTIFY_EMAIL_REPLY_TO_SUPPORT_ID);
+    }
 }

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -72,7 +72,12 @@ notify:
   inviteServiceUserDisabledEmailTemplateId: ${NOTIFY_INVITE_SERVICE_USER_DISABLED_EMAIL_TEMPLATE_ID:-pay-notify-invite-service-user-disabled-email-template-id}
   liveAccountCreatedEmailTemplateId: ${NOTIFY_LIVE_ACCOUNT_CREATED_EMAIL_TEMPLATE_ID:-pay-notify-live-account-created-email-template-id}
   stripeDisputeCreatedEmailTemplateId: ${NOTIFY_STRIPE_DISPUTE_CREATED_EMAIL_TEMPLATE_ID:-pay-notify-stripe-dispute-created-email-template-id}
+  stripeDisputeLostEmailTemplateId: ${NOTIFY_STRIPE_DISPUTE_LOST_EMAIL_TEMPLATE_ID:-pay-notify-stripe-dispute-lost-email-template-id}
+  stripeDisputeUpdatedEmailTemplateId: ${NOTIFY_STRIPE_DISPUTE_UPDATED_EMAIL_TEMPLATE_ID:-pay-notify-stripe-dispute-updated-email-template-id}
+  stripeDisputeWonEmailTemplateId: ${NOTIFY_STRIPE_DISPUTE_WON_EMAIL_TEMPLATE_ID:-pay-notify-stripe-dispute-won-email-template-id}
   notifyEmailReplyToSupportId: ${NOTIFY_EMAIL_REPLY_TO_SUPPORT_ID:-pay-notify-email-reply-to-support-id}
+  enableEmailsNotificationsForLivePaymentsDisputeUpdatesFrom: ${ENABLE_EMAILS_NOTIFICATIONS_FOR_LIVE_PAYMENTS_DISPUTE_UPDATES:-1672531201}
+  enableEmailsNotificationsForTestPaymentsDisputeUpdatesFrom: ${ENABLE_EMAILS_NOTIFICATIONS_FOR_TEST_PAYMENTS_DISPUTE_UPDATES:-1640995201}
 
 notifyDirectDebit:
   mandateCancelledEmailTemplateId: ${NOTIFY_MANDATE_CANCELLED_EMAIL_TEMPLATE_ID:-pay-mandate-cancelled-email-template-id}


### PR DESCRIPTION
## WHAT YOU DID
- add parsing of env vars for Stripe dispute updates (email templeta ids and enabled from dates)
- add env vars to NotifyConfiguration and NotificationService
- add methods to send emails for new templates
