### PR TITLE
BAU: Update dropwizard to 2.0.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dropwizard.version>2.0.29</dropwizard.version>
+        <dropwizard.version>2.0.33</dropwizard.version>
         <hamcrest.version>2.2</hamcrest.version>
         <eclipselink.version>2.7.11</eclipselink.version>
         <guice.version>5.1.0</guice.version>


### PR DESCRIPTION
## WHAT YOU DID
* Bump dropwizard from 2.0.29 to 2.0.33.
* This fixes a low severity vulnerability reported by Snyk (CVE-2022-2047).
* The vulnerability is fixed in 2.0.32, but we may as go as far as we can within this major version.
* PP-9562 suggests it would not be trivial to update to 2.1.x.