### PR TITLE
PP-9814 Fix the OpenApi spec for search services

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/Yelp/detect-secrets
-  rev: f6027a0521e044ba46e54611cabd787b7a88d1a9 
+  rev: 70e6cf69f2d544a49729039a374d86d7b3e472d9
   hooks:
     - id: detect-secrets
       args: ['--baseline', '.secrets.baseline']

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,11 +1,14 @@
 {
-  "version": "1.1.0",
+  "version": "1.2.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
     },
     {
       "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
     },
     {
       "name": "Base64HighEntropyString",
@@ -18,8 +21,11 @@
       "name": "CloudantDetector"
     },
     {
+      "name": "GitHubTokenDetector"
+    },
+    {
       "name": "HexHighEntropyString",
-      "limit": 3
+      "limit": 3.0
     },
     {
       "name": "IbmCloudIamDetector"
@@ -38,13 +44,22 @@
       "name": "MailchimpDetector"
     },
     {
+      "name": "NpmDetector"
+    },
+    {
       "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
     },
     {
       "name": "SlackDetector"
     },
     {
       "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
     },
     {
       "name": "StripeDetector"
@@ -98,37 +113,74 @@
       {
         "type": "Hex High Entropy String",
         "filename": ".pre-commit-config.yaml",
-        "hashed_secret": "d8371c23f86b4df4be2854848f6f28f13d7582f5",
+        "hashed_secret": "7480301177f005722b05b9c2b80ec86d9d74b9fd",
         "is_verified": false,
         "line_number": 3
       }
     ],
-    "dev.yml": [
+    "openapi/adminusers_spec.yaml": [
       {
-        "type": "Secret Keyword",
-        "filename": "dev.yml",
-        "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
+        "type": "Hex High Entropy String",
+        "filename": "openapi/adminusers_spec.yaml",
+        "hashed_secret": "675fecb5af336276574d3d88a4d382d961cf7418",
         "is_verified": false,
-        "line_number": 8,
-        "is_secret": false
+        "line_number": 55
       },
       {
         "type": "Secret Keyword",
-        "filename": "dev.yml",
-        "hashed_secret": "0838dfce4c5ff12e20d5509df30db2851cbfae29",
+        "filename": "openapi/adminusers_spec.yaml",
+        "hashed_secret": "699b58571f2c1cb5611f23879bb3e91465a13d75",
         "is_verified": false,
-        "line_number": 16,
-        "is_secret": false
-      }
-    ],
-    "docs/api_specification.md": [
+        "line_number": 153
+      },
       {
         "type": "Secret Keyword",
-        "filename": "docs/api_specification.md",
+        "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "0ea7458942ab65e0a340cf4fd28ca00d93c494f3",
         "is_verified": false,
-        "line_number": 227,
-        "is_secret": false
+        "line_number": 266
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "openapi/adminusers_spec.yaml",
+        "hashed_secret": "675fecb5af336276574d3d88a4d382d961cf7418",
+        "is_verified": false,
+        "line_number": 290
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "openapi/adminusers_spec.yaml",
+        "hashed_secret": "fefda504251b73d30a7cf3d047d241388a3c11b3",
+        "is_verified": false,
+        "line_number": 291
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi/adminusers_spec.yaml",
+        "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
+        "is_verified": false,
+        "line_number": 403
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi/adminusers_spec.yaml",
+        "hashed_secret": "1976a945a8d2733655e4b2453bd49fb59cb7ba19",
+        "is_verified": false,
+        "line_number": 663
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi/adminusers_spec.yaml",
+        "hashed_secret": "a31519136d26754afeb0df49b5f066f387091f88",
+        "is_verified": false,
+        "line_number": 697
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi/adminusers_spec.yaml",
+        "hashed_secret": "3660e32cde5fccc8d1e4521d0c831c2012388720",
+        "is_verified": false,
+        "line_number": 1153
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/model/CreateUserRequest.java": [
@@ -137,7 +189,30 @@
         "filename": "src/main/java/uk/gov/pay/adminusers/model/CreateUserRequest.java",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 24
+        "line_number": 26
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/main/java/uk/gov/pay/adminusers/model/CreateUserRequest.java",
+        "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
+        "is_verified": false,
+        "line_number": 42
+      }
+    ],
+    "src/main/java/uk/gov/pay/adminusers/model/ForgottenPassword.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/main/java/uk/gov/pay/adminusers/model/ForgottenPassword.java",
+        "hashed_secret": "675fecb5af336276574d3d88a4d382d961cf7418",
+        "is_verified": false,
+        "line_number": 46
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/main/java/uk/gov/pay/adminusers/model/ForgottenPassword.java",
+        "hashed_secret": "3660e32cde5fccc8d1e4521d0c831c2012388720",
+        "is_verified": false,
+        "line_number": 57
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/model/InviteOtpRequest.java": [
@@ -146,7 +221,7 @@
         "filename": "src/main/java/uk/gov/pay/adminusers/model/InviteOtpRequest.java",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 11
+        "line_number": 15
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/model/InviteServiceRequest.java": [
@@ -158,13 +233,38 @@
         "line_number": 10
       }
     ],
+    "src/main/java/uk/gov/pay/adminusers/model/Service.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/main/java/uk/gov/pay/adminusers/model/Service.java",
+        "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
+        "is_verified": false,
+        "line_number": 31
+      }
+    ],
     "src/main/java/uk/gov/pay/adminusers/model/User.java": [
       {
         "type": "Secret Keyword",
         "filename": "src/main/java/uk/gov/pay/adminusers/model/User.java",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 20
+        "line_number": 21
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/main/java/uk/gov/pay/adminusers/model/User.java",
+        "hashed_secret": "a31519136d26754afeb0df49b5f066f387091f88",
+        "is_verified": false,
+        "line_number": 27
+      }
+    ],
+    "src/main/java/uk/gov/pay/adminusers/resources/ForgottenPasswordResource.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/main/java/uk/gov/pay/adminusers/resources/ForgottenPasswordResource.java",
+        "hashed_secret": "675fecb5af336276574d3d88a4d382d961cf7418",
+        "is_verified": false,
+        "line_number": 88
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/resources/ResetPasswordResource.java": [
@@ -173,8 +273,55 @@
         "filename": "src/main/java/uk/gov/pay/adminusers/resources/ResetPasswordResource.java",
         "hashed_secret": "f054ffc85b4c1615a7190ea0b248564bb1e9f9ab",
         "is_verified": false,
-        "line_number": 28,
-        "is_secret": false
+        "line_number": 33
+      }
+    ],
+    "src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java",
+        "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
+        "is_verified": false,
+        "line_number": 118
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java",
+        "hashed_secret": "1976a945a8d2733655e4b2453bd49fb59cb7ba19",
+        "is_verified": false,
+        "line_number": 356
+      }
+    ],
+    "src/main/java/uk/gov/pay/adminusers/resources/ToolboxEndpointResource.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/main/java/uk/gov/pay/adminusers/resources/ToolboxEndpointResource.java",
+        "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
+        "is_verified": false,
+        "line_number": 50
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/main/java/uk/gov/pay/adminusers/resources/ToolboxEndpointResource.java",
+        "hashed_secret": "a31519136d26754afeb0df49b5f066f387091f88",
+        "is_verified": false,
+        "line_number": 52
+      }
+    ],
+    "src/main/java/uk/gov/pay/adminusers/resources/UserResource.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/main/java/uk/gov/pay/adminusers/resources/UserResource.java",
+        "hashed_secret": "a31519136d26754afeb0df49b5f066f387091f88",
+        "is_verified": false,
+        "line_number": 117
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/main/java/uk/gov/pay/adminusers/resources/UserResource.java",
+        "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
+        "is_verified": false,
+        "line_number": 432
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/service/ForgottenPasswordServices.java": [
@@ -192,8 +339,7 @@
         "filename": "src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java",
         "hashed_secret": "95578813f8acdd659caf14acd19b09c875addbb6",
         "is_verified": false,
-        "line_number": 27,
-        "is_secret": false
+        "line_number": 27
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/pact/ContractTest.java": [
@@ -202,8 +348,7 @@
         "filename": "src/test/java/uk/gov/pay/adminusers/pact/ContractTest.java",
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_verified": false,
-        "line_number": 132,
-        "is_secret": false
+        "line_number": 132
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGenerateOtpIT.java": [
@@ -212,8 +357,7 @@
         "filename": "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGenerateOtpIT.java",
         "hashed_secret": "833b5c8e76b19b617849d9a67a5980f08c784882",
         "is_verified": false,
-        "line_number": 24,
-        "is_secret": false
+        "line_number": 24
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpIT.java": [
@@ -222,8 +366,7 @@
         "filename": "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpIT.java",
         "hashed_secret": "833b5c8e76b19b617849d9a67a5980f08c784882",
         "is_verified": false,
-        "line_number": 36,
-        "is_secret": false
+        "line_number": 36
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceServiceCompleteIT.java": [
@@ -232,8 +375,7 @@
         "filename": "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceServiceCompleteIT.java",
         "hashed_secret": "969c35357bb1a825bf84783da60799e29511e357",
         "is_verified": false,
-        "line_number": 32,
-        "is_secret": false
+        "line_number": 32
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceUserCompleteIT.java": [
@@ -242,8 +384,7 @@
         "filename": "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceUserCompleteIT.java",
         "hashed_secret": "969c35357bb1a825bf84783da60799e29511e357",
         "is_verified": false,
-        "line_number": 24,
-        "is_secret": false
+        "line_number": 24
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/resources/ResetPasswordResourceIT.java": [
@@ -261,8 +402,7 @@
         "filename": "src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceGovUkPayAgreementResourceIT.java",
         "hashed_secret": "c3a8fcf85a56dee95cff4ce7adf0bb9a4c18f747",
         "is_verified": false,
-        "line_number": 59,
-        "is_secret": false
+        "line_number": 59
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationIT.java": [
@@ -271,8 +411,7 @@
         "filename": "src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationIT.java",
         "hashed_secret": "95578813f8acdd659caf14acd19b09c875addbb6",
         "is_verified": false,
-        "line_number": 60,
-        "is_secret": false
+        "line_number": 60
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/service/InviteServiceTest.java": [
@@ -281,8 +420,7 @@
         "filename": "src/test/java/uk/gov/pay/adminusers/service/InviteServiceTest.java",
         "hashed_secret": "7300c52390b4026eb1a60642b0eabfb54475c21b",
         "is_verified": false,
-        "line_number": 48,
-        "is_secret": false
+        "line_number": 48
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/service/ResetPasswordServiceTest.java": [
@@ -314,8 +452,7 @@
         "filename": "src/test/java/uk/gov/pay/adminusers/service/SecondFactorAuthenticatorTest.java",
         "hashed_secret": "e9fe51f94eadabf54dbf2fbbd57188b9abee436e",
         "is_verified": false,
-        "line_number": 27,
-        "is_secret": false
+        "line_number": 27
       },
       {
         "type": "Secret Keyword",
@@ -331,10 +468,9 @@
         "filename": "src/test/resources/config/test-it-config.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_verified": false,
-        "line_number": 23,
-        "is_secret": false
+        "line_number": 23
       }
     ]
   },
-  "generated_at": "2021-09-29T14:41:21Z"
+  "generated_at": "2022-10-04T09:48:34Z"
 }

--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -389,15 +389,13 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Service'
+                $ref: '#/components/schemas/SearchServicesResponse'
           description: OK
         "400":
           description: Invalid JSON payload
       summary: Search services by name or merchant name
       tags:
-      - Toolbox
+      - Services
   /v1/api/services/{serviceExternalId}:
     get:
       operationId: findService
@@ -1350,6 +1348,17 @@ components:
           items:
             $ref: '#/components/schemas/Permission'
           uniqueItems: true
+    SearchServicesResponse:
+      type: object
+      properties:
+        merchant_results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Service'
+        name_results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Service'
     Service:
       type: object
       properties:

--- a/src/main/java/uk/gov/pay/adminusers/model/SearchServicesResponse.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/SearchServicesResponse.java
@@ -1,0 +1,26 @@
+package uk.gov.pay.adminusers.model;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.util.List;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class SearchServicesResponse {
+    private final List<Service> nameResults;
+    
+    private final List<Service> merchantResults;
+
+    public SearchServicesResponse(List<Service> nameResults, List<Service> merchantResults) {
+        this.nameResults = nameResults;
+        this.merchantResults = merchantResults;
+    }
+
+    public List<Service> getNameResults() {
+        return nameResults;
+    }
+
+    public List<Service> getMerchantResults() {
+        return merchantResults;
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
@@ -151,7 +151,7 @@ public class ServiceResource {
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
     @Operation(
-            tags = "Toolbox",
+            tags = "Services",
             summary = "Search services by name or merchant name",
             description = "This endpoint returns a list of services using lexical meaning to determine a match to the search criteria",
             requestBody = @RequestBody(
@@ -162,7 +162,7 @@ public class ServiceResource {
             ),
             responses = {
                     @ApiResponse(responseCode = "200", description = "OK",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = Service.class)))),
+                            content = @Content(schema = @Schema(implementation = SearchServicesResponse.class))),
                     @ApiResponse(responseCode = "400", description = "Invalid JSON payload")
             }
     )

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceFinder.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceFinder.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.adminusers.service;
 
 import com.google.inject.Inject;
+import uk.gov.pay.adminusers.model.SearchServicesResponse;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.ServiceSearchRequest;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
@@ -35,12 +36,12 @@ public class ServiceFinder {
                 .map(serviceEntity -> linksBuilder.decorate(serviceEntity.toService()));
     }
     
-    public Map<String, List<?>> bySearchRequest(ServiceSearchRequest request) {
-        var servicesByName = !isBlank(request.getServiceNameSearchString()) ? streamServiceEntitiesToServices(serviceDao
+    public SearchServicesResponse bySearchRequest(ServiceSearchRequest request) {
+        List<Service> servicesByName = !isBlank(request.getServiceNameSearchString()) ? streamServiceEntitiesToServices(serviceDao
                 .findByENServiceName(request.getServiceNameSearchString())) : Collections.emptyList();
-        var servicesByMerchantName = !isBlank(request.getServiceMerchantNameSearchString()) ? streamServiceEntitiesToServices(serviceDao
+        List<Service> servicesByMerchantName = !isBlank(request.getServiceMerchantNameSearchString()) ? streamServiceEntitiesToServices(serviceDao
                 .findByServiceMerchantName(request.getServiceMerchantNameSearchString())) : Collections.emptyList();
-        return Map.of("name_results", servicesByName, "merchant_results", servicesByMerchantName);
+        return new SearchServicesResponse(servicesByName, servicesByMerchantName);
     }
     
     private List<Service> streamServiceEntitiesToServices (List<ServiceEntity> serviceEntities) {

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceFinderTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceFinderTest.java
@@ -78,8 +78,8 @@ public class ServiceFinderTest {
         when(serviceDao.findByENServiceName("serv")).thenReturn(serviceEntities);
         var searchRequest = new ServiceSearchRequest("serv", "");
         var results = serviceFinder.bySearchRequest(searchRequest);
-        var servicesByName = (List<Service>) results.get("name_results");
-        var servicesByMerchant = (List<Service>) serviceFinder.bySearchRequest(searchRequest).get("merchant_results");
+        var servicesByName = (List<Service>) results.getNameResults();
+        var servicesByMerchant = (List<Service>) serviceFinder.bySearchRequest(searchRequest).getMerchantResults();
         assertThat(servicesByName.size(), is(2));
         assertThat(servicesByName.stream().map(Service::getName).collect(Collectors.toSet()), containsInAnyOrder("serv 1", "serv 2"));
         assertThat(servicesByMerchant, is(empty()));
@@ -93,8 +93,8 @@ public class ServiceFinderTest {
         when(serviceDao.findByServiceMerchantName("merchant name")).thenReturn(serviceEntities);
         var searchRequest = new ServiceSearchRequest("", "merchant name");
         var results = serviceFinder.bySearchRequest(searchRequest);
-        var servicesByName = (List<Service>) results.get("name_results");
-        var servicesByMerchant = (List<Service>) serviceFinder.bySearchRequest(searchRequest).get("merchant_results");
+        var servicesByName = (List<Service>) results.getNameResults();
+        var servicesByMerchant = (List<Service>) serviceFinder.bySearchRequest(searchRequest).getMerchantResults();
         assertThat(servicesByMerchant.size(), is(2));
         assertThat(servicesByMerchant.stream().map(Service::getName).collect(Collectors.toSet()), containsInAnyOrder("serv 3", "serv 4"));
         assertThat(servicesByName, is(empty()));
@@ -110,8 +110,8 @@ public class ServiceFinderTest {
         when(serviceDao.findByServiceMerchantName("merchant name")).thenReturn(serviceEntities2);
         var searchRequest = new ServiceSearchRequest("serv", "merchant name");
         var results = serviceFinder.bySearchRequest(searchRequest);
-        var servicesByName = (List<Service>) results.get("name_results");
-        var servicesByMerchant = (List<Service>) serviceFinder.bySearchRequest(searchRequest).get("merchant_results");
+        var servicesByName = (List<Service>) results.getNameResults();
+        var servicesByMerchant = (List<Service>) serviceFinder.bySearchRequest(searchRequest).getMerchantResults();
         assertThat(servicesByName.size(), is(2));
         assertThat(servicesByMerchant.size(), is(2));
         assertThat(servicesByName.stream().map(Service::getName).collect(Collectors.toSet()), containsInAnyOrder("serv 1", "serv 2"));
@@ -123,8 +123,8 @@ public class ServiceFinderTest {
     public void shouldReturnEmptyLists_whenSearchRequestParamsAreBlank() {
         var searchRequest = new ServiceSearchRequest("", "");
         var results = serviceFinder.bySearchRequest(searchRequest);
-        var servicesByName = (List<Service>) results.get("name_results");
-        var servicesByMerchant = (List<Service>) serviceFinder.bySearchRequest(searchRequest).get("merchant_results");
+        var servicesByName = (List<Service>) results.getNameResults();
+        var servicesByMerchant = (List<Service>) serviceFinder.bySearchRequest(searchRequest).getMerchantResults();
         verify(serviceDao, never()).findByENServiceName(anyString());
         verify(serviceDao, never()).findByServiceMerchantName(anyString());
         assertThat(servicesByName, is(empty()));


### PR DESCRIPTION
The OpenApi schema for the search services response was incorrectly stating that the response was an array of services. However, it actually returns an object with two fields: `name_results` and `merchant_results`

Fix this by creating a Java class to represent the response, rather than returning a Map and use this as the schema for the OpenApi spec.

Regenerated .secrets.baseline file using version 1.2.0 of detect-secrets, as used by other repositories.