### PR TITLE
PP-9671 Handle unknown event types

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/queue/event/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/adminusers/queue/event/EventMessageHandler.java
@@ -71,7 +71,7 @@ public class EventMessageHandler {
         List<EventMessage> eventMessages = eventSubscriberQueue.retrieveEvents();
         for (EventMessage message : eventMessages) {
             try {
-                EventType eventType = EventType.valueOf(message.getEvent().getEventType().toUpperCase());
+                EventType eventType = EventType.byType(message.getEvent().getEventType());
 
                 logger.info("Retrieved event queue message with id [{}] for resource external id [{}]",
                         message.getQueueMessage().getMessageId(), message.getEvent().getResourceExternalId());
@@ -90,7 +90,7 @@ public class EventMessageHandler {
                         handleDisputeWonMessage(message.getEvent());
                         break;
                     default:
-                        logger.warn("Unknown event type: {}", eventType);
+                        logger.info("Unknown event type: {}", message.getEvent().getEventType());
                 }
 
                 eventSubscriberQueue.markMessageAsProcessed(message.getQueueMessage());
@@ -176,8 +176,10 @@ public class EventMessageHandler {
         Service service = getService(gatewayAccountId);
         LedgerTransaction transaction = getTransaction(parentResourceExternalId);
 
-        return new HashMap<>(Map.of("organisationName", service.getMerchantDetails() != null ?
-                        service.getMerchantDetails().getName() : service.getName(),
+        String organisationName = (service.getMerchantDetails() != null && service.getMerchantDetails().getName() != null) ?
+                service.getMerchantDetails().getName() : service.getName();
+
+        return new HashMap<>(Map.of("organisationName", organisationName,
                 "serviceName", service.getName(),
                 "serviceReference", transaction.getReference()));
     }

--- a/src/main/java/uk/gov/pay/adminusers/queue/model/EventType.java
+++ b/src/main/java/uk/gov/pay/adminusers/queue/model/EventType.java
@@ -1,9 +1,23 @@
 package uk.gov.pay.adminusers.queue.model;
 
+import java.util.Arrays;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public enum EventType {
     DISPUTE_CREATED,
     DISPUTE_LOST,
     DISPUTE_WON,
-    DISPUTE_EVIDENCE_SUBMITTED
+    DISPUTE_EVIDENCE_SUBMITTED,
+    UNKNOWN;
+
+    public static EventType byType(String type) {
+        if (isBlank(type)) {
+            return UNKNOWN;
+        }
+        return Arrays.stream(EventType.values())
+                .filter(c -> c.name().equals(type.toUpperCase()))
+                .findFirst()
+                .orElse(UNKNOWN);
+    }
 }

--- a/src/test/java/uk/gov/pay/adminusers/queue/model/EventTypeTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/queue/model/EventTypeTest.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.adminusers.queue.model;
+
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.adminusers.queue.model.EventType.DISPUTE_CREATED;
+import static uk.gov.pay.adminusers.queue.model.EventType.UNKNOWN;
+
+class EventTypeTest {
+
+    @Test
+    void shouldGetCorrectEventTypeForValidValue() {
+        assertThat(EventType.byType("DISPUTE_CREATED"), is(DISPUTE_CREATED));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "",
+            "some-random-string"
+    })
+    @NullSource
+    void shouldReturnUnknownForEmptyValue(String value) {
+        assertThat(EventType.byType(value), is(UNKNOWN));
+    }
+}


### PR DESCRIPTION
## WHAT YOU DID
- Handle unknown event types better. The current way of getting EventType enum throws an exception if an event type is not in enum constants
