### PR TITLE
PP-9620 update liquibase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,15 +10,6 @@ updates:
   - dependencies
   - govuk-pay
   - java
-  ignore:
-  - dependency-name: org.liquibase:liquibase-core
-    versions:
-    - "> 3.8.0"
-    - "< 3.9"
-  - dependency-name: org.liquibase:liquibase-core
-    versions:
-    - ">= 4.3.a"
-    - "< 4.4"
 - package-ecosystem: docker
   directory: "/"
   schedule:

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
-            <version>3.10.2</version>
+            <version>4.12.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.servlet</groupId>


### PR DESCRIPTION
## WHAT YOU DID

- The Github UI is giving critical warnings for our Java apps with liquibase below v4.8.0. Patched liquibase to 4.12.0
- Thus ignoring liquibase is no longer required, remove it from dependabot yaml file.