### PR TITLE
PP-9841: Use different Notify template when a lost dispute has a fee

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/app/config/NotifyConfiguration.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/NotifyConfiguration.java
@@ -70,6 +70,10 @@ public class NotifyConfiguration extends Configuration {
 
     @Valid
     @NotNull
+    private String stripeDisputeLostAndServiceChargedEmailTemplateId;
+
+    @Valid
+    @NotNull
     private String stripeDisputeEvidenceSubmittedEmailTemplateId;
 
     @Valid
@@ -146,6 +150,10 @@ public class NotifyConfiguration extends Configuration {
 
     public String getStripeDisputeLostEmailTemplateId() {
         return stripeDisputeLostEmailTemplateId;
+    }
+
+    public String getStripeDisputeLostAndServiceChargedEmailTemplateId() {
+        return stripeDisputeLostAndServiceChargedEmailTemplateId;
     }
 
     public String getStripeDisputeEvidenceSubmittedEmailTemplateId() {

--- a/src/main/java/uk/gov/pay/adminusers/queue/event/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/adminusers/queue/event/EventMessageHandler.java
@@ -158,7 +158,7 @@ public class EventMessageHandler {
             MDC.put(GATEWAY_ACCOUNT_ID, disputeLostDetails.getGatewayAccountId());
 
             if (shallSendDisputeUpdatedEmail(disputeLostEvent)) {
-                Map<String, String> personalisation = getMinimumRequiredPersonalisation(disputeLostDetails.getGatewayAccountId(),
+                Map<String, String> personalisation = getPersonalisationForDisputeLost(disputeLostDetails,
                         disputeLostEvent.getParentResourceExternalId());
 
                 sendEmailNotificationToServiceAdmins(disputeLostEvent.getEventType(), disputeLostDetails.getGatewayAccountId(),
@@ -180,6 +180,17 @@ public class EventMessageHandler {
                         service.getMerchantDetails().getName() : service.getName(),
                 "serviceName", service.getName(),
                 "serviceReference", transaction.getReference()));
+    }
+
+    private Map<String, String> getPersonalisationForDisputeLost(DisputeLostDetails details, String parentResourceExternalId) {
+        var personalisation = getMinimumRequiredPersonalisation(details.getGatewayAccountId(), parentResourceExternalId);
+
+        if (details.getFee() != null) {
+            personalisation.put("disputedAmount", convertPenceToPounds.apply(details.getAmount()).toString());
+            personalisation.put("disputeFee", convertPenceToPounds.apply(details.getFee()).toString());
+        }
+
+        return personalisation;
     }
 
     private boolean shallSendDisputeUpdatedEmail(Event disputeLostEvent) {

--- a/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
@@ -40,6 +40,7 @@ public class NotificationService {
 
     private final String stripeDisputeCreatedEmailTemplateId;
     private final String stripeDisputeLostEmailTemplateId;
+    private final String stripeDisputeLostAndServiceChargedEmailTemplateId;
     private final String stripeDisputeEvidenceSubmittedEmailTemplateId;
     private final String stripeDisputeWonEmailTemplateId;
     private final String notifyEmailReplyToSupportId;
@@ -66,6 +67,7 @@ public class NotificationService {
         
         this.stripeDisputeCreatedEmailTemplateId = notifyConfiguration.getStripeDisputeCreatedEmailTemplateId();
         this.stripeDisputeLostEmailTemplateId = notifyConfiguration.getStripeDisputeLostEmailTemplateId();
+        this.stripeDisputeLostAndServiceChargedEmailTemplateId = notifyConfiguration.getStripeDisputeLostAndServiceChargedEmailTemplateId();
         this.stripeDisputeEvidenceSubmittedEmailTemplateId = notifyConfiguration.getStripeDisputeEvidenceSubmittedEmailTemplateId();
         this.stripeDisputeWonEmailTemplateId = notifyConfiguration.getStripeDisputeWonEmailTemplateId();
         this.notifyEmailReplyToSupportId = notifyConfiguration.getNotifyEmailReplyToSupportId();
@@ -159,7 +161,10 @@ public class NotificationService {
     }
 
     public void sendStripeDisputeLostEmail(Set<String> emailAddresses, Map<String, String> personalisation) {
-        emailAddresses.forEach(email -> sendEmail(stripeDisputeLostEmailTemplateId, email, personalisation, notifyEmailReplyToSupportId));
+        boolean hasFee = personalisation.containsKey("disputeFee");
+        String templateId = hasFee ? stripeDisputeLostAndServiceChargedEmailTemplateId : stripeDisputeLostEmailTemplateId;
+
+        emailAddresses.forEach(email -> sendEmail(templateId, email, personalisation, notifyEmailReplyToSupportId));
     }
 
     public void sendStripeDisputeEvidenceSubmittedEmail(Set<String> emailAddresses, Map<String, String> personalisation) {

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -84,6 +84,7 @@ notify:
   liveAccountCreatedEmailTemplateId: ${NOTIFY_LIVE_ACCOUNT_CREATED_EMAIL_TEMPLATE_ID:-pay-notify-live-account-created-email-template-id}
   stripeDisputeCreatedEmailTemplateId: ${NOTIFY_STRIPE_DISPUTE_CREATED_EMAIL_TEMPLATE_ID:-pay-notify-stripe-dispute-created-email-template-id}
   stripeDisputeLostEmailTemplateId: ${NOTIFY_STRIPE_DISPUTE_LOST_EMAIL_TEMPLATE_ID:-pay-notify-stripe-dispute-lost-email-template-id}
+  stripeDisputeLostAndServiceChargedEmailTemplateId: ${NOTIFY_STRIPE_DISPUTE_LOST_AND_SERVICE_CHARGED_EMAIL_TEMPLATE_ID:-pay-notify-stripe-dispute-lost-email-template-id}
   stripeDisputeEvidenceSubmittedEmailTemplateId: ${NOTIFY_STRIPE_DISPUTE_EVIDENCE_SUBMITTED_EMAIL_TEMPLATE_ID:-pay-notify-stripe-dispute-evidence-submitted-email-template-id}
   stripeDisputeWonEmailTemplateId: ${NOTIFY_STRIPE_DISPUTE_WON_EMAIL_TEMPLATE_ID:-pay-notify-stripe-dispute-won-email-template-id}
   notifyEmailReplyToSupportId: ${NOTIFY_EMAIL_REPLY_TO_SUPPORT_ID:-pay-notify-email-reply-to-support-id}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -73,6 +73,7 @@ notify:
   liveAccountCreatedEmailTemplateId: ${NOTIFY_LIVE_ACCOUNT_CREATED_EMAIL_TEMPLATE_ID:-pay-notify-live-account-created-email-template-id}
   stripeDisputeCreatedEmailTemplateId: ${NOTIFY_STRIPE_DISPUTE_CREATED_EMAIL_TEMPLATE_ID:-pay-notify-stripe-dispute-created-email-template-id}
   stripeDisputeLostEmailTemplateId: ${NOTIFY_STRIPE_DISPUTE_LOST_EMAIL_TEMPLATE_ID:-pay-notify-stripe-dispute-lost-email-template-id}
+  stripeDisputeLostAndServiceChargedEmailTemplateId: ${NOTIFY_STRIPE_DISPUTE_LOST_AND_SERVICE_CHARGED_EMAIL_TEMPLATE_ID:-pay-notify-stripe-dispute-lost-email-template-id}
   stripeDisputeEvidenceSubmittedEmailTemplateId: ${NOTIFY_STRIPE_DISPUTE_EVIDENCE_SUBMITTED_EMAIL_TEMPLATE_ID:-pay-notify-stripe-dispute-evidence-submitted-email-template-id}
   stripeDisputeWonEmailTemplateId: ${NOTIFY_STRIPE_DISPUTE_WON_EMAIL_TEMPLATE_ID:-pay-notify-stripe-dispute-won-email-template-id}
   notifyEmailReplyToSupportId: ${NOTIFY_EMAIL_REPLY_TO_SUPPORT_ID:-pay-notify-email-reply-to-support-id}


### PR DESCRIPTION
The NotificationService chooses between two different templates based on whether the personalisation info includes details of a fee.