### PR TITLE
PP-9576 refactor dispute lost event handling

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/queue/model/event/DisputeLostDetails.java
+++ b/src/main/java/uk/gov/pay/adminusers/queue/model/event/DisputeLostDetails.java
@@ -10,6 +10,7 @@ public class DisputeLostDetails {
     private Long netAmount;
     private Long amount;
     private Long fee;
+    private String gatewayAccountId;
 
     public DisputeLostDetails() {
         // empty constructor
@@ -25,5 +26,9 @@ public class DisputeLostDetails {
 
     public Long getFee() {
         return fee;
+    }
+
+    public String getGatewayAccountId() {
+        return gatewayAccountId;
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/queue/event/EventMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/queue/event/EventMessageHandlerTest.java
@@ -1,11 +1,11 @@
 package uk.gov.pay.adminusers.queue.event;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.GsonBuilder;
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
 import org.hamcrest.core.Is;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,7 +31,6 @@ import uk.gov.service.payments.commons.queue.exception.QueueException;
 import uk.gov.service.payments.commons.queue.model.QueueMessage;
 
 import java.time.Instant;
-import java.time.temporal.TemporalUnit;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -170,7 +169,7 @@ class EventMessageHandlerTest {
         var mockQueueMessage = mock(QueueMessage.class);
         disputeEvent = anEventFixture()
                 .withEventType(EventType.DISPUTE_LOST.name())
-                .withEventDetails(new GsonBuilder().create().toJson(Map.of("net_amount", -4000L, "fee", 1500L, "amount", 2500L)))
+                .withEventDetails(new GsonBuilder().create().toJson(Map.of("net_amount", -4000L, "fee", 1500L, "amount", 2500L, "gateway_account_id", gatewayAccountId)))
                 .withParentResourceExternalId("456")
                 .withServiceId(service.getExternalId())
                 .withLive(true)
@@ -179,7 +178,7 @@ class EventMessageHandlerTest {
         when(mockQueueMessage.getMessageId()).thenReturn("queue-message-id");
         when(mockEventSubscriberQueue.retrieveEvents()).thenReturn(List.of(eventMessage));
         when(mockNotificationService.getEmailNotificationsForLivePaymentsDisputeUpdatesFrom()).thenReturn(Instant.now().minusSeconds(6000L));
-        when(mockServiceFinder.byExternalId(service.getExternalId())).thenReturn(Optional.of(service));
+        when(mockServiceFinder.byGatewayAccountId(gatewayAccountId)).thenReturn(Optional.of(service));
         when(mockLedgerService.getTransaction(transaction.getTransactionId())).thenReturn(Optional.of(transaction));
         when(mockUserServices.getAdminUsersForService(service)).thenReturn(users);
 
@@ -210,7 +209,7 @@ class EventMessageHandlerTest {
         var mockQueueMessage = mock(QueueMessage.class);
         disputeEvent = anEventFixture()
                 .withEventType(EventType.DISPUTE_LOST.name())
-                .withEventDetails(new GsonBuilder().create().toJson(Map.of("net_amount", -4000L, "fee", 1500L, "amount", 2500L)))
+                .withEventDetails(new GsonBuilder().create().toJson(Map.of("net_amount", -4000L, "fee", 1500L, "amount", 2500L, "gateway_account_id", gatewayAccountId)))
                 .withParentResourceExternalId("456")
                 .withServiceId(service.getExternalId())
                 .withLive(false)
@@ -219,7 +218,7 @@ class EventMessageHandlerTest {
         when(mockQueueMessage.getMessageId()).thenReturn("queue-message-id");
         when(mockEventSubscriberQueue.retrieveEvents()).thenReturn(List.of(eventMessage));
         when(mockNotificationService.getEmailNotificationsForTestPaymentsDisputeUpdatesFrom()).thenReturn(Instant.now().minusSeconds(6000L));
-        when(mockServiceFinder.byExternalId(service.getExternalId())).thenReturn(Optional.of(service));
+        when(mockServiceFinder.byGatewayAccountId(gatewayAccountId)).thenReturn(Optional.of(service));
         when(mockLedgerService.getTransaction(transaction.getTransactionId())).thenReturn(Optional.of(transaction));
         when(mockUserServices.getAdminUsersForService(service)).thenReturn(users);
 
@@ -259,7 +258,7 @@ class EventMessageHandlerTest {
         when(mockQueueMessage.getMessageId()).thenReturn("queue-message-id");
         when(mockEventSubscriberQueue.retrieveEvents()).thenReturn(List.of(eventMessage));
         when(mockNotificationService.getEmailNotificationsForTestPaymentsDisputeUpdatesFrom()).thenReturn(Instant.now().plusSeconds(6000L));
-        when(mockServiceFinder.byExternalId(service.getExternalId())).thenReturn(Optional.of(service));
+        when(mockServiceFinder.byGatewayAccountId(gatewayAccountId)).thenReturn(Optional.of(service));
         when(mockLedgerService.getTransaction(transaction.getTransactionId())).thenReturn(Optional.of(transaction));
         when(mockUserServices.getAdminUsersForService(service)).thenReturn(users);
 
@@ -282,7 +281,7 @@ class EventMessageHandlerTest {
         when(mockQueueMessage.getMessageId()).thenReturn("queue-message-id");
         when(mockEventSubscriberQueue.retrieveEvents()).thenReturn(List.of(eventMessage));
         when(mockNotificationService.getEmailNotificationsForLivePaymentsDisputeUpdatesFrom()).thenReturn(Instant.now().plusSeconds(6000L));
-        when(mockServiceFinder.byExternalId(service.getExternalId())).thenReturn(Optional.of(service));
+        when(mockServiceFinder.byGatewayAccountId(gatewayAccountId)).thenReturn(Optional.of(service));
         when(mockLedgerService.getTransaction(transaction.getTransactionId())).thenReturn(Optional.of(transaction));
         when(mockUserServices.getAdminUsersForService(service)).thenReturn(users);
 

--- a/src/test/java/uk/gov/pay/adminusers/queue/model/event/DisputeLostDetailsTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/queue/model/event/DisputeLostDetailsTest.java
@@ -26,5 +26,6 @@ class DisputeLostDetailsTest {
         assertThat(disputeLostDetails.getFee(), is(1500L));
         assertThat(disputeLostDetails.getAmount(), is(2500L));
         assertThat(disputeLostDetails.getNetAmount(), is(-4000L));
+        assertThat(disputeLostDetails.getGatewayAccountId(), is("123"));
     }
 }

--- a/src/test/resources/templates/events/dispute_lost_event.json
+++ b/src/test/resources/templates/events/dispute_lost_event.json
@@ -2,7 +2,7 @@
   "event_type": "DISPUTE_LOST",
   "service_id": "111111111",
   "resource_type": "dispute",
-  "event_details": "{\"net_amount\":-4000,\"amount\":2500,\"fee\":1500}",
+  "event_details": "{\"net_amount\":-4000,\"amount\":2500,\"fee\":1500,\"gateway_account_id\":\"123\"}",
   "live": false,
   "timestamp": "2022-06-16T15:29:01.123456Z",
   "resource_external_id": "external_id",


### PR DESCRIPTION
## WHAT YOU DID
- refactor DISPUTE_LOST event handling to use gateway account id. This is needed because disputes can be opened up to 120 days and sending service id was only fixed on 24/03
- also refactor a few code repetitions
- refactor tests as well
