### PR TITLE
PP-9576 refactor dispute event handling

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/queue/event/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/adminusers/queue/event/EventMessageHandler.java
@@ -122,7 +122,7 @@ public class EventMessageHandler {
                     throw new IllegalStateException(format("Service has no Admin users [external_id: %s]", service.getExternalId()));
                 }
             } else {
-                throw new IllegalArgumentException(format("Dispute evidence submitted email sending is not yet enabled for [service_id: %s]", disputeEvidenceSubmittedEvent.getServiceId()));
+                logger.info(format("Dispute evidence submitted email sending is not yet enabled for [service_id: %s]", disputeEvidenceSubmittedEvent.getServiceId()));
             }
         } finally {
             tearDownMDC();
@@ -156,7 +156,7 @@ public class EventMessageHandler {
                     throw new IllegalStateException(format("Service has no Admin users [external_id: %s]", service.getExternalId()));
                 }
             } else {
-                throw new IllegalArgumentException(format("Dispute won email sending is not yet enabled for [service_id: %s]", disputeWonEvent.getServiceId()));
+                logger.info(format("Dispute won email sending is not yet enabled for [service_id: %s]", disputeWonEvent.getServiceId()));
             }
         } finally {
             tearDownMDC();
@@ -193,7 +193,7 @@ public class EventMessageHandler {
                     throw new IllegalStateException(format("Service has no Admin users [external_id: %s]", service.getExternalId()));
                 }
             } else {
-                throw new IllegalArgumentException(format("Dispute lost email sending is not yet enabled for [service_id: %s]", disputeLostEvent.getServiceId()));
+                logger.info(format("Dispute lost email sending is not yet enabled for [service_id: %s]", disputeLostEvent.getServiceId()));
             }
         } finally {
             tearDownMDC();

--- a/src/test/java/uk/gov/pay/adminusers/queue/event/EventMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/queue/event/EventMessageHandlerTest.java
@@ -209,7 +209,10 @@ class EventMessageHandlerTest {
         var mockQueueMessage = mock(QueueMessage.class);
         disputeEvent = anEventFixture()
                 .withEventType(EventType.DISPUTE_LOST.name())
-                .withEventDetails(new GsonBuilder().create().toJson(Map.of("net_amount", -4000L, "fee", 1500L, "amount", 2500L, "gateway_account_id", gatewayAccountId)))
+                .withEventDetails(new GsonBuilder().create().toJson(Map.of("net_amount", -4000L,
+                        "fee", 1500L,
+                        "amount", 2500L,
+                        "gateway_account_id", gatewayAccountId)))
                 .withParentResourceExternalId("456")
                 .withServiceId(service.getExternalId())
                 .withLive(false)
@@ -249,7 +252,10 @@ class EventMessageHandlerTest {
         var mockQueueMessage = mock(QueueMessage.class);
         disputeEvent = anEventFixture()
                 .withEventType(EventType.DISPUTE_LOST.name())
-                .withEventDetails(new GsonBuilder().create().toJson(Map.of("net_amount", -4000L, "fee", 1500L, "amount", 2500L)))
+                .withEventDetails(new GsonBuilder().create().toJson(Map.of("net_amount", -4000L,
+                        "fee", 1500L,
+                        "amount", 2500L,
+                        "gateway_account_id", gatewayAccountId)))
                 .withParentResourceExternalId("456")
                 .withServiceId(service.getExternalId())
                 .withLive(false)
@@ -265,6 +271,12 @@ class EventMessageHandlerTest {
         eventMessageHandler.processMessages();
 
         verify(mockNotificationService, never()).sendStripeDisputeLostEmail(anySet(), anyMap());
+
+        verify(mockLogAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
+
+        List<ILoggingEvent> logStatement = loggingEventArgumentCaptor.getAllValues();
+        assertThat(logStatement.get(0).getFormattedMessage(), Is.is("Retrieved event queue message with id [queue-message-id] for resource external id [a-resource-external-id]"));
+        assertThat(logStatement.get(1).getFormattedMessage(), Is.is("Dispute lost email sending is not yet enabled for [service_id: " + service.getExternalId() + "]"));
     }
 
     @Test
@@ -348,7 +360,7 @@ class EventMessageHandlerTest {
         var mockQueueMessage = mock(QueueMessage.class);
         disputeEvent = anEventFixture()
                 .withEventType(EventType.DISPUTE_LOST.name())
-                .withEventDetails(new GsonBuilder().create().toJson(Map.of("net_amount", -4000L, "fee", 1500L, "amount", 2500L)))
+                .withEventDetails(new GsonBuilder().create().toJson(Map.of("net_amount", -4000L, "fee", 1500L, "amount", 2500L, "gateway_account_id", gatewayAccountId)))
                 .withParentResourceExternalId("456")
                 .withServiceId(service.getExternalId())
                 .withLive(true)
@@ -364,6 +376,12 @@ class EventMessageHandlerTest {
         eventMessageHandler.processMessages();
 
         verify(mockNotificationService, never()).sendStripeDisputeLostEmail(anySet(), anyMap());
+
+        verify(mockLogAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
+
+        List<ILoggingEvent> logStatement = loggingEventArgumentCaptor.getAllValues();
+        assertThat(logStatement.get(0).getFormattedMessage(), Is.is("Retrieved event queue message with id [queue-message-id] for resource external id [a-resource-external-id]"));
+        assertThat(logStatement.get(1).getFormattedMessage(), Is.is("Dispute lost email sending is not yet enabled for [service_id: " + service.getExternalId() + "]"));
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID
- Do not throw exception when email sending is not yet enabled. Just log the issue.
- Update tests.
