### PR TITLE
PP-10041: Prepare to switch to new InviteType constants

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/model/InviteType.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/InviteType.java
@@ -15,6 +15,16 @@ public enum InviteType {
         return name().toLowerCase();
     }
 
+    @Deprecated  // We will get rid of this method once we are only using the new enum values.
+    public boolean isExistingUserExistingService() {
+        return this == USER || this == EXISTING_USER_INVITED_TO_EXISTING_SERVICE;
+    }
+
+    @Deprecated  // We will get rid of this method once we are only using the new enum values.
+    public boolean isSelfSignup() {
+        return this == SERVICE || this == NEW_USER_AND_NEW_SERVICE_SELF_SIGNUP;
+    }
+
     public static InviteType from(String typeString) {
         return InviteType.valueOf(typeString.toUpperCase());
     }

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
@@ -210,14 +210,6 @@ public class InviteEntity extends AbstractEntity {
         this.type = type;
     }
 
-    public boolean isServiceType() {
-        return InviteType.SERVICE.equals(type);
-    }
-
-    public boolean isUserType() {
-        return InviteType.USER.equals(type);
-    }
-
     public Invite toInvite() {
         return new Invite(code, email, telephoneNumber, disabled, loginCounter, type.getType(), role.getName(), isExpired(), hasPassword());
     }

--- a/src/main/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleter.java
@@ -34,7 +34,7 @@ public class ExistingUserInviteCompleter extends InviteCompleter {
                     }
                     return userDao.findByEmail(inviteEntity.getEmail())
                             .map(userEntity -> {
-                                if (inviteEntity.getService() != null && inviteEntity.isUserType()) {
+                                if (inviteEntity.getService() != null && inviteEntity.getType().isExistingUserExistingService()) {
                                     ServiceRoleEntity serviceRole = new ServiceRoleEntity(inviteEntity.getService(), inviteEntity.getRole());
                                     userEntity.addServiceRole(serviceRole);
                                     userDao.merge(userEntity);

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteRouter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteRouter.java
@@ -2,6 +2,7 @@ package uk.gov.pay.adminusers.service;
 
 import com.google.inject.Inject;
 import org.apache.commons.lang3.tuple.Pair;
+import uk.gov.pay.adminusers.model.InviteType;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
 
@@ -25,30 +26,42 @@ public class InviteRouter {
                     switch (inviteEntity.getType()) {
                         case SERVICE:
                         case NEW_USER_AND_NEW_SERVICE_SELF_SIGNUP:
-                            return Optional.of(inviteServiceFactory.completeSelfSignupInvite());
+                            return inviteServiceFactory.completeSelfSignupInvite();
                         case USER:
                         case EXISTING_USER_INVITED_TO_EXISTING_SERVICE:
-                            return Optional.of(inviteServiceFactory.completeExistingUserInvite());
+                            return inviteServiceFactory.completeExistingUserInvite();
                         case NEW_USER_INVITED_TO_EXISTING_SERVICE:
-                            return Optional.of(inviteServiceFactory.completeNewUserExistingServiceInvite());
+                            return inviteServiceFactory.completeNewUserExistingServiceInvite();
                         default:
                             throw new IllegalArgumentException(String.format("Unrecognised invite type: %s", inviteEntity.getType()));
                     }
                 });
     }
 
+    /**
+     * @return an optional pair consisting of: the InviteOtpDispatcher to use, and a boolean flag to indicate whether the OTP requires validation during invite completion.
+     */
     public Optional<Pair<InviteOtpDispatcher, Boolean>> routeOtpDispatch(String inviteCode) {
         return routeIfExist(inviteCode,
                 inviteEntity -> {
-                    boolean isUserType = inviteEntity.isUserType();
-                    InviteOtpDispatcher inviteOtpDispatcher = isUserType ? inviteServiceFactory.dispatchUserOtp() : inviteServiceFactory.dispatchServiceOtp();
-                    return Optional.of(Pair.of(inviteOtpDispatcher, isUserType));
+                    InviteType inviteType = inviteEntity.getType();
+                    switch (inviteType) {
+                        case SERVICE:
+                        case NEW_USER_AND_NEW_SERVICE_SELF_SIGNUP:
+                            return Pair.of(inviteServiceFactory.dispatchServiceOtp(), false);
+                        case USER:
+                        case NEW_USER_INVITED_TO_EXISTING_SERVICE:
+                            return Pair.of(inviteServiceFactory.dispatchUserOtp(), true);
+                        case EXISTING_USER_INVITED_TO_EXISTING_SERVICE:
+                            throw new IllegalArgumentException("routeOtpDispatch called on an invite for an existing user");
+                        default:
+                            throw new IllegalArgumentException("Unrecognised InviteType: " + inviteType.name());
+                    }
                 });
 
     }
 
-    private <T> Optional<T> routeIfExist(String inviteCode, Function<InviteEntity, Optional<T>> routeFunction) {
-        return inviteDao.findByCode(inviteCode).map(routeFunction)
-                .orElseGet(Optional::empty);
+    private <T> Optional<T> routeIfExist(String inviteCode, Function<InviteEntity, T> routeFunction) {
+        return inviteDao.findByCode(inviteCode).map(routeFunction);
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteService.java
@@ -124,9 +124,13 @@ public class InviteService {
     private static OtpNotifySmsTemplateId mapInviteTypeToOtpNotifySmsTemplateId(InviteType inviteType) {
         switch (inviteType) {
             case SERVICE:
+            case NEW_USER_AND_NEW_SERVICE_SELF_SIGNUP:
                 return SELF_INITIATED_CREATE_NEW_USER_AND_SERVICE;
             case USER:
+            case NEW_USER_INVITED_TO_EXISTING_SERVICE:
                 return CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE;
+            case EXISTING_USER_INVITED_TO_EXISTING_SERVICE:
+                throw new IllegalArgumentException("mapInviteTypeToOtpNotifySmsTemplateId called on an invite for an existing user");
             default:
                 throw new IllegalArgumentException("Unrecognised InviteType: " + inviteType.name());
         }

--- a/src/main/java/uk/gov/pay/adminusers/service/SelfSignupInviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/SelfSignupInviteCompleter.java
@@ -51,7 +51,7 @@ public class SelfSignupInviteCompleter extends InviteCompleter {
                         throw conflictingEmail(inviteEntity.getEmail());
                     }
 
-                    if (inviteEntity.isServiceType()) {
+                    if (inviteEntity.getType().isSelfSignup()) {
                         UserEntity userEntity = inviteEntity.mapToUserEntity();
                         ServiceEntity serviceEntity = ServiceEntity.from(Service.from());
                         if (!data.getGatewayAccountIds().isEmpty()) {

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceInviteCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceInviteCreator.java
@@ -73,7 +73,7 @@ public class ServiceInviteCreator {
         List<InviteEntity> exitingInvites = inviteDao.findByEmail(requestEmail);
         List<InviteEntity> existingValidServiceInvitesForSameEmail = exitingInvites.stream()
                 .filter(inviteEntity -> !inviteEntity.isDisabled() && !inviteEntity.isExpired())
-                .filter(InviteEntity::isServiceType).collect(toUnmodifiableList());
+                .filter(inviteEntity -> inviteEntity.getType().isSelfSignup()).collect(toUnmodifiableList());
 
         if (!existingValidServiceInvitesForSameEmail.isEmpty()) {
             InviteEntity foundInvite = existingValidServiceInvitesForSameEmail.get(0);

--- a/src/test/java/uk/gov/pay/adminusers/persistence/entity/InviteTypeConverterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/entity/InviteTypeConverterTest.java
@@ -24,6 +24,24 @@ public class InviteTypeConverterTest {
     }
 
     @Test
+    public void existingUserInvitedToExistingServiceEnumConstantConvertToDatabaseColumnReturnsExistingUserInvitedToExistingServiceString() {
+        String databaseColumnValue = inviteTypeConverter.convertToDatabaseColumn(InviteType.EXISTING_USER_INVITED_TO_EXISTING_SERVICE);
+        assertThat(databaseColumnValue, is("existing_user_invited_to_existing_service"));
+    }
+
+    @Test
+    public void newUserInvitedToExistingServiceEnumConstantConvertToDatabaseColumnReturnsNewUserInvitedToExistingServiceString() {
+        String databaseColumnValue = inviteTypeConverter.convertToDatabaseColumn(InviteType.NEW_USER_INVITED_TO_EXISTING_SERVICE);
+        assertThat(databaseColumnValue, is("new_user_invited_to_existing_service"));
+    }
+
+    @Test
+    public void newUserAndNewServiceSelfSignupEnumConstantConvertToDatabaseColumnReturnsnewUserAndNewServiceSelfSignupString() {
+        String databaseColumnValue = inviteTypeConverter.convertToDatabaseColumn(InviteType.NEW_USER_AND_NEW_SERVICE_SELF_SIGNUP);
+        assertThat(databaseColumnValue, is("new_user_and_new_service_self_signup"));
+    }
+
+    @Test
     public void userStringConvertToEntityAttributeReturnsUserEnumConstant() {
         InviteType entityAttribute = inviteTypeConverter.convertToEntityAttribute("user");
         assertThat(entityAttribute, is(InviteType.USER));
@@ -33,6 +51,24 @@ public class InviteTypeConverterTest {
     public void serviceStringConvertToEntityAttributeReturnsServiceEnumConstant() {
         InviteType entityAttribute = inviteTypeConverter.convertToEntityAttribute("service");
         assertThat(entityAttribute, is(InviteType.SERVICE));
+    }
+
+    @Test
+    public void existingUserInvitedToExistingServiceStringConvertToEntityAttributeReturnsExistingUserInvitedToExistingServiceEnumConstant() {
+        InviteType entityAttribute = inviteTypeConverter.convertToEntityAttribute("existing_user_invited_to_existing_service");
+        assertThat(entityAttribute, is(InviteType.EXISTING_USER_INVITED_TO_EXISTING_SERVICE));
+    }
+
+    @Test
+    public void newUserInvitedToExistingServiceStringConvertToEntityAttributeReturnsNewUserInvitedToExistingServiceEnumConstant() {
+        InviteType entityAttribute = inviteTypeConverter.convertToEntityAttribute("new_user_invited_to_existing_service");
+        assertThat(entityAttribute, is(InviteType.NEW_USER_INVITED_TO_EXISTING_SERVICE));
+    }
+
+    @Test
+    public void newUserAndNewServiceSelfSignupStringConvertToEntityAttributeReturnsNewUserAndNewServiceSelfSignupEnumConstant() {
+        InviteType entityAttribute = inviteTypeConverter.convertToEntityAttribute("new_user_and_new_service_self_signup");
+        assertThat(entityAttribute, is(InviteType.NEW_USER_AND_NEW_SERVICE_SELF_SIGNUP));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/service/SelfSignupInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/SelfSignupInviteCompleterTest.java
@@ -213,6 +213,54 @@ public class SelfSignupInviteCompleterTest {
         assertThat(exception.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 
+    @Test
+    public void shouldThrowEmailExistsException_whenPassedInviteCodeWhichIsExpired__newEnumValue() {
+        ServiceEntity service = new ServiceEntity();
+        service.setId(serviceId);
+
+        InviteEntity anInvite = createInvite();
+        anInvite.setType(InviteType.NEW_USER_AND_NEW_SERVICE_SELF_SIGNUP);
+        anInvite.setExpiryDate(ZonedDateTime.now().minusDays(1));
+
+        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
+
+        WebApplicationException exception = assertThrows(WebApplicationException.class,
+                () -> selfSignupInviteCompleter.complete(anInvite.getCode()));
+        assertThat(exception.getMessage(), is("HTTP 410 Gone"));
+    }
+
+    @Test
+    public void shouldError_whenTryingToCreateServiceAndService_ifInviteIsOfNewUserInvitedToExistingServiceType() {
+        ServiceEntity service = new ServiceEntity();
+        service.setId(serviceId);
+
+        InviteEntity anInvite = createInvite();
+        anInvite.setType(InviteType.NEW_USER_INVITED_TO_EXISTING_SERVICE);
+
+        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
+        when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
+
+        WebApplicationException exception = assertThrows(WebApplicationException.class,
+                () -> selfSignupInviteCompleter.complete(anInvite.getCode()));
+        assertThat(exception.getMessage(), is("HTTP 500 Internal Server Error"));
+    }
+
+    @Test
+    public void shouldError_whenTryingToCreateServiceAndService_ifInviteIsOfExistingUserInvitedToExistingServiceType() {
+        ServiceEntity service = new ServiceEntity();
+        service.setId(serviceId);
+
+        InviteEntity anInvite = createInvite();
+        anInvite.setType(InviteType.EXISTING_USER_INVITED_TO_EXISTING_SERVICE);
+
+        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
+        when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
+
+        WebApplicationException exception = assertThrows(WebApplicationException.class,
+                () -> selfSignupInviteCompleter.complete(anInvite.getCode()));
+        assertThat(exception.getMessage(), is("HTTP 500 Internal Server Error"));
+    }
+
     private InviteEntity createInvite() {
 
         ServiceEntity service = new ServiceEntity();


### PR DESCRIPTION
Before we can switch over to using the new values, we need to update the places where they are used:
* Remove isServiceType() and isUserType() methods from InviteEntity
* Temporarily replace the above with isSelfService() and isExistingUserExistingService methods on InviteType - we will get rid of these once the old enum values no longer need to be handled
* Use the enum values (old and new) to choose which InviteOtpDispatcher to use in InviteRouter
  * Also, refactor InviteRouter a bit to get rid of a pointless Optional type
* Map the new enum values to Notify templates for sending OTP SMS messages 
* Support use of the new enum values in InviteService
* Add test coverage for the new enum values