### PR TITLE
PP-10041: Add new InviteType constants and refactor invite completers

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/model/InviteType.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/InviteType.java
@@ -4,7 +4,14 @@ import static java.lang.String.format;
 
 public enum InviteType {
 
-    USER("user"), SERVICE("service");
+    // Old values; these are still in use.
+    USER("user"),
+    SERVICE("service"),
+
+    // New values; these are not used yet.
+    EXISTING_USER_INVITED_TO_EXISTING_SERVICE("existing_user_invited_to_existing_service"),
+    NEW_USER_INVITED_TO_EXISTING_SERVICE("new_user_invited_to_existing_service"),
+    NEW_USER_AND_NEW_SERVICE_SELF_SIGNUP("new_user_new_service_self_signup");
 
     private String type;
 

--- a/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
@@ -21,7 +21,6 @@ import uk.gov.pay.adminusers.model.InviteServiceRequest;
 import uk.gov.pay.adminusers.model.InviteUserRequest;
 import uk.gov.pay.adminusers.model.InviteValidateOtpRequest;
 import uk.gov.pay.adminusers.model.User;
-import uk.gov.pay.adminusers.service.InviteCompleter;
 import uk.gov.pay.adminusers.service.InviteOtpDispatcher;
 import uk.gov.pay.adminusers.service.InviteService;
 import uk.gov.pay.adminusers.service.InviteServiceFactory;

--- a/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
@@ -117,8 +117,7 @@ public class InviteResource {
         }
 
         return inviteServiceFactory.inviteCompleteRouter().routeComplete(inviteCode)
-                .map(inviteCompleterAndValidate -> {
-                    InviteCompleter inviteCompleter = inviteCompleterAndValidate.getLeft();
+                .map(inviteCompleter -> {
                     return inviteCompleter.withData(inviteCompleteRequestFrom(payload)).complete(inviteCode)
                             .map(inviteCompleteResponse -> Response.status(OK).entity(inviteCompleteResponse).build())
                             .orElseGet(() -> Response.status(NOT_FOUND).build());

--- a/src/main/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleter.java
@@ -13,13 +13,13 @@ import static java.lang.String.format;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.internalServerError;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.inviteLockedException;
 
-public class UserInviteCompleter extends InviteCompleter {
+public class ExistingUserInviteCompleter extends InviteCompleter {
 
     private final InviteDao inviteDao;
     private final UserDao userDao;
 
     @Inject
-    public UserInviteCompleter(InviteDao inviteDao, UserDao userDao) {
+    public ExistingUserInviteCompleter(InviteDao inviteDao, UserDao userDao) {
         super();
         this.inviteDao = inviteDao;
         this.userDao = userDao;

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteRouter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteRouter.java
@@ -23,7 +23,7 @@ public class InviteRouter {
         return routeIfExist(inviteCode,
                 inviteEntity -> {
                     boolean isServiceType = inviteEntity.isServiceType();
-                    InviteCompleter inviteCompleter = isServiceType ? inviteServiceFactory.completeServiceInvite() : inviteServiceFactory.completeExistingUserInvite();
+                    InviteCompleter inviteCompleter = isServiceType ? inviteServiceFactory.completeSelfSignupInvite() : inviteServiceFactory.completeExistingUserInvite();
                     return Optional.of(Pair.of(inviteCompleter, isServiceType));
                 });
     }

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteRouter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteRouter.java
@@ -23,7 +23,7 @@ public class InviteRouter {
         return routeIfExist(inviteCode,
                 inviteEntity -> {
                     boolean isServiceType = inviteEntity.isServiceType();
-                    InviteCompleter inviteCompleter = isServiceType ? inviteServiceFactory.completeServiceInvite() : inviteServiceFactory.completeUserInvite();
+                    InviteCompleter inviteCompleter = isServiceType ? inviteServiceFactory.completeServiceInvite() : inviteServiceFactory.completeExistingUserInvite();
                     return Optional.of(Pair.of(inviteCompleter, isServiceType));
                 });
     }

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteRouter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteRouter.java
@@ -19,12 +19,12 @@ public class InviteRouter {
         this.inviteDao = inviteDao;
     }
 
-    public Optional<Pair<InviteCompleter, Boolean>> routeComplete(String inviteCode) {
+    public Optional<InviteCompleter> routeComplete(String inviteCode) {
         return routeIfExist(inviteCode,
                 inviteEntity -> {
                     boolean isServiceType = inviteEntity.isServiceType();
                     InviteCompleter inviteCompleter = isServiceType ? inviteServiceFactory.completeSelfSignupInvite() : inviteServiceFactory.completeExistingUserInvite();
-                    return Optional.of(Pair.of(inviteCompleter, isServiceType));
+                    return Optional.of(inviteCompleter);
                 });
     }
 
@@ -38,7 +38,7 @@ public class InviteRouter {
 
     }
 
-    private <T> Optional<Pair<T, Boolean>> routeIfExist(String inviteCode, Function<InviteEntity, Optional<Pair<T, Boolean>>> routeFunction) {
+    private <T> Optional<T> routeIfExist(String inviteCode, Function<InviteEntity, Optional<T>> routeFunction) {
         return inviteDao.findByCode(inviteCode).map(routeFunction)
                 .orElseGet(Optional::empty);
     }

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteServiceFactory.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteServiceFactory.java
@@ -13,7 +13,7 @@ public interface InviteServiceFactory {
 
     ServiceInviteCompleter completeServiceInvite();
 
-    UserInviteCompleter completeUserInvite();
+    ExistingUserInviteCompleter completeExistingUserInvite();
 
     InviteRouter inviteOtpRouter();
 

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteServiceFactory.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteServiceFactory.java
@@ -13,6 +13,8 @@ public interface InviteServiceFactory {
 
     SelfSignupInviteCompleter completeSelfSignupInvite();
 
+    NewUserExistingServiceInviteCompleter completeNewUserExistingServiceInvite();
+
     ExistingUserInviteCompleter completeExistingUserInvite();
 
     InviteRouter inviteOtpRouter();

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteServiceFactory.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteServiceFactory.java
@@ -11,7 +11,7 @@ public interface InviteServiceFactory {
 
     InviteRouter inviteCompleteRouter();
 
-    ServiceInviteCompleter completeServiceInvite();
+    SelfSignupInviteCompleter completeSelfSignupInvite();
 
     ExistingUserInviteCompleter completeExistingUserInvite();
 

--- a/src/main/java/uk/gov/pay/adminusers/service/NewUserExistingServiceInviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NewUserExistingServiceInviteCompleter.java
@@ -1,0 +1,77 @@
+package uk.gov.pay.adminusers.service;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.adminusers.model.Invite;
+import uk.gov.pay.adminusers.model.InviteCompleteResponse;
+import uk.gov.pay.adminusers.model.InviteType;
+import uk.gov.pay.adminusers.model.User;
+import uk.gov.pay.adminusers.persistence.dao.InviteDao;
+import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
+import uk.gov.pay.adminusers.persistence.dao.UserDao;
+import uk.gov.pay.adminusers.persistence.entity.UserEntity;
+
+import javax.ws.rs.WebApplicationException;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+import static uk.gov.pay.adminusers.service.AdminUsersExceptions.conflictingEmail;
+import static uk.gov.pay.adminusers.service.AdminUsersExceptions.internalServerError;
+import static uk.gov.pay.adminusers.service.AdminUsersExceptions.inviteLockedException;
+import static uk.gov.pay.adminusers.service.AdminUsersExceptions.notFoundInviteException;
+
+public class NewUserExistingServiceInviteCompleter extends InviteCompleter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NewUserExistingServiceInviteCompleter.class);
+    
+    private final InviteDao inviteDao;
+    private final UserDao userDao;
+    private final LinksBuilder linksBuilder;
+
+    @Inject
+    public NewUserExistingServiceInviteCompleter(InviteDao inviteDao, UserDao userDao, LinksBuilder linksBuilder) {
+        super();
+        this.inviteDao = inviteDao;
+        this.userDao = userDao;
+        this.linksBuilder = linksBuilder;
+    }
+
+    @Override
+    @Transactional
+    public Optional<InviteCompleteResponse> complete(String inviteCode) {
+        return inviteDao.findByCode(inviteCode)
+                .map(inviteEntity -> {
+                    if (inviteEntity.isExpired() || inviteEntity.isDisabled()) {
+                        throw inviteLockedException(inviteEntity.getCode());
+                    }
+                    if (userDao.findByEmail(inviteEntity.getEmail()).isPresent()) {
+                        throw conflictingEmail(inviteEntity.getEmail());
+                    }
+                    if (inviteEntity.getType() != InviteType.NEW_USER_INVITED_TO_EXISTING_SERVICE) {
+                        throw internalServerError(format("Attempting to complete a 'new user, existing service' invite for an invite of type '%s'", inviteEntity.getCode()));
+                    }
+                    
+                    UserEntity userEntity = inviteEntity.mapToUserEntity();
+                    userDao.persist(userEntity);
+                    inviteEntity.setDisabled(Boolean.TRUE);
+                    inviteDao.merge(inviteEntity);
+                    
+                    String serviceIds = userEntity.getServicesRoles().stream()
+                            .map(serviceRole -> serviceRole.getService().getExternalId())
+                            .collect(Collectors.joining(", "));
+
+                    LOGGER.info("User created successfully from invitation [{}] for services [{}]", userEntity.getExternalId(), serviceIds);
+
+                    Invite invite = linksBuilder.addUserLink(userEntity.toUser(), inviteEntity.toInvite());
+                    InviteCompleteResponse response = new InviteCompleteResponse(invite);
+                    response.setUserExternalId(userEntity.getExternalId());
+
+                    return Optional.of(response);
+                })
+                .orElseThrow(() -> notFoundInviteException(inviteCode));
+    }
+
+}

--- a/src/main/java/uk/gov/pay/adminusers/service/SelfSignupInviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/SelfSignupInviteCompleter.java
@@ -19,7 +19,7 @@ import static uk.gov.pay.adminusers.service.AdminUsersExceptions.conflictingEmai
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.internalServerError;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.inviteLockedException;
 
-public class ServiceInviteCompleter extends InviteCompleter {
+public class SelfSignupInviteCompleter extends InviteCompleter {
 
     private final InviteDao inviteDao;
     private final UserDao userDao;
@@ -27,7 +27,7 @@ public class ServiceInviteCompleter extends InviteCompleter {
     private final LinksBuilder linksBuilder;
 
     @Inject
-    public ServiceInviteCompleter(InviteDao inviteDao, UserDao userDao, ServiceDao serviceDao, LinksBuilder linksBuilder) {
+    public SelfSignupInviteCompleter(InviteDao inviteDao, UserDao userDao, ServiceDao serviceDao, LinksBuilder linksBuilder) {
         super();
         this.inviteDao = inviteDao;
         this.userDao = userDao;
@@ -36,9 +36,8 @@ public class ServiceInviteCompleter extends InviteCompleter {
     }
 
     /**
-     * Completes a service invite.
-     * ie. it creates and persists a user from an invite or/and subscribe a user to an existing service
-     * and if it is a service invite also creates a default service.
+     * Completes a self-signup invite.
+     * ie. it creates and persists a user from an invite and also creates a default service.
      * It then disables the invite.
      */
     @Override

--- a/src/test/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleterTest.java
@@ -37,14 +37,14 @@ import static uk.gov.pay.adminusers.model.Role.role;
 import static uk.gov.pay.adminusers.persistence.entity.Role.ADMIN;
 
 @ExtendWith(MockitoExtension.class)
-public class UserInviteCompleterTest {
+public class ExistingUserInviteCompleterTest {
 
     @Mock
     private UserDao mockUserDao;
     @Mock
     private InviteDao mockInviteDao;
 
-    private InviteCompleter userInviteCompleter;
+    private InviteCompleter existingUserInviteCompleter;
 
     private String otpKey = "otpKey";
     private String inviteCode = "code";
@@ -56,7 +56,7 @@ public class UserInviteCompleterTest {
 
     @BeforeEach
     public void setUp() {
-        userInviteCompleter = new UserInviteCompleter(
+        existingUserInviteCompleter = new ExistingUserInviteCompleter(
                 mockInviteDao,
                 mockUserDao
         );
@@ -76,7 +76,7 @@ public class UserInviteCompleterTest {
         when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(user));
 
-        Optional<InviteCompleteResponse> completedInvite = userInviteCompleter.complete(inviteCode);
+        Optional<InviteCompleteResponse> completedInvite = existingUserInviteCompleter.complete(inviteCode);
 
         ArgumentCaptor<UserEntity> persistedUser = ArgumentCaptor.forClass(UserEntity.class);
         verify(mockUserDao).merge(persistedUser.capture());
@@ -102,7 +102,7 @@ public class UserInviteCompleterTest {
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(user));
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> userInviteCompleter.complete(inviteCode));
+                () -> existingUserInviteCompleter.complete(inviteCode));
         assertThat(webApplicationException.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 
@@ -122,7 +122,7 @@ public class UserInviteCompleterTest {
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(user));
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> userInviteCompleter.complete(inviteCode));
+                () -> existingUserInviteCompleter.complete(inviteCode));
         assertThat(webApplicationException.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 
@@ -136,7 +136,7 @@ public class UserInviteCompleterTest {
         when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> userInviteCompleter.complete(inviteCode));
+                () -> existingUserInviteCompleter.complete(inviteCode));
         assertThat(webApplicationException.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -149,7 +149,7 @@ public class UserInviteCompleterTest {
         when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> userInviteCompleter.complete(inviteCode));
+                () -> existingUserInviteCompleter.complete(inviteCode));
         assertThat(webApplicationException.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -162,7 +162,7 @@ public class UserInviteCompleterTest {
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> userInviteCompleter.complete(inviteCode));
+                () -> existingUserInviteCompleter.complete(inviteCode));
         assertThat(webApplicationException.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/service/InviteRouterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/InviteRouterTest.java
@@ -36,15 +36,15 @@ public class InviteRouterTest {
     }
 
     @Test
-    public void shouldResolve_serviceInviteCompleter_withValidation() {
+    public void shouldResolve_selfSignupInviteCompleter_withValidation() {
         String inviteCode = "a-code";
         InviteEntity inviteEntity = anInvite(inviteCode, SERVICE);
         when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
-        when(inviteServiceFactory.completeServiceInvite()).thenReturn(new ServiceInviteCompleter(null, null, null, null));
+        when(inviteServiceFactory.completeSelfSignupInvite()).thenReturn(new SelfSignupInviteCompleter(null, null, null, null));
         Optional<Pair<InviteCompleter, Boolean>> result = inviteRouter.routeComplete(inviteCode);
 
         assertThat(result.isPresent(), is(true));
-        assertThat(result.get().getLeft(), is(instanceOf(ServiceInviteCompleter.class)));
+        assertThat(result.get().getLeft(), is(instanceOf(SelfSignupInviteCompleter.class)));
         assertThat(result.get().getRight(), is(true));
     }
 
@@ -75,7 +75,7 @@ public class InviteRouterTest {
     }
 
     @Test
-    public void shouldResolve_serviceInviteDispatcher_withoutValidation() {
+    public void shouldResolve_selfSignupInviteDispatcher_withoutValidation() {
         String inviteCode = "a-code";
         InviteEntity inviteEntity = anInvite(inviteCode, SERVICE);
         when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));

--- a/src/test/java/uk/gov/pay/adminusers/service/InviteRouterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/InviteRouterTest.java
@@ -41,11 +41,10 @@ public class InviteRouterTest {
         InviteEntity inviteEntity = anInvite(inviteCode, SERVICE);
         when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
         when(inviteServiceFactory.completeSelfSignupInvite()).thenReturn(new SelfSignupInviteCompleter(null, null, null, null));
-        Optional<Pair<InviteCompleter, Boolean>> result = inviteRouter.routeComplete(inviteCode);
+        Optional<InviteCompleter> result = inviteRouter.routeComplete(inviteCode);
 
         assertThat(result.isPresent(), is(true));
-        assertThat(result.get().getLeft(), is(instanceOf(SelfSignupInviteCompleter.class)));
-        assertThat(result.get().getRight(), is(true));
+        assertThat(result.get(), is(instanceOf(SelfSignupInviteCompleter.class)));
     }
 
     @Test
@@ -54,11 +53,10 @@ public class InviteRouterTest {
         InviteEntity inviteEntity = anInvite(inviteCode, USER);
         when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
         when(inviteServiceFactory.completeExistingUserInvite()).thenReturn(new ExistingUserInviteCompleter(null, null));
-        Optional<Pair<InviteCompleter, Boolean>> result = inviteRouter.routeComplete(inviteCode);
+        Optional<InviteCompleter> result = inviteRouter.routeComplete(inviteCode);
 
         assertThat(result.isPresent(), is(true));
-        assertThat(result.get().getLeft(), is(instanceOf(ExistingUserInviteCompleter.class)));
-        assertThat(result.get().getRight(), is(false));
+        assertThat(result.get(), is(instanceOf(ExistingUserInviteCompleter.class)));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/service/InviteRouterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/InviteRouterTest.java
@@ -49,20 +49,20 @@ public class InviteRouterTest {
     }
 
     @Test
-    public void shouldResolve_userInviteCompleter_withoutValidation() {
+    public void shouldResolve_existingUserInviteCompleter_withoutValidation() {
         String inviteCode = "a-code";
         InviteEntity inviteEntity = anInvite(inviteCode, USER);
         when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
-        when(inviteServiceFactory.completeUserInvite()).thenReturn(new UserInviteCompleter(null, null));
+        when(inviteServiceFactory.completeExistingUserInvite()).thenReturn(new ExistingUserInviteCompleter(null, null));
         Optional<Pair<InviteCompleter, Boolean>> result = inviteRouter.routeComplete(inviteCode);
 
         assertThat(result.isPresent(), is(true));
-        assertThat(result.get().getLeft(), is(instanceOf(UserInviteCompleter.class)));
+        assertThat(result.get().getLeft(), is(instanceOf(ExistingUserInviteCompleter.class)));
         assertThat(result.get().getRight(), is(false));
     }
 
     @Test
-    public void shouldResolve_userInviteDispatcher_withValidation() {
+    public void shouldResolve_existingUserInviteDispatcher_withValidation() {
         String inviteCode = "a-code";
         InviteEntity inviteEntity = anInvite(inviteCode, USER);
         when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));

--- a/src/test/java/uk/gov/pay/adminusers/service/SelfSignupInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/SelfSignupInviteCompleterTest.java
@@ -41,7 +41,7 @@ import static uk.gov.pay.adminusers.model.Role.role;
 import static uk.gov.pay.adminusers.persistence.entity.Role.ADMIN;
 
 @ExtendWith(MockitoExtension.class)
-public class ServiceInviteCompleterTest {
+public class SelfSignupInviteCompleterTest {
     @Mock
     private ServiceDao mockServiceDao;
     @Mock
@@ -49,7 +49,7 @@ public class ServiceInviteCompleterTest {
     @Mock
     private InviteDao mockInviteDao;
 
-    private InviteCompleter serviceInviteCompleter;
+    private InviteCompleter selfSignupInviteCompleter;
     private ArgumentCaptor<UserEntity> expectedInvitedUser = ArgumentCaptor.forClass(UserEntity.class);
     private ArgumentCaptor<InviteEntity> expectedInvite = ArgumentCaptor.forClass(InviteEntity.class);
     private ArgumentCaptor<ServiceEntity> expectedService = ArgumentCaptor.forClass(ServiceEntity.class);
@@ -64,7 +64,7 @@ public class ServiceInviteCompleterTest {
 
     @BeforeEach
     public void setUp() {
-        serviceInviteCompleter = new ServiceInviteCompleter(
+        selfSignupInviteCompleter = new SelfSignupInviteCompleter(
                 mockInviteDao,
                 mockUserDao,
                 mockServiceDao,
@@ -84,7 +84,7 @@ public class ServiceInviteCompleterTest {
 
         InviteCompleteRequest data = new InviteCompleteRequest();
         data.setGatewayAccountIds(asList("1", "2"));
-        InviteCompleteResponse inviteResponse = serviceInviteCompleter.withData(data).complete(anInvite.getCode()).get();
+        InviteCompleteResponse inviteResponse = selfSignupInviteCompleter.withData(data).complete(anInvite.getCode()).get();
 
         verify(mockServiceDao).persist(expectedService.capture());
         verify(mockUserDao).merge(expectedInvitedUser.capture());
@@ -116,7 +116,7 @@ public class ServiceInviteCompleterTest {
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
         when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
 
-        InviteCompleteResponse inviteResponse = serviceInviteCompleter.withData(new InviteCompleteRequest()).complete(anInvite.getCode()).get();
+        InviteCompleteResponse inviteResponse = selfSignupInviteCompleter.withData(new InviteCompleteRequest()).complete(anInvite.getCode()).get();
 
         verify(mockServiceDao).persist(expectedService.capture());
         verify(mockUserDao).merge(expectedInvitedUser.capture());
@@ -149,7 +149,7 @@ public class ServiceInviteCompleterTest {
         when(mockUserDao.findByEmail(anInvite.getEmail())).thenReturn(Optional.of(mock(UserEntity.class)));
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> serviceInviteCompleter.complete(anInvite.getCode()));
+                () -> selfSignupInviteCompleter.complete(anInvite.getCode()));
         assertThat(exception.getMessage(), is("HTTP 409 Conflict"));
     }
 
@@ -165,7 +165,7 @@ public class ServiceInviteCompleterTest {
         when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> serviceInviteCompleter.complete(anInvite.getCode()));
+                () -> selfSignupInviteCompleter.complete(anInvite.getCode()));
         assertThat(exception.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -181,7 +181,7 @@ public class ServiceInviteCompleterTest {
         when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> serviceInviteCompleter.complete(anInvite.getCode()));
+                () -> selfSignupInviteCompleter.complete(anInvite.getCode()));
         assertThat(exception.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -197,7 +197,7 @@ public class ServiceInviteCompleterTest {
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> serviceInviteCompleter.complete(anInvite.getCode()));
+                () -> selfSignupInviteCompleter.complete(anInvite.getCode()));
         assertThat(exception.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 


### PR DESCRIPTION
## WHAT YOU DID
* Add new InviteType constants, which will replace the old ones (the new ones have better names and cover the full range of journeys).  This PR adds the new constants but does not start using them.
* Rename the InviteCompleter implementations to reduce ambiguity, and add new InviteCompleter to handle the 'new user, existing service' journey.
