### PR TITLE
PP-9622 Log leger_event_type and remove fee from dispute created event

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/queue/model/event/DisputeCreatedDetails.java
+++ b/src/main/java/uk/gov/pay/adminusers/queue/model/event/DisputeCreatedDetails.java
@@ -8,12 +8,11 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DisputeCreatedDetails {
-    
+
     private Long amount;
-    private Long fee;
     private Long evidenceDueDate;
     private String gatewayAccountId;
-    
+
     public DisputeCreatedDetails() {
         // empty constructor
     }
@@ -22,13 +21,11 @@ public class DisputeCreatedDetails {
         return amount;
     }
 
-    public Long getFee() {
-        return fee;
-    }
-
     public long getEvidenceDueDate() {
         return evidenceDueDate;
     }
-    
-    public String getGatewayAccountId() { return gatewayAccountId; }
+
+    public String getGatewayAccountId() {
+        return gatewayAccountId;
+    }
 }

--- a/src/test/java/uk/gov/pay/adminusers/queue/event/EventMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/queue/event/EventMessageHandlerTest.java
@@ -97,7 +97,7 @@ class EventMessageHandlerTest {
     void setUp() {
         eventMessageHandler = new EventMessageHandler(mockEventSubscriberQueue, mockLedgerService, mockNotificationService, mockServiceFinder, mockUserServices, objectMapper);
         service = Service.from(randomInt(), randomUuid(), new ServiceName(DEFAULT_NAME_VALUE));
-        service.setMerchantDetails(new MerchantDetails("Organisation Name", null, null, null, null, null, null, null,null));
+        service.setMerchantDetails(new MerchantDetails("Organisation Name", null, null, null, null, null, null, null, null));
         transaction = aLedgerTransactionFixture()
                 .withTransactionId("456")
                 .withReference("tx ref")
@@ -129,7 +129,7 @@ class EventMessageHandlerTest {
         var mockQueueMessage = mock(QueueMessage.class);
         disputeEvent = anEventFixture()
                 .withEventType(EventType.DISPUTE_CREATED.name())
-                .withEventDetails(new GsonBuilder().create().toJson(Map.of("amount", 21000L, "fee", 1500L, "evidence_due_date", 1646658000L, "gateway_account_id", gatewayAccountId)))
+                .withEventDetails(new GsonBuilder().create().toJson(Map.of("amount", 21000L, "evidence_due_date", 1646658000L, "gateway_account_id", gatewayAccountId)))
                 .withParentResourceExternalId("456")
                 .build();
         var eventMessage = EventMessage.of(disputeEvent, mockQueueMessage);
@@ -153,7 +153,6 @@ class EventMessageHandlerTest {
         assertThat(personalisation.get("paymentExternalId"), is("456"));
         assertThat(personalisation.get("serviceReference"), is("tx ref"));
         assertThat(personalisation.get("paymentAmount"), is("210.00"));
-        assertThat(personalisation.get("disputeFee"), is("15.00"));
         assertThat(personalisation.get("disputeEvidenceDueDate"), is("7 March 2022"));
         assertThat(personalisation.get("sendEvidenceToPayDueDate"), is("4 March 2022"));
 
@@ -195,7 +194,7 @@ class EventMessageHandlerTest {
         assertThat(personalisation.get("serviceReference"), is("tx ref"));
         assertThat(personalisation.get("disputedAmount"), is("25.00"));
         assertThat(personalisation.get("disputeFee"), is("15.00"));
-        assertThat(personalisation.get("organisationName"), is(service.getMerchantDetails().getName())) ;
+        assertThat(personalisation.get("organisationName"), is(service.getMerchantDetails().getName()));
 
         verify(mockLogAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
 
@@ -238,7 +237,7 @@ class EventMessageHandlerTest {
         assertThat(personalisation.get("serviceReference"), is("tx ref"));
         assertThat(personalisation.get("disputedAmount"), is("25.00"));
         assertThat(personalisation.get("disputeFee"), is("15.00"));
-        assertThat(personalisation.get("organisationName"), is(service.getMerchantDetails().getName())) ;
+        assertThat(personalisation.get("organisationName"), is(service.getMerchantDetails().getName()));
 
         verify(mockLogAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
 
@@ -308,7 +307,7 @@ class EventMessageHandlerTest {
         assertThat(emails, hasItems("admin1@service.gov.uk", "admin2@service.gov.uk"));
         assertThat(personalisation.get("serviceName"), is(service.getName()));
         assertThat(personalisation.get("serviceReference"), is("tx ref"));
-        assertThat(personalisation.get("organisationName"), is(service.getMerchantDetails().getName())) ;
+        assertThat(personalisation.get("organisationName"), is(service.getMerchantDetails().getName()));
 
         verify(mockLogAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
 
@@ -346,7 +345,7 @@ class EventMessageHandlerTest {
         assertThat(emails, hasItems("admin1@service.gov.uk", "admin2@service.gov.uk"));
         assertThat(personalisation.get("serviceName"), is(service.getName()));
         assertThat(personalisation.get("serviceReference"), is("tx ref"));
-        assertThat(personalisation.get("organisationName"), is(service.getMerchantDetails().getName())) ;
+        assertThat(personalisation.get("organisationName"), is(service.getMerchantDetails().getName()));
 
         verify(mockLogAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
 

--- a/src/test/java/uk/gov/pay/adminusers/queue/model/event/DisputeCreatedDetailsTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/queue/model/event/DisputeCreatedDetailsTest.java
@@ -23,7 +23,6 @@ class DisputeCreatedDetailsTest {
         var disputeCreatedDetails = objectMapper.readValue(evt.getEventDetails(), DisputeCreatedDetails.class);
         
         assertThat(evt.getEventType(), is(EventType.DISPUTE_CREATED.name()));
-        assertThat(disputeCreatedDetails.getFee(), is(1500L));
         assertThat(disputeCreatedDetails.getAmount(), is(125000L));
         assertThat(disputeCreatedDetails.getEvidenceDueDate(), is(1648745127L));
         assertThat(disputeCreatedDetails.getGatewayAccountId(), is("123"));


### PR DESCRIPTION
## WHAT YOU DID
- Added ledger_event_type to the structured logs for dispute related logging activity
- Remove `fee` from dispute_created event as `fee` and `net_amount` will only be included in dispute_lost event.
  Update notify template for new dispute email to hardcode fee.
- Added `disputedAmount` placeholder for the disputed amount. To remove `paymentAmount` once the notify template has been updated to use `disputedAmount`

