### PR TITLE
PP-9677 Remove fields from dispute lost email personalisation

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/queue/event/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/adminusers/queue/event/EventMessageHandler.java
@@ -161,9 +161,6 @@ public class EventMessageHandler {
                 Map<String, String> personalisation = getMinimumRequiredPersonalisation(disputeLostDetails.getGatewayAccountId(),
                         disputeLostEvent.getParentResourceExternalId());
 
-                personalisation.put("disputedAmount", convertPenceToPounds.apply(disputeLostDetails.getAmount()).toString());
-                personalisation.put("disputeFee", convertPenceToPounds.apply(disputeLostDetails.getFee()).toString());
-
                 sendEmailNotificationToServiceAdmins(disputeLostEvent.getEventType(), disputeLostDetails.getGatewayAccountId(),
                         personalisation);
 

--- a/src/test/java/uk/gov/pay/adminusers/queue/event/EventMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/queue/event/EventMessageHandlerTest.java
@@ -200,8 +200,6 @@ class EventMessageHandlerTest {
         assertThat(emails, hasItems("admin1@service.gov.uk", "admin2@service.gov.uk"));
         assertThat(personalisation.get("serviceName"), is(service.getName()));
         assertThat(personalisation.get("serviceReference"), is("tx ref"));
-        assertThat(personalisation.get("disputedAmount"), is("25.00"));
-        assertThat(personalisation.get("disputeFee"), is("15.00"));
         assertThat(personalisation.get("organisationName"), is(service.getMerchantDetails().getName()));
 
         verify(mockLogAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
@@ -243,8 +241,6 @@ class EventMessageHandlerTest {
         assertThat(emails, hasItems("admin1@service.gov.uk", "admin2@service.gov.uk"));
         assertThat(personalisation.get("serviceName"), is(service.getName()));
         assertThat(personalisation.get("serviceReference"), is("tx ref"));
-        assertThat(personalisation.get("disputedAmount"), is("25.00"));
-        assertThat(personalisation.get("disputeFee"), is("15.00"));
         assertThat(personalisation.get("organisationName"), is(service.getMerchantDetails().getName()));
 
         verify(mockLogAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());


### PR DESCRIPTION
Remove the disputeFee and disputeAmount fields from the personalisation
as these are not yet used by the Notify template.

The `fee` and `net_amount` fields will only be sent in the DISPUTE_LOST
event from connector when we are charging for disputes.

The story to update the template with information about the amount
charged for lost disputes can add these back in where appropriate.