### PR TITLE
PP-10041: Validate OTP during completion step

### DIFF
--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -1197,6 +1197,9 @@ components:
           example: +440787654534
         type:
           type: string
+          enum:
+          - USER
+          - SERVICE
           example: service
         user_exist:
           type: boolean

--- a/src/main/java/uk/gov/pay/adminusers/model/Invite.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Invite.java
@@ -23,7 +23,7 @@ public class Invite {
     private Integer attemptCounter = 0;
 
     private List<Link> links = new ArrayList<>();
-    private String type;
+    private InviteType type;
     private boolean userExist = false;
     private boolean expired;
     private boolean passwordSet;
@@ -35,7 +35,7 @@ public class Invite {
         this.telephoneNumber = telephoneNumber;
         this.disabled = disabled;
         this.attemptCounter = attemptCounter;
-        this.type = type;
+        this.type = InviteType.from(type);
         this.role = role;
         this.expired = expired;
         this.passwordSet = passwordSet;
@@ -94,12 +94,12 @@ public class Invite {
     }
 
     @Schema(example = "service")
-    public String getType() {
+    public InviteType getType() {
         return type;
     }
 
     public void setType(String type) {
-        this.type = type;
+        this.type = InviteType.from(type);
     }
 
     @JsonIgnore

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteOtpValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteOtpValidator.java
@@ -1,0 +1,34 @@
+package uk.gov.pay.adminusers.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import uk.gov.pay.adminusers.model.Invite;
+import uk.gov.pay.adminusers.model.InviteType;
+
+import javax.ws.rs.WebApplicationException;
+import java.util.Optional;
+
+public class InviteOtpValidator {
+    
+    public Optional<WebApplicationException> validate(Invite invite, JsonNode requestPayload) {
+        Optional<WebApplicationException> result = Optional.empty();
+        
+        switch (invite.getType()) {
+            case SERVICE: {
+                result = validateForServiceJourney(invite, requestPayload);
+            }
+            case USER: {
+                result = validateForUserJourney(invite, requestPayload);
+            }
+        }
+        
+        return result;
+    }
+
+    private Optional<WebApplicationException> validateForServiceJourney(Invite invite, JsonNode requestPayload) {
+        return null;
+    }
+
+    private Optional<WebApplicationException> validateForUserJourney(Invite invite, JsonNode requestPayload) {
+        return null;
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCreatorTest.java
@@ -67,7 +67,7 @@ public class ServiceInviteCreatorTest {
         verify(inviteDao, times(1)).persist(persistedInviteEntity.capture());
         assertThat(invite.getEmail(), is(request.getEmail()));
         assertThat(invite.getTelephoneNumber(), is("+441134960000"));
-        assertThat(invite.getType(), is("service"));
+        assertThat(invite.getType(), is(InviteType.SERVICE));
         assertThat(invite.getLinks().get(0).getHref(), matchesPattern("^http://selfservice/invites/[0-9a-z]{32}$"));
 
         assertThat(persistedInviteEntity.getValue().getPassword(), is("encrypted-password"));
@@ -90,7 +90,7 @@ public class ServiceInviteCreatorTest {
         verify(inviteDao, times(1)).persist(persistedInviteEntity.capture());
         assertThat(invite.getEmail(), is(request.getEmail()));
         assertThat(invite.getTelephoneNumber(), is(nullValue()));
-        assertThat(invite.getType(), is("service"));
+        assertThat(invite.getType(), is(InviteType.SERVICE));
         assertThat(invite.getLinks().get(0).getHref(), matchesPattern("^http://selfservice/invites/[0-9a-z]{32}$"));
 
         assertThat(persistedInviteEntity.getValue().getTelephoneNumber(), is(nullValue()));
@@ -113,7 +113,7 @@ public class ServiceInviteCreatorTest {
         verify(inviteDao, times(1)).persist(persistedInviteEntity.capture());
         assertThat(invite.getEmail(), is(request.getEmail()));
         assertThat(invite.getTelephoneNumber(), is("+441134960000"));
-        assertThat(invite.getType(), is("service"));
+        assertThat(invite.getType(), is(InviteType.SERVICE));
         assertThat(invite.getLinks().get(0).getHref(), matchesPattern("^http://selfservice/invites/[0-9a-z]{32}$"));
 
     }
@@ -142,7 +142,7 @@ public class ServiceInviteCreatorTest {
 
         verify(inviteDao, times(1)).merge(persistedInviteEntity.capture());
         assertThat(invite.getEmail(), is(request.getEmail()));
-        assertThat(invite.getType(), is("service"));
+        assertThat(invite.getType(), is(InviteType.SERVICE));
         assertThat(invite.getLinks().get(0).getHref(), is("http://selfservice/invites/code"));
     }
 
@@ -170,7 +170,7 @@ public class ServiceInviteCreatorTest {
         Invite invite = serviceInviteCreator.doInvite(request);
 
         assertThat(invite.getEmail(), is(request.getEmail()));
-        assertThat(invite.getType(), is("service"));
+        assertThat(invite.getType(), is(InviteType.SERVICE));
         assertThat(invite.getLinks().get(0).getHref().matches("^http://selfservice/invites/[0-9a-z]{32}$"), is(true));
     }
 


### PR DESCRIPTION
## WHAT YOU DID
* Validate the OTP when the `/{code}/complete` endpoint is invoked, so long as the request is not for an 'existing user' journey.
* At present this will be repeating the validation of the OTP, which will already have been performed by an earlier call, but we will remove the earlier duplicate soon once we have unified the divergent journey flows.
* The `Invite` model now represents its `type` field as an instance of the `InviteType` enum, rather than as a string.
  * I'm not sure whether this is legit.  I checked where the field gets used, but I am wondering whether the class is ever used in anything reflectiony; there are annotations on a lot of the fields but I'm not sure what they relate to - plausibly json serialisation/deserialisation, in which case this change might cause an issue?
* There is an opportunity to refactor the part of `InviteResource#completeInvite` which deals with actually completing the invite (the lengthy `return` statement beginning on line 136).  I think I will leave that until we have added a third value to the `inviteType` enum though.

## How to test

- Make sure the `completeInvite` method still succeeds/fails correctly for the relevant journeys (journeys 1 and 2 as described in the task).
- Consider whether the change to the `Invite` model is safe.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
