### PR TITLE
PP-10041: Use Jackson serialisation for InviteType

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/model/Invite.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Invite.java
@@ -23,13 +23,13 @@ public class Invite {
     private Integer attemptCounter = 0;
 
     private List<Link> links = new ArrayList<>();
-    private String type;
+    private InviteType type;
     private boolean userExist = false;
     private boolean expired;
     private boolean passwordSet;
 
     public Invite(String code, String email, String telephoneNumber,
-                  Boolean disabled, Integer attemptCounter, String type, String role, Boolean expired, boolean passwordSet) {
+                  Boolean disabled, Integer attemptCounter, InviteType type, String role, Boolean expired, boolean passwordSet) {
         this.code = code;
         this.email = email;
         this.telephoneNumber = telephoneNumber;
@@ -94,11 +94,11 @@ public class Invite {
     }
 
     @Schema(example = "service")
-    public String getType() {
+    public InviteType getType() {
         return type;
     }
 
-    public void setType(String type) {
+    public void setType(InviteType type) {
         this.type = type;
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/model/InviteType.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/InviteType.java
@@ -10,12 +10,4 @@ public enum InviteType {
     EXISTING_USER_INVITED_TO_EXISTING_SERVICE,
     NEW_USER_INVITED_TO_EXISTING_SERVICE,
     NEW_USER_AND_NEW_SERVICE_SELF_SIGNUP;
-
-    public String getType() {
-        return name().toLowerCase();
-    }
-
-    public static InviteType from(String typeString) {
-        return InviteType.valueOf(typeString.toUpperCase());
-    }
 }

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
@@ -219,7 +219,7 @@ public class InviteEntity extends AbstractEntity {
     }
 
     public Invite toInvite() {
-        return new Invite(code, email, telephoneNumber, disabled, loginCounter, type.getType(), role.getName(), isExpired(), hasPassword());
+        return new Invite(code, email, telephoneNumber, disabled, loginCounter, type, role.getName(), isExpired(), hasPassword());
     }
 
     public boolean isExpired() {

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteTypeConverter.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteTypeConverter.java
@@ -10,12 +10,12 @@ public class InviteTypeConverter implements AttributeConverter<InviteType, Strin
 
     @Override
     public String convertToDatabaseColumn(InviteType inviteType) {
-        return inviteType.getType();
+        return inviteType.name().toLowerCase();
     }
 
     @Override
     public InviteType convertToEntityAttribute(String string) {
-        return InviteType.from(string);
+        return InviteType.valueOf(string.toUpperCase());
     }
 
 }

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCreatorTest.java
@@ -67,7 +67,7 @@ public class ServiceInviteCreatorTest {
         verify(inviteDao, times(1)).persist(persistedInviteEntity.capture());
         assertThat(invite.getEmail(), is(request.getEmail()));
         assertThat(invite.getTelephoneNumber(), is("+441134960000"));
-        assertThat(invite.getType(), is("service"));
+        assertThat(invite.getType(), is(InviteType.SERVICE));
         assertThat(invite.getLinks().get(0).getHref(), matchesPattern("^http://selfservice/invites/[0-9a-z]{32}$"));
 
         assertThat(persistedInviteEntity.getValue().getPassword(), is("encrypted-password"));
@@ -90,7 +90,7 @@ public class ServiceInviteCreatorTest {
         verify(inviteDao, times(1)).persist(persistedInviteEntity.capture());
         assertThat(invite.getEmail(), is(request.getEmail()));
         assertThat(invite.getTelephoneNumber(), is(nullValue()));
-        assertThat(invite.getType(), is("service"));
+        assertThat(invite.getType(), is(InviteType.SERVICE));
         assertThat(invite.getLinks().get(0).getHref(), matchesPattern("^http://selfservice/invites/[0-9a-z]{32}$"));
 
         assertThat(persistedInviteEntity.getValue().getTelephoneNumber(), is(nullValue()));
@@ -113,7 +113,7 @@ public class ServiceInviteCreatorTest {
         verify(inviteDao, times(1)).persist(persistedInviteEntity.capture());
         assertThat(invite.getEmail(), is(request.getEmail()));
         assertThat(invite.getTelephoneNumber(), is("+441134960000"));
-        assertThat(invite.getType(), is("service"));
+        assertThat(invite.getType(), is(InviteType.SERVICE));
         assertThat(invite.getLinks().get(0).getHref(), matchesPattern("^http://selfservice/invites/[0-9a-z]{32}$"));
 
     }
@@ -142,7 +142,7 @@ public class ServiceInviteCreatorTest {
 
         verify(inviteDao, times(1)).merge(persistedInviteEntity.capture());
         assertThat(invite.getEmail(), is(request.getEmail()));
-        assertThat(invite.getType(), is("service"));
+        assertThat(invite.getType(), is(InviteType.SERVICE));
         assertThat(invite.getLinks().get(0).getHref(), is("http://selfservice/invites/code"));
     }
 
@@ -170,7 +170,7 @@ public class ServiceInviteCreatorTest {
         Invite invite = serviceInviteCreator.doInvite(request);
 
         assertThat(invite.getEmail(), is(request.getEmail()));
-        assertThat(invite.getType(), is("service"));
+        assertThat(invite.getType(), is(InviteType.SERVICE));
         assertThat(invite.getLinks().get(0).getHref().matches("^http://selfservice/invites/[0-9a-z]{32}$"), is(true));
     }
 


### PR DESCRIPTION
The custom serialisation/deserialisation code for InviteType is now implemented in InviteTypeConverter, rather than inside the InviteType enum itself.  This is more idiomatic.  Also, it means we can now exclusively use the enum type in the rest of the codebase, instead of messing around with its string representation.  Jackson/JPA will deal with serialisation and deserialisation as needed; that's their job.

Assuming that I'm right about how Jackson/JPA will behave, this PR should be functionally equivalent to the recently merged #1643.