### PR TITLE
PP-9670 refactor sending dispute created email personalisation

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/queue/model/event/DisputeCreatedDetails.java
+++ b/src/main/java/uk/gov/pay/adminusers/queue/model/event/DisputeCreatedDetails.java
@@ -16,6 +16,7 @@ public class DisputeCreatedDetails {
     @JsonDeserialize(using = ApiResponseDateTimeDeserializer.class)
     private ZonedDateTime evidenceDueDate;
     private String gatewayAccountId;
+    private String reason;
 
     public DisputeCreatedDetails() {
         // empty constructor
@@ -31,5 +32,9 @@ public class DisputeCreatedDetails {
 
     public String getGatewayAccountId() {
         return gatewayAccountId;
+    }
+
+    public String getReason() {
+        return reason;
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/utils/dispute/DisputeReasonMapper.java
+++ b/src/main/java/uk/gov/pay/adminusers/utils/dispute/DisputeReasonMapper.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.adminusers.utils.dispute;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+public class DisputeReasonMapper {
+
+    public static String mapToNotifyEmail(String stripeReason) {
+        if (isBlank(stripeReason)) {
+            return "unknown";
+        }
+        switch (stripeReason) {
+            case "duplicate":
+            case "fraudulent":
+            case "general":
+                return stripeReason;
+            case "credit_not_processed":
+                return "credit not processed";
+            case "product_not_received":
+                return "product not received";
+            case "product_unacceptable":
+                return "product unacceptable";
+            case "subscription_canceled":
+                return "subscription cancelled";
+            case "unrecognized":
+                return "unrecognised";
+            default:
+                return "other";
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/queue/event/EventMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/queue/event/EventMessageHandlerTest.java
@@ -137,7 +137,7 @@ class EventMessageHandlerTest {
         var mockQueueMessage = mock(QueueMessage.class);
         disputeEvent = anEventFixture()
                 .withEventType(EventType.DISPUTE_CREATED.name())
-                .withEventDetails(new GsonBuilder().create().toJson(Map.of("amount", 21000L, "evidence_due_date", "2022-03-07T13:00:00.001Z", "gateway_account_id", gatewayAccountId)))
+                .withEventDetails(new GsonBuilder().create().toJson(Map.of("amount", 21000L, "evidence_due_date", "2022-03-07T13:00:00.001Z", "gateway_account_id", gatewayAccountId, "reason", "fraudulent")))
                 .withParentResourceExternalId("456")
                 .build();
         var eventMessage = EventMessage.of(disputeEvent, mockQueueMessage);
@@ -163,6 +163,9 @@ class EventMessageHandlerTest {
         assertThat(personalisation.get("paymentAmount"), is("210.00"));
         assertThat(personalisation.get("disputeEvidenceDueDate"), is("7 March 2022"));
         assertThat(personalisation.get("sendEvidenceToPayDueDate"), is("4 March 2022"));
+
+        assertThat(personalisation.get("fraudulent"), is("yes"));
+        assertThat(personalisation.get("disputedAmount"), is("210.00"));
 
         verify(mockLogAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
 

--- a/src/test/java/uk/gov/pay/adminusers/queue/model/event/DisputeCreatedDetailsTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/queue/model/event/DisputeCreatedDetailsTest.java
@@ -26,5 +26,6 @@ class DisputeCreatedDetailsTest {
         assertThat(disputeCreatedDetails.getAmount(), is(125000L));
         assertThat(disputeCreatedDetails.getEvidenceDueDate().toString(), is("2022-03-07T13:00:00.001Z"));
         assertThat(disputeCreatedDetails.getGatewayAccountId(), is("123"));
+        assertThat(disputeCreatedDetails.getReason(), is("fraudulent"));
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/utils/dispute/DisputeReasonMapperTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/dispute/DisputeReasonMapperTest.java
@@ -1,0 +1,34 @@
+package uk.gov.pay.adminusers.utils.dispute;
+
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class DisputeReasonMapperTest {
+
+    @Test
+    void shouldReturnUnrecognised() {
+        String mappedValue = DisputeReasonMapper.mapToNotifyEmail("unrecognized");
+        assertThat(mappedValue, is("unrecognised"));
+    }
+
+    @Test
+    void shouldReturnOther() {
+        String mappedValue = DisputeReasonMapper.mapToNotifyEmail("insufficient_funds");
+        assertThat(mappedValue, is("other"));
+    }
+
+    @Test
+    void shouldHandleNullValue() {
+        String mappedValue = DisputeReasonMapper.mapToNotifyEmail(null);
+        assertThat(mappedValue, is("unknown"));
+    }
+
+    @Test
+    void shouldHandleEmptyValue() {
+        String mappedValue = DisputeReasonMapper.mapToNotifyEmail("");
+        assertThat(mappedValue, is("unknown"));
+    }
+}


### PR DESCRIPTION
## WHAT YOU DID
- Add the new personalisation content variables to sending a dispute created email. Going to remove the unused ones in the next iteration, once the new template has been enabled.
