### PR TITLE
PP-9292 Fix deserialisation of events

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/queue/event/EventMessageHandler.java
+++ b/src/main/java/uk/gov/pay/adminusers/queue/event/EventMessageHandler.java
@@ -123,7 +123,7 @@ public class EventMessageHandler {
         try {
             setupMDC(disputeEvidenceSubmittedEvent);
 
-            var disputeEvidenceSubmittedDetails = objectMapper.readValue(disputeEvidenceSubmittedEvent.getEventDetails(), DisputeEvidenceSubmittedDetails.class);
+            var disputeEvidenceSubmittedDetails = objectMapper.treeToValue(disputeEvidenceSubmittedEvent.getEventDetails(), DisputeEvidenceSubmittedDetails.class);
 
             MDC.put(GATEWAY_ACCOUNT_ID, disputeEvidenceSubmittedDetails.getGatewayAccountId());
 
@@ -146,7 +146,7 @@ public class EventMessageHandler {
         try {
             setupMDC(disputeWonEvent);
 
-            var disputeWonDetails = objectMapper.readValue(disputeWonEvent.getEventDetails(), DisputeWonDetails.class);
+            var disputeWonDetails = objectMapper.treeToValue(disputeWonEvent.getEventDetails(), DisputeWonDetails.class);
 
             MDC.put(GATEWAY_ACCOUNT_ID, disputeWonDetails.getGatewayAccountId());
 
@@ -167,7 +167,7 @@ public class EventMessageHandler {
         try {
             setupMDC(disputeLostEvent);
 
-            var disputeLostDetails = objectMapper.readValue(disputeLostEvent.getEventDetails(), DisputeLostDetails.class);
+            var disputeLostDetails = objectMapper.treeToValue(disputeLostEvent.getEventDetails(), DisputeLostDetails.class);
 
             MDC.put(GATEWAY_ACCOUNT_ID, disputeLostDetails.getGatewayAccountId());
 
@@ -222,7 +222,7 @@ public class EventMessageHandler {
         try {
             setupMDC(disputeCreatedEvent);
 
-            var disputeCreatedDetails = objectMapper.readValue(disputeCreatedEvent.getEventDetails(), DisputeCreatedDetails.class);
+            var disputeCreatedDetails = objectMapper.treeToValue(disputeCreatedEvent.getEventDetails(), DisputeCreatedDetails.class);
 
             MDC.put(GATEWAY_ACCOUNT_ID, disputeCreatedDetails.getGatewayAccountId());
 

--- a/src/main/java/uk/gov/pay/adminusers/queue/event/EventSubscriberQueue.java
+++ b/src/main/java/uk/gov/pay/adminusers/queue/event/EventSubscriberQueue.java
@@ -44,7 +44,7 @@ public class EventSubscriberQueue extends AbstractQueue {
         try {
             SNSMessage snsMessage = objectMapper.readValue(queueMessage.getMessageBody(), SNSMessage.class);
             Event event = objectMapper.readValue(snsMessage.getMessage(), Event.class);
-
+            
             return EventMessage.of(event, queueMessage);
         } catch (IOException e) {
             logger.warn(

--- a/src/main/java/uk/gov/pay/adminusers/queue/model/Event.java
+++ b/src/main/java/uk/gov/pay/adminusers/queue/model/Event.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.adminusers.queue.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -13,7 +14,7 @@ public class Event {
     private String resourceExternalId;
     private String parentResourceExternalId;
     private String eventType;
-    private String eventDetails;
+    private JsonNode eventDetails;
     private String serviceId;
     private Boolean live;
 
@@ -24,7 +25,7 @@ public class Event {
     public Event(String resourceExternalId,
                  String parentResourceExternalId,
                  String eventType,
-                 String eventDetails,
+                 JsonNode eventDetails,
                  String serviceId,
                  Boolean live) {
         this.resourceExternalId = resourceExternalId;
@@ -47,7 +48,7 @@ public class Event {
         return eventType;
     }
 
-    public String getEventDetails() {
+    public JsonNode getEventDetails() {
         return eventDetails;
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/EventFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/EventFixture.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.adminusers.fixtures;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import uk.gov.pay.adminusers.queue.model.Event;
 
 public class EventFixture {
@@ -7,7 +8,7 @@ public class EventFixture {
     private String resourceExternalId = "a-resource-external-id";
     private String parentResourceExternalId;
     private String eventType = "AN_EVENT_TYPE";
-    private String eventDetails;
+    private JsonNode eventDetails;
     private String serviceId = "service_id";
     private Boolean live = false;
 
@@ -33,7 +34,7 @@ public class EventFixture {
         return this;
     }
     
-    public EventFixture withEventDetails(String eventDetails) {
+    public EventFixture withEventDetails(JsonNode eventDetails) {
         this.eventDetails = eventDetails;
         return this;
     }

--- a/src/test/java/uk/gov/pay/adminusers/queue/event/EventMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/queue/event/EventMessageHandlerTest.java
@@ -116,7 +116,7 @@ class EventMessageHandlerTest {
     void shouldMarkMessageAsProcessed() throws Exception {
         disputeEvent = anEventFixture()
                 .withEventType(EventType.DISPUTE_CREATED.name())
-                .withEventDetails(new GsonBuilder().create().toJson(Map.of("amount", 21000L, "evidence_due_date", "2022-03-07T13:00:00.001Z", "gateway_account_id", gatewayAccountId)))
+                .withEventDetails(objectMapper.valueToTree(Map.of("amount", 21000L, "evidence_due_date", "2022-03-07T13:00:00.001Z", "gateway_account_id", gatewayAccountId)))
                 .withParentResourceExternalId("456")
                 .build();
         when(mockServiceFinder.byGatewayAccountId(gatewayAccountId)).thenReturn(Optional.of(service));
@@ -137,7 +137,7 @@ class EventMessageHandlerTest {
         var mockQueueMessage = mock(QueueMessage.class);
         disputeEvent = anEventFixture()
                 .withEventType(EventType.DISPUTE_CREATED.name())
-                .withEventDetails(new GsonBuilder().create().toJson(Map.of("amount", 21000L, "evidence_due_date", "2022-03-07T13:00:00.001Z", "gateway_account_id", gatewayAccountId, "reason", "fraudulent")))
+                .withEventDetails(objectMapper.valueToTree(Map.of("amount", 21000L, "evidence_due_date", "2022-03-07T13:00:00.001Z", "gateway_account_id", gatewayAccountId, "reason", "fraudulent")))
                 .withParentResourceExternalId("456")
                 .build();
         var eventMessage = EventMessage.of(disputeEvent, mockQueueMessage);
@@ -179,7 +179,7 @@ class EventMessageHandlerTest {
         var mockQueueMessage = mock(QueueMessage.class);
         disputeEvent = anEventFixture()
                 .withEventType(EventType.DISPUTE_LOST.name())
-                .withEventDetails(new GsonBuilder().create().toJson(Map.of("net_amount", -4000L, "fee", 1500L, "amount", 2500L, "gateway_account_id", gatewayAccountId)))
+                .withEventDetails(objectMapper.valueToTree(Map.of("net_amount", -4000L, "fee", 1500L, "amount", 2500L, "gateway_account_id", gatewayAccountId)))
                 .withParentResourceExternalId("456")
                 .withServiceId(service.getExternalId())
                 .withLive(true)
@@ -217,7 +217,7 @@ class EventMessageHandlerTest {
         var mockQueueMessage = mock(QueueMessage.class);
         disputeEvent = anEventFixture()
                 .withEventType(EventType.DISPUTE_LOST.name())
-                .withEventDetails(new GsonBuilder().create().toJson(Map.of("net_amount", -4000L,
+                .withEventDetails(objectMapper.valueToTree(Map.of("net_amount", -4000L,
                         "fee", 1500L,
                         "amount", 2500L,
                         "gateway_account_id", gatewayAccountId)))
@@ -258,7 +258,7 @@ class EventMessageHandlerTest {
         var mockQueueMessage = mock(QueueMessage.class);
         disputeEvent = anEventFixture()
                 .withEventType(EventType.DISPUTE_LOST.name())
-                .withEventDetails(new GsonBuilder().create().toJson(Map.of("net_amount", -4000L,
+                .withEventDetails(objectMapper.valueToTree(Map.of("net_amount", -4000L,
                         "fee", 1500L,
                         "amount", 2500L,
                         "gateway_account_id", gatewayAccountId)))
@@ -287,7 +287,7 @@ class EventMessageHandlerTest {
         var mockQueueMessage = mock(QueueMessage.class);
         disputeEvent = anEventFixture()
                 .withEventType(EventType.DISPUTE_WON.name())
-                .withEventDetails(new GsonBuilder().create().toJson(Map.of("gateway_account_id", gatewayAccountId)))
+                .withEventDetails(objectMapper.valueToTree(Map.of("gateway_account_id", gatewayAccountId)))
                 .withParentResourceExternalId("456")
                 .withServiceId(service.getExternalId())
                 .withLive(true)
@@ -325,7 +325,7 @@ class EventMessageHandlerTest {
         var mockQueueMessage = mock(QueueMessage.class);
         disputeEvent = anEventFixture()
                 .withEventType(EventType.DISPUTE_EVIDENCE_SUBMITTED.name())
-                .withEventDetails(new GsonBuilder().create().toJson(Map.of("gateway_account_id", gatewayAccountId)))
+                .withEventDetails(objectMapper.valueToTree(Map.of("gateway_account_id", gatewayAccountId)))
                 .withParentResourceExternalId("456")
                 .withServiceId(service.getExternalId())
                 .withLive(true)
@@ -363,7 +363,7 @@ class EventMessageHandlerTest {
         var mockQueueMessage = mock(QueueMessage.class);
         disputeEvent = anEventFixture()
                 .withEventType(EventType.DISPUTE_LOST.name())
-                .withEventDetails(new GsonBuilder().create().toJson(Map.of("net_amount", -4000L, "fee", 1500L, "amount", 2500L, "gateway_account_id", gatewayAccountId)))
+                .withEventDetails(objectMapper.valueToTree(Map.of("net_amount", -4000L, "fee", 1500L, "amount", 2500L, "gateway_account_id", gatewayAccountId)))
                 .withParentResourceExternalId("456")
                 .withServiceId(service.getExternalId())
                 .withLive(true)
@@ -389,7 +389,7 @@ class EventMessageHandlerTest {
         var mockQueueMessage = mock(QueueMessage.class);
         disputeEvent = anEventFixture()
                 .withEventType(EventType.DISPUTE_CREATED.name())
-                .withEventDetails(new GsonBuilder().create().toJson(Map.of("amount", 21000L, "fee", 1500L, "evidence_due_date", "2022-03-07T13:00:00Z", "gateway_account_id", gatewayAccountId)))
+                .withEventDetails(objectMapper.valueToTree(Map.of("amount", 21000L, "fee", 1500L, "evidence_due_date", "2022-03-07T13:00:00Z", "gateway_account_id", gatewayAccountId)))
                 .withParentResourceExternalId("456")
                 .build();
         var eventMessage = EventMessage.of(disputeEvent, mockQueueMessage);
@@ -406,7 +406,7 @@ class EventMessageHandlerTest {
         var mockQueueMessage = mock(QueueMessage.class);
         disputeEvent = anEventFixture()
                 .withEventType(EventType.DISPUTE_CREATED.name())
-                .withEventDetails(new GsonBuilder().create().toJson(Map.of("amount", 21000L, "fee", 1500L, "evidence_due_date", "2022-03-07T13:00:00.001Z", "gateway_account_id", gatewayAccountId)))
+                .withEventDetails(objectMapper.valueToTree(Map.of("amount", 21000L, "fee", 1500L, "evidence_due_date", "2022-03-07T13:00:00.001Z", "gateway_account_id", gatewayAccountId)))
                 .withParentResourceExternalId("456")
                 .build();
         var eventMessage = EventMessage.of(disputeEvent, mockQueueMessage);
@@ -424,7 +424,7 @@ class EventMessageHandlerTest {
         var mockQueueMessage = mock(QueueMessage.class);
         disputeEvent = anEventFixture()
                 .withEventType(EventType.DISPUTE_CREATED.name())
-                .withEventDetails(new GsonBuilder().create().toJson(Map.of("amount", 21000L, "fee", 1500L, "evidence_due_date", "2022-03-07T13:00:00.001Z", "gateway_account_id", gatewayAccountId)))
+                .withEventDetails(objectMapper.valueToTree(Map.of("amount", 21000L, "fee", 1500L, "evidence_due_date", "2022-03-07T13:00:00.001Z", "gateway_account_id", gatewayAccountId)))
                 .withParentResourceExternalId("456")
                 .build();
         var eventMessage = EventMessage.of(disputeEvent, mockQueueMessage);

--- a/src/test/java/uk/gov/pay/adminusers/queue/event/EventSubscriberQueueTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/queue/event/EventSubscriberQueueTest.java
@@ -71,7 +71,6 @@ class EventSubscriberQueueTest {
         assertThat(event.getResourceExternalId(), is("dp_1KfoljHj08j2jFuBkNEd89sd"));
         assertThat(event.getParentResourceExternalId(), is("pk8vak8vfiii5hjvqpsa4dsd"));
         assertThat(event.getEventType(), is("DISPUTE_CREATED"));
-        
-        assertThat(event.getEventDetails(), is("{\"fee\":1500,\"evidence_due_date\":1648684799,\"gateway_account_id\":\"528\",\"amount\":1000,\"net_amount\":2500,\"reason\":\"fraudulent\"}"));
+        assertThat(event.getEventDetails().toString(), is("{\"fee\":1500,\"evidence_due_date\":1648684799,\"gateway_account_id\":\"528\",\"amount\":1000,\"net_amount\":2500,\"reason\":\"fraudulent\"}"));
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/queue/model/event/DisputeCreatedDetailsTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/queue/model/event/DisputeCreatedDetailsTest.java
@@ -20,7 +20,7 @@ class DisputeCreatedDetailsTest {
 
         var json = objectMapper.readTree(load(DISPUTE_CREATED_EVENT));
         var evt = objectMapper.treeToValue(json, Event.class);
-        var disputeCreatedDetails = objectMapper.readValue(evt.getEventDetails(), DisputeCreatedDetails.class);
+        var disputeCreatedDetails = objectMapper.treeToValue(evt.getEventDetails(), DisputeCreatedDetails.class);
 
         assertThat(evt.getEventType(), is(EventType.DISPUTE_CREATED.name()));
         assertThat(disputeCreatedDetails.getAmount(), is(125000L));

--- a/src/test/java/uk/gov/pay/adminusers/queue/model/event/DisputeEvidenceSubmittedDetailsTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/queue/model/event/DisputeEvidenceSubmittedDetailsTest.java
@@ -20,7 +20,7 @@ class DisputeEvidenceSubmittedDetailsTest {
 
         var json = objectMapper.readTree(load(DISPUTE_EVIDENCE_SUBMITTED_EVENT));
         var evt = objectMapper.treeToValue(json, Event.class);
-        var disputeLostDetails = objectMapper.readValue(evt.getEventDetails(), DisputeEvidenceSubmittedDetails.class);
+        var disputeLostDetails = objectMapper.treeToValue(evt.getEventDetails(), DisputeEvidenceSubmittedDetails.class);
 
         assertThat(evt.getEventType(), is(EventType.DISPUTE_EVIDENCE_SUBMITTED.name()));
         assertThat(disputeLostDetails.getGatewayAccountId(), is("123"));

--- a/src/test/java/uk/gov/pay/adminusers/queue/model/event/DisputeLostDetailsTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/queue/model/event/DisputeLostDetailsTest.java
@@ -20,7 +20,7 @@ class DisputeLostDetailsTest {
 
         var json = objectMapper.readTree(load(DISPUTE_LOST_EVENT));
         var evt = objectMapper.treeToValue(json, Event.class);
-        var disputeLostDetails = objectMapper.readValue(evt.getEventDetails(), DisputeLostDetails.class);
+        var disputeLostDetails = objectMapper.treeToValue(evt.getEventDetails(), DisputeLostDetails.class);
         
         assertThat(evt.getEventType(), is(EventType.DISPUTE_LOST.name()));
         assertThat(disputeLostDetails.getFee(), is(1500L));

--- a/src/test/java/uk/gov/pay/adminusers/queue/model/event/DisputeWonDetailsTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/queue/model/event/DisputeWonDetailsTest.java
@@ -20,7 +20,7 @@ class DisputeWonDetailsTest {
 
         var json = objectMapper.readTree(load(DISPUTE_WON_EVENT));
         var evt = objectMapper.treeToValue(json, Event.class);
-        var disputeLostDetails = objectMapper.readValue(evt.getEventDetails(), DisputeWonDetails.class);
+        var disputeLostDetails = objectMapper.treeToValue(evt.getEventDetails(), DisputeWonDetails.class);
 
         assertThat(evt.getEventType(), is(EventType.DISPUTE_WON.name()));
         assertThat(disputeLostDetails.getGatewayAccountId(), is("123"));

--- a/src/test/resources/templates/events/dispute_created_event.json
+++ b/src/test/resources/templates/events/dispute_created_event.json
@@ -2,7 +2,14 @@
   "event_type": "DISPUTE_CREATED",
   "service_id": "111111111",
   "resource_type": "dispute",
-  "event_details": "{\"fee\":1500,\"evidence_due_date\":\"2022-03-07T13:00:00.001Z\",\"gateway_account_id\":\"123\",\"amount\":125000,\"net_amount\":126500,\"reason\":\"fraudulent\"}",
+  "event_details": {
+    "fee": 1500,
+    "evidence_due_date": "2022-03-07T13:00:00.001Z",
+    "gateway_account_id": "123",
+    "amount": 125000,
+    "net_amount": 126500,
+    "reason": "fraudulent"
+  },
   "live": false,
   "timestamp": "2022-03-17T17:46:01.123456Z",
   "resource_external_id": "du_abcd",

--- a/src/test/resources/templates/events/dispute_evidence_submitted_event.json
+++ b/src/test/resources/templates/events/dispute_evidence_submitted_event.json
@@ -2,7 +2,7 @@
   "event_type": "DISPUTE_EVIDENCE_SUBMITTED",
   "service_id": "111111111",
   "resource_type": "dispute",
-  "event_details": "{\"gateway_account_id\":\"123\"}",
+  "event_details": {"gateway_account_id":"123"},
   "live": false,
   "timestamp": "2022-06-16T15:29:01.123456Z",
   "resource_external_id": "external_id",

--- a/src/test/resources/templates/events/dispute_lost_event.json
+++ b/src/test/resources/templates/events/dispute_lost_event.json
@@ -2,7 +2,7 @@
   "event_type": "DISPUTE_LOST",
   "service_id": "111111111",
   "resource_type": "dispute",
-  "event_details": "{\"net_amount\":-4000,\"amount\":2500,\"fee\":1500,\"gateway_account_id\":\"123\"}",
+  "event_details": {"net_amount":-4000,"amount":2500,"fee":1500,"gateway_account_id":"123"},
   "live": false,
   "timestamp": "2022-06-16T15:29:01.123456Z",
   "resource_external_id": "external_id",

--- a/src/test/resources/templates/events/dispute_won_event.json
+++ b/src/test/resources/templates/events/dispute_won_event.json
@@ -2,7 +2,7 @@
   "event_type": "DISPUTE_WON",
   "service_id": "111111111",
   "resource_type": "dispute",
-  "event_details": "{\"gateway_account_id\":\"123\"}",
+  "event_details": {"gateway_account_id":"123"},
   "live": false,
   "timestamp": "2022-06-16T15:29:01.123456Z",
   "resource_external_id": "external_id",

--- a/src/test/resources/templates/sns/dispute_created_sns_message.json
+++ b/src/test/resources/templates/sns/dispute_created_sns_message.json
@@ -1,6 +1,6 @@
 {
   "Type" : "Notification",
   "MessageId" : "6326cb99-e0ad-5ddb-9d2e-912b54b8b228",
-  "Message" : "{\"sqs_message_id\":\"6959d97f-ba36-4599-9751-3d811242202s4\",\"service_id\":\"5e0207ee342048d4ac4d1d05dd9ek3js\",\"live\":true,\"resource_type\":\"dispute\",\"resource_external_id\":\"dp_1KfoljHj08j2jFuBkNEd89sd\",\"parent_resource_external_id\":\"pk8vak8vfiii5hjvqpsa4dsd\",\"event_date\":\"2022-03-21T17:11:47.000000Z\",\"event_type\":\"DISPUTE_CREATED\",\"event_details\":\"{\\\"fee\\\":1500,\\\"evidence_due_date\\\":1648684799,\\\"gateway_account_id\\\":\\\"528\\\",\\\"amount\\\":1000,\\\"net_amount\\\":2500,\\\"reason\\\":\\\"fraudulent\\\"}\",\"reproject_domain_object\":false}",
+  "Message" : "{\"sqs_message_id\":\"6959d97f-ba36-4599-9751-3d811242202s4\",\"service_id\":\"5e0207ee342048d4ac4d1d05dd9ek3js\",\"live\":true,\"resource_type\":\"dispute\",\"resource_external_id\":\"dp_1KfoljHj08j2jFuBkNEd89sd\",\"parent_resource_external_id\":\"pk8vak8vfiii5hjvqpsa4dsd\",\"event_date\":\"2022-03-21T17:11:47.000000Z\",\"event_type\":\"DISPUTE_CREATED\",\"event_details\":{\"fee\":1500,\"evidence_due_date\":1648684799,\"gateway_account_id\":\"528\",\"amount\":1000,\"net_amount\":2500,\"reason\":\"fraudulent\"},\"reproject_domain_object\":false}",
   "Timestamp" : "2022-03-21T17:11:49.763Z"
 }


### PR DESCRIPTION
Ledger was previously re-serialising events to send to SNS with the
`event_details` value as an escaped JSON string.

This has been changed so that the event processed by ledger is directly
passed on without deserialising and then re-serialising the event
message in a way that transformed the `event_details` in this way.