### PR TITLE
PP-10041 refactor getting invite

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -357,7 +357,7 @@
         "filename": "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGenerateOtpIT.java",
         "hashed_secret": "833b5c8e76b19b617849d9a67a5980f08c784882",
         "is_verified": false,
-        "line_number": 24
+        "line_number": 26
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpIT.java": [
@@ -472,5 +472,5 @@
       }
     ]
   },
-  "generated_at": "2022-10-10T17:18:03Z"
+  "generated_at": "2022-10-12T10:38:32Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -384,7 +384,7 @@
         "filename": "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceUserCompleteIT.java",
         "hashed_secret": "969c35357bb1a825bf84783da60799e29511e357",
         "is_verified": false,
-        "line_number": 24
+        "line_number": 26
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/resources/ResetPasswordResourceIT.java": [
@@ -472,5 +472,5 @@
       }
     ]
   },
-  "generated_at": "2022-10-12T10:38:32Z"
+  "generated_at": "2022-10-12T11:06:48Z"
 }

--- a/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
@@ -21,6 +21,7 @@ import uk.gov.pay.adminusers.model.InviteServiceRequest;
 import uk.gov.pay.adminusers.model.InviteUserRequest;
 import uk.gov.pay.adminusers.model.InviteValidateOtpRequest;
 import uk.gov.pay.adminusers.model.User;
+import uk.gov.pay.adminusers.service.InviteCompleter;
 import uk.gov.pay.adminusers.service.InviteOtpDispatcher;
 import uk.gov.pay.adminusers.service.InviteService;
 import uk.gov.pay.adminusers.service.InviteServiceFactory;
@@ -115,9 +116,10 @@ public class InviteResource {
             throw new WebApplicationException(Response.Status.NOT_FOUND);
         }
 
-        return inviteServiceFactory.inviteCompleteRouter().routeComplete(inviteCode)
-                .map(inviteCompleter -> inviteCompleter.withData(inviteCompleteRequestFrom(payload)).complete(inviteCode))
-                .orElseThrow(() -> new WebApplicationException(Response.Status.NOT_FOUND));
+        return inviteService.findInvite(inviteCode).map(inviteEntity -> {
+            InviteCompleter inviteCompleter = inviteServiceFactory.inviteCompleteRouter().routeComplete(inviteEntity);
+            return inviteCompleter.withData(inviteCompleteRequestFrom(payload)).complete(inviteEntity);
+        }).orElseThrow(() -> new WebApplicationException(Response.Status.NOT_FOUND));
     }
 
     private InviteCompleteRequest inviteCompleteRequestFrom(JsonNode payload) {

--- a/src/main/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleter.java
@@ -5,12 +5,12 @@ import com.google.inject.persist.Transactional;
 import uk.gov.pay.adminusers.model.InviteCompleteResponse;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
+import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
 
 import static java.lang.String.format;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.internalServerError;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.inviteLockedException;
-import static uk.gov.pay.adminusers.service.AdminUsersExceptions.notFoundInviteException;
 
 public class ExistingUserInviteCompleter extends InviteCompleter {
 
@@ -26,35 +26,32 @@ public class ExistingUserInviteCompleter extends InviteCompleter {
 
     @Override
     @Transactional
-    public InviteCompleteResponse complete(String inviteCode) {
-        return inviteDao.findByCode(inviteCode)
-                .map(inviteEntity -> {
-                    if (inviteEntity.isExpired() || inviteEntity.isDisabled()) {
-                        throw inviteLockedException(inviteEntity.getCode());
+    public InviteCompleteResponse complete(InviteEntity inviteEntity) {
+        if (inviteEntity.isExpired() || Boolean.TRUE.equals(inviteEntity.isDisabled())) {
+            throw inviteLockedException(inviteEntity.getCode());
+        }
+        return userDao.findByEmail(inviteEntity.getEmail())
+                .map(userEntity -> {
+                    if (inviteEntity.getService() != null && inviteEntity.getType().isExistingUserExistingService()) {
+                        ServiceRoleEntity serviceRole = new ServiceRoleEntity(inviteEntity.getService(), inviteEntity.getRole());
+                        userEntity.addServiceRole(serviceRole);
+                        userDao.merge(userEntity);
+
+                        inviteEntity.setDisabled(true);
+                        inviteDao.merge(inviteEntity);
+
+                        InviteCompleteResponse response = new InviteCompleteResponse(inviteEntity.toInvite());
+                        response.setUserExternalId(userEntity.getExternalId());
+                        response.setServiceExternalId(inviteEntity.getService().getExternalId());
+                        return response;
+                    } else {
+                        throw internalServerError(format("Attempting to complete user subscription to a service for a non existent service. invite-code = %s", inviteEntity.getCode()));
                     }
-                    return userDao.findByEmail(inviteEntity.getEmail())
-                            .map(userEntity -> {
-                                if (inviteEntity.getService() != null && inviteEntity.getType().isExistingUserExistingService()) {
-                                    ServiceRoleEntity serviceRole = new ServiceRoleEntity(inviteEntity.getService(), inviteEntity.getRole());
-                                    userEntity.addServiceRole(serviceRole);
-                                    userDao.merge(userEntity);
-
-                                    inviteEntity.setDisabled(true);
-                                    inviteDao.merge(inviteEntity);
-
-                                    InviteCompleteResponse response = new InviteCompleteResponse(inviteEntity.toInvite());
-                                    response.setUserExternalId(userEntity.getExternalId());
-                                    response.setServiceExternalId(inviteEntity.getService().getExternalId());
-                                    return response;
-                                } else {
-                                    throw internalServerError(format("Attempting to complete user subscription to a service for a non existent service. invite-code = %s", inviteEntity.getCode()));
-                                }
-                            }).orElseThrow(() ->
-                                internalServerError(format(
-                                        "Attempting to complete user subscription to a service for a non existent user. invite-code = %s",
-                                        inviteEntity.getCode()
-                                )));
-                }).orElseThrow(() -> notFoundInviteException(inviteCode));
+                }).orElseThrow(() ->
+                        internalServerError(format(
+                                "Attempting to complete user subscription to a service for a non existent user. invite-code = %s",
+                                inviteEntity.getCode()
+                        )));
 
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteCompleter.java
@@ -2,12 +2,13 @@ package uk.gov.pay.adminusers.service;
 
 import uk.gov.pay.adminusers.model.InviteCompleteRequest;
 import uk.gov.pay.adminusers.model.InviteCompleteResponse;
+import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
 
 public abstract class InviteCompleter {
 
     /* default */ InviteCompleteRequest data = null;
 
-    public abstract InviteCompleteResponse complete(String inviteCode);
+    public abstract InviteCompleteResponse complete(InviteEntity inviteEntity);
 
     public InviteCompleter withData(InviteCompleteRequest data) {
         this.data = data;

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteRouter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteRouter.java
@@ -2,41 +2,32 @@ package uk.gov.pay.adminusers.service;
 
 import com.google.inject.Inject;
 import uk.gov.pay.adminusers.model.InviteType;
-import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
-
-import java.util.Optional;
-import java.util.function.Function;
 
 public class InviteRouter {
 
     private final InviteServiceFactory inviteServiceFactory;
-    private final InviteDao inviteDao;
 
     @Inject
-    public InviteRouter(InviteServiceFactory inviteServiceFactory, InviteDao inviteDao) {
+    public InviteRouter(InviteServiceFactory inviteServiceFactory) {
         this.inviteServiceFactory = inviteServiceFactory;
-        this.inviteDao = inviteDao;
     }
 
-    public Optional<InviteCompleter> routeComplete(String inviteCode) {
-        return routeIfExist(inviteCode,
-                inviteEntity -> {
-                    switch (inviteEntity.getType()) {
-                        case SERVICE:
-                        case NEW_USER_AND_NEW_SERVICE_SELF_SIGNUP:
-                            return inviteServiceFactory.completeSelfSignupInvite();
-                        case USER:
-                        case EXISTING_USER_INVITED_TO_EXISTING_SERVICE:
-                            return inviteServiceFactory.completeExistingUserInvite();
-                        case NEW_USER_INVITED_TO_EXISTING_SERVICE:
-                            return inviteServiceFactory.completeNewUserExistingServiceInvite();
-                        default:
-                            throw new IllegalArgumentException(String.format("Unrecognised invite type: %s", inviteEntity.getType()));
-                    }
-                });
+    public InviteCompleter routeComplete(InviteEntity inviteEntity) {
+        switch (inviteEntity.getType()) {
+            case SERVICE:
+            case NEW_USER_AND_NEW_SERVICE_SELF_SIGNUP:
+                return inviteServiceFactory.completeSelfSignupInvite();
+            case USER:
+            case EXISTING_USER_INVITED_TO_EXISTING_SERVICE:
+                return inviteServiceFactory.completeExistingUserInvite();
+            case NEW_USER_INVITED_TO_EXISTING_SERVICE:
+                return inviteServiceFactory.completeNewUserExistingServiceInvite();
+            default:
+                throw new IllegalArgumentException(String.format("Unrecognised invite type: %s", inviteEntity.getType()));
+        }
     }
-    
+
     public InviteOtpDispatcher routeOtpDispatch(InviteEntity inviteEntity) {
         InviteType inviteType = inviteEntity.getType();
         switch (inviteType) {
@@ -51,9 +42,5 @@ public class InviteRouter {
             default:
                 throw new IllegalArgumentException("Unrecognised InviteType: " + inviteType.name());
         }
-    }
-
-    private <T> Optional<T> routeIfExist(String inviteCode, Function<InviteEntity, T> routeFunction) {
-        return inviteDao.findByCode(inviteCode).map(routeFunction);
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteRouter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteRouter.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.adminusers.service;
 
 import com.google.inject.Inject;
-import org.apache.commons.lang3.tuple.Pair;
 import uk.gov.pay.adminusers.model.InviteType;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
@@ -37,28 +36,21 @@ public class InviteRouter {
                     }
                 });
     }
-
-    /**
-     * @return an optional pair consisting of: the InviteOtpDispatcher to use, and a boolean flag to indicate whether the OTP requires validation during invite completion.
-     */
-    public Optional<Pair<InviteOtpDispatcher, Boolean>> routeOtpDispatch(String inviteCode) {
-        return routeIfExist(inviteCode,
-                inviteEntity -> {
-                    InviteType inviteType = inviteEntity.getType();
-                    switch (inviteType) {
-                        case SERVICE:
-                        case NEW_USER_AND_NEW_SERVICE_SELF_SIGNUP:
-                            return Pair.of(inviteServiceFactory.dispatchServiceOtp(), false);
-                        case USER:
-                        case NEW_USER_INVITED_TO_EXISTING_SERVICE:
-                            return Pair.of(inviteServiceFactory.dispatchUserOtp(), true);
-                        case EXISTING_USER_INVITED_TO_EXISTING_SERVICE:
-                            throw new IllegalArgumentException("routeOtpDispatch called on an invite for an existing user");
-                        default:
-                            throw new IllegalArgumentException("Unrecognised InviteType: " + inviteType.name());
-                    }
-                });
-
+    
+    public InviteOtpDispatcher routeOtpDispatch(InviteEntity inviteEntity) {
+        InviteType inviteType = inviteEntity.getType();
+        switch (inviteType) {
+            case SERVICE:
+            case NEW_USER_AND_NEW_SERVICE_SELF_SIGNUP:
+                return inviteServiceFactory.dispatchServiceOtp();
+            case USER:
+            case NEW_USER_INVITED_TO_EXISTING_SERVICE:
+                return inviteServiceFactory.dispatchUserOtp();
+            case EXISTING_USER_INVITED_TO_EXISTING_SERVICE:
+                throw new IllegalArgumentException("routeOtpDispatch called on an invite for an existing user");
+            default:
+                throw new IllegalArgumentException("Unrecognised InviteType: " + inviteType.name());
+        }
     }
 
     private <T> Optional<T> routeIfExist(String inviteCode, Function<InviteEntity, T> routeFunction) {

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteService.java
@@ -4,6 +4,7 @@ import com.google.inject.name.Named;
 import com.google.inject.persist.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.adminusers.model.Invite;
 import uk.gov.pay.adminusers.model.InviteOtpRequest;
 import uk.gov.pay.adminusers.model.InviteType;
 import uk.gov.pay.adminusers.model.InviteValidateOtpRequest;
@@ -119,6 +120,10 @@ public class InviteService {
             return Optional.of(invalidOtpAuthCodeInviteException(inviteEntity.getCode()));
         }
         return Optional.empty();
+    }
+    
+    public Optional<InviteEntity> findInvite(String code) {
+        return inviteDao.findByCode(code);
     }
 
     private static OtpNotifySmsTemplateId mapInviteTypeToOtpNotifySmsTemplateId(InviteType inviteType) {

--- a/src/main/java/uk/gov/pay/adminusers/service/NewUserExistingServiceInviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NewUserExistingServiceInviteCompleter.java
@@ -10,6 +10,7 @@ import uk.gov.pay.adminusers.model.InviteCompleteResponse;
 import uk.gov.pay.adminusers.model.InviteType;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
+import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 
 import java.util.stream.Collectors;
@@ -18,14 +19,13 @@ import static java.lang.String.format;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.conflictingEmail;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.internalServerError;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.inviteLockedException;
-import static uk.gov.pay.adminusers.service.AdminUsersExceptions.notFoundInviteException;
 import static uk.gov.service.payments.logging.LoggingKeys.SERVICE_EXTERNAL_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.USER_EXTERNAL_ID;
 
 public class NewUserExistingServiceInviteCompleter extends InviteCompleter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NewUserExistingServiceInviteCompleter.class);
-    
+
     private final InviteDao inviteDao;
     private final UserDao userDao;
     private final LinksBuilder linksBuilder;
@@ -40,41 +40,37 @@ public class NewUserExistingServiceInviteCompleter extends InviteCompleter {
 
     @Override
     @Transactional
-    public InviteCompleteResponse complete(String inviteCode) {
-        return inviteDao.findByCode(inviteCode)
-                .map(inviteEntity -> {
-                    if (inviteEntity.isExpired() || inviteEntity.isDisabled()) {
-                        throw inviteLockedException(inviteEntity.getCode());
-                    }
-                    if (userDao.findByEmail(inviteEntity.getEmail()).isPresent()) {
-                        throw conflictingEmail(inviteEntity.getEmail());
-                    }
-                    if (inviteEntity.getType() != InviteType.NEW_USER_INVITED_TO_EXISTING_SERVICE) {
-                        throw internalServerError(format("Attempting to complete a 'new user, existing service' invite for an invite of type '%s'", inviteEntity.getCode()));
-                    }
-                    
-                    UserEntity userEntity = inviteEntity.mapToUserEntity();
-                    userDao.persist(userEntity);
-                    inviteEntity.setDisabled(Boolean.TRUE);
-                    inviteDao.merge(inviteEntity);
-                    
-                    String serviceIds = userEntity.getServicesRoles().stream()
-                            .map(serviceRole -> serviceRole.getService().getExternalId())
-                            .collect(Collectors.joining(", "));
+    public InviteCompleteResponse complete(InviteEntity inviteEntity) {
+        if (inviteEntity.isExpired() || Boolean.TRUE.equals(inviteEntity.isDisabled())) {
+            throw inviteLockedException(inviteEntity.getCode());
+        }
+        if (userDao.findByEmail(inviteEntity.getEmail()).isPresent()) {
+            throw conflictingEmail(inviteEntity.getEmail());
+        }
+        if (inviteEntity.getType() != InviteType.NEW_USER_INVITED_TO_EXISTING_SERVICE) {
+            throw internalServerError(format("Attempting to complete a 'new user, existing service' invite for an invite of type '%s'", inviteEntity.getCode()));
+        }
 
-                    LOGGER.info(
-                            Markers.append(USER_EXTERNAL_ID, userEntity.getExternalId())
-                                    .and(Markers.append(SERVICE_EXTERNAL_ID, serviceIds)),
-                            "User created successfully from invitation"
-                    );
+        UserEntity userEntity = inviteEntity.mapToUserEntity();
+        userDao.persist(userEntity);
+        inviteEntity.setDisabled(Boolean.TRUE);
+        inviteDao.merge(inviteEntity);
 
-                    Invite invite = linksBuilder.addUserLink(userEntity.toUser(), inviteEntity.toInvite());
-                    InviteCompleteResponse response = new InviteCompleteResponse(invite);
-                    response.setUserExternalId(userEntity.getExternalId());
+        String serviceIds = userEntity.getServicesRoles().stream()
+                .map(serviceRole -> serviceRole.getService().getExternalId())
+                .collect(Collectors.joining(", "));
 
-                    return response;
-                })
-                .orElseThrow(() -> notFoundInviteException(inviteCode));
+        LOGGER.info(
+                Markers.append(USER_EXTERNAL_ID, userEntity.getExternalId())
+                        .and(Markers.append(SERVICE_EXTERNAL_ID, serviceIds)),
+                "User created successfully from invitation"
+        );
+
+        Invite invite = linksBuilder.addUserLink(userEntity.toUser(), inviteEntity.toInvite());
+        InviteCompleteResponse response = new InviteCompleteResponse(invite);
+        response.setUserExternalId(userEntity.getExternalId());
+
+        return response;
     }
 
 }

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGenerateOtpIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGenerateOtpIT.java
@@ -12,6 +12,8 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang3.RandomStringUtils.random;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.newId;
 
 public class InviteResourceGenerateOtpIT extends IntegrationTest {
@@ -38,6 +40,9 @@ public class InviteResourceGenerateOtpIT extends IntegrationTest {
                 .post(format(INVITES_GENERATE_OTP_RESOURCE_URL, code))
                 .then()
                 .statusCode(OK.getStatusCode());
+
+        Map<String, Object> invite = databaseHelper.findInviteByCode(code).get();
+        assertThat(invite.get("telephone_number"), is(TELEPHONE_NUMBER));
     }
 
     @Test
@@ -108,6 +113,9 @@ public class InviteResourceGenerateOtpIT extends IntegrationTest {
                 .post(format(INVITES_GENERATE_OTP_RESOURCE_URL, code))
                 .then()
                 .statusCode(OK.getStatusCode());
+
+        Map<String, Object> invite = databaseHelper.findInviteByCode(code).get();
+        assertThat(invite.get("telephone_number"), is(TELEPHONE_NUMBER));
     }
 
     private void givenAnExistingUserInvite() {

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpIT.java
@@ -60,7 +60,7 @@ public class InviteResourceOtpIT extends IntegrationTest {
                 "code", code,
                 "otp", PASSCODE);
 
-        assertThat(databaseHelper.findInviteByCode(code).size(), is(1));
+        assertThat(databaseHelper.findInviteByCode(code).isPresent(), is(true));
 
         ValidatableResponse response = givenSetup()
                 .when()
@@ -169,9 +169,7 @@ public class InviteResourceOtpIT extends IntegrationTest {
                 .statusCode(GONE.getStatusCode());
 
         // check if "login_counter" and "disabled" columns are properly updated
-        List<Map<String, Object>> foundInvites = databaseHelper.findInviteByCode(code);
-        assertThat(foundInvites.size(), is(1));
-        Map<String, Object> foundInvite = foundInvites.get(0);
+        Map<String, Object> foundInvite = databaseHelper.findInviteByCode(code).get();
         assertThat(foundInvite.get("disabled"), is(Boolean.TRUE));
         assertThat(foundInvite.get("login_counter"), is(10));
     }
@@ -215,9 +213,7 @@ public class InviteResourceOtpIT extends IntegrationTest {
                 .statusCode(OK.getStatusCode());
 
         // check if we are using the newTelephoneNumber in the invitation
-        List<Map<String, Object>> foundInvites = databaseHelper.findInviteByCode(code);
-        assertThat(foundInvites.size(), is(1));
-        Map<String, Object> foundInvite = foundInvites.get(0);
+        Map<String, Object> foundInvite = databaseHelper.findInviteByCode(code).get();
         assertThat(foundInvite.get("telephone_number"), is(newTelephoneNumber));
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceServiceCompleteIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceServiceCompleteIT.java
@@ -58,6 +58,8 @@ public class InviteResourceServiceCompleteIT extends IntegrationTest {
         assertThat(createdUser.get("password"), is(password));
         assertThat(createdUser.get("email"), is(email));
         assertThat(createdUser.get("telephone_number"), is(telephoneNumber));
+        
+        assertThat(invite.get("disabled"), is(true));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleterTest.java
@@ -73,34 +73,15 @@ public class ExistingUserInviteCompleterTest {
         anInvite.setService(service);
         UserEntity user = UserEntity.from(aUser(anInvite.getEmail()));
 
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(user));
 
-        InviteCompleteResponse completedInvite = existingUserInviteCompleter.complete(inviteCode);
+        InviteCompleteResponse completedInvite = existingUserInviteCompleter.complete(anInvite);
 
         ArgumentCaptor<UserEntity> persistedUser = ArgumentCaptor.forClass(UserEntity.class);
         verify(mockUserDao).merge(persistedUser.capture());
 
         assertThat(completedInvite.getInvite().isDisabled(), is(true));
         assertThat(persistedUser.getValue().getServicesRole(service.getExternalId()).isPresent(), is(true));
-    }
-
-    @Test
-    public void shouldError_whenSubscribingAServiceToAnExistingUser_forUnrecognisedInvite() {
-
-        ServiceEntity service = new ServiceEntity();
-        service.setId(serviceId);
-        service.setExternalId(serviceExternalId);
-
-        InviteEntity anInvite = createInvite();
-        anInvite.setType(InviteType.SERVICE);
-        anInvite.setService(service);
-
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.empty());
-
-        WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(inviteCode));
-        assertThat(webApplicationException.getMessage(), is("HTTP 404 Not Found"));
     }
 
     @Test
@@ -115,11 +96,10 @@ public class ExistingUserInviteCompleterTest {
         anInvite.setService(null);
         UserEntity user = UserEntity.from(aUser(anInvite.getEmail()));
 
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(user));
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(inviteCode));
+                () -> existingUserInviteCompleter.complete(anInvite));
         assertThat(webApplicationException.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 
@@ -135,11 +115,10 @@ public class ExistingUserInviteCompleterTest {
         anInvite.setService(service);
         UserEntity user = UserEntity.from(aUser(anInvite.getEmail()));
 
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(user));
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(inviteCode));
+                () -> existingUserInviteCompleter.complete(anInvite));
         assertThat(webApplicationException.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 
@@ -150,10 +129,8 @@ public class ExistingUserInviteCompleterTest {
         anInvite.setType(InviteType.USER);
         anInvite.setDisabled(true);
 
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
-
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(inviteCode));
+                () -> existingUserInviteCompleter.complete(anInvite));
         assertThat(webApplicationException.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -163,10 +140,8 @@ public class ExistingUserInviteCompleterTest {
         anInvite.setType(InviteType.USER);
         anInvite.setExpiryDate(ZonedDateTime.now().minusDays(1));
 
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
-
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(inviteCode));
+                () -> existingUserInviteCompleter.complete(anInvite));
         assertThat(webApplicationException.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -174,12 +149,11 @@ public class ExistingUserInviteCompleterTest {
     public void shouldThrowInternalError_whenUserWithSpecifiedEmailNotExists() {
         InviteEntity anInvite = createInvite();
         anInvite.setType(InviteType.USER);
-
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
+        
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(inviteCode));
+                () -> existingUserInviteCompleter.complete(anInvite));
         assertThat(webApplicationException.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 
@@ -194,34 +168,15 @@ public class ExistingUserInviteCompleterTest {
         anInvite.setService(service);
         UserEntity user = UserEntity.from(aUser(anInvite.getEmail()));
 
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(user));
 
-        InviteCompleteResponse completedInvite = existingUserInviteCompleter.complete(inviteCode);
+        InviteCompleteResponse completedInvite = existingUserInviteCompleter.complete(anInvite);
 
         ArgumentCaptor<UserEntity> persistedUser = ArgumentCaptor.forClass(UserEntity.class);
         verify(mockUserDao).merge(persistedUser.capture());
 
         assertThat(completedInvite.getInvite().isDisabled(), is(true));
         assertThat(persistedUser.getValue().getServicesRole(service.getExternalId()).isPresent(), is(true));
-    }
-
-    @Test
-    public void shouldError_whenSubscribingAServiceToAnExistingUser_forUnrecognisedInvite__newEnumValue() {
-
-        ServiceEntity service = new ServiceEntity();
-        service.setId(serviceId);
-        service.setExternalId(serviceExternalId);
-
-        InviteEntity anInvite = createInvite();
-        anInvite.setType(InviteType.EXISTING_USER_INVITED_TO_EXISTING_SERVICE);
-        anInvite.setService(service);
-
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.empty());
-
-        WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(inviteCode));
-        assertThat(webApplicationException.getMessage(), is("HTTP 404 Not Found"));
     }
 
     @Test
@@ -235,12 +190,11 @@ public class ExistingUserInviteCompleterTest {
         anInvite.setType(InviteType.EXISTING_USER_INVITED_TO_EXISTING_SERVICE);
         anInvite.setService(null);
         UserEntity user = UserEntity.from(aUser(anInvite.getEmail()));
-
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
+        
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(user));
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(inviteCode));
+                () -> existingUserInviteCompleter.complete(anInvite));
         assertThat(webApplicationException.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 
@@ -256,11 +210,10 @@ public class ExistingUserInviteCompleterTest {
         anInvite.setService(service);
         UserEntity user = UserEntity.from(aUser(anInvite.getEmail()));
 
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(user));
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(inviteCode));
+                () -> existingUserInviteCompleter.complete(anInvite));
         assertThat(webApplicationException.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 
@@ -271,10 +224,8 @@ public class ExistingUserInviteCompleterTest {
         anInvite.setType(InviteType.EXISTING_USER_INVITED_TO_EXISTING_SERVICE);
         anInvite.setDisabled(true);
 
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
-
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(inviteCode));
+                () -> existingUserInviteCompleter.complete(anInvite));
         assertThat(webApplicationException.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -284,10 +235,8 @@ public class ExistingUserInviteCompleterTest {
         anInvite.setType(InviteType.EXISTING_USER_INVITED_TO_EXISTING_SERVICE);
         anInvite.setExpiryDate(ZonedDateTime.now().minusDays(1));
 
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
-
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(inviteCode));
+                () -> existingUserInviteCompleter.complete(anInvite));
         assertThat(webApplicationException.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -295,12 +244,11 @@ public class ExistingUserInviteCompleterTest {
     public void shouldThrowInternalError_whenUserWithSpecifiedEmailNotExists__newEnumValue() {
         InviteEntity anInvite = createInvite();
         anInvite.setType(InviteType.EXISTING_USER_INVITED_TO_EXISTING_SERVICE);
-
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
+        
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(inviteCode));
+                () -> existingUserInviteCompleter.complete(anInvite));
         assertThat(webApplicationException.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/service/InviteRouterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/InviteRouterTest.java
@@ -9,8 +9,6 @@ import uk.gov.pay.adminusers.model.InviteType;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
 
-import java.util.Optional;
-
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -35,31 +33,25 @@ public class InviteRouterTest {
 
     @BeforeEach
     public void before() {
-        inviteRouter = new InviteRouter(inviteServiceFactory, inviteDao);
+        inviteRouter = new InviteRouter(inviteServiceFactory);
     }
 
     @Test
     public void shouldResolve_selfSignupInviteCompleter_withValidation() {
-        String inviteCode = "a-code";
         InviteEntity inviteEntity = anInvite(SERVICE);
-        when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
         when(inviteServiceFactory.completeSelfSignupInvite()).thenReturn(new SelfSignupInviteCompleter(null, null, null, null));
-        Optional<InviteCompleter> result = inviteRouter.routeComplete(inviteCode);
-
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get(), is(instanceOf(SelfSignupInviteCompleter.class)));
+        InviteCompleter inviteCompleter = inviteRouter.routeComplete(inviteEntity);
+        
+        assertThat(inviteCompleter, is(instanceOf(SelfSignupInviteCompleter.class)));
     }
 
     @Test
     public void shouldResolve_existingUserInviteCompleter_withoutValidation() {
-        String inviteCode = "a-code";
         InviteEntity inviteEntity = anInvite(USER);
-        when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
         when(inviteServiceFactory.completeExistingUserInvite()).thenReturn(new ExistingUserInviteCompleter(null, null));
-        Optional<InviteCompleter> result = inviteRouter.routeComplete(inviteCode);
-
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get(), is(instanceOf(ExistingUserInviteCompleter.class)));
+        InviteCompleter inviteCompleter = inviteRouter.routeComplete(inviteEntity);
+        
+        assertThat(inviteCompleter, is(instanceOf(ExistingUserInviteCompleter.class)));
     }
 
     @Test
@@ -82,38 +74,29 @@ public class InviteRouterTest {
 
     @Test
     public void shouldResolve_selfSignupInviteCompleter() {
-        String inviteCode = "a-code";
         InviteEntity inviteEntity = anInvite(NEW_USER_AND_NEW_SERVICE_SELF_SIGNUP);
-        when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
         when(inviteServiceFactory.completeSelfSignupInvite()).thenReturn(new SelfSignupInviteCompleter(null, null, null, null));
-        Optional<InviteCompleter> result = inviteRouter.routeComplete(inviteCode);
-
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get(), is(instanceOf(SelfSignupInviteCompleter.class)));
+        InviteCompleter inviteCompleter = inviteRouter.routeComplete(inviteEntity);
+        
+        assertThat(inviteCompleter, is(instanceOf(SelfSignupInviteCompleter.class)));
     }
 
     @Test
     public void shouldResolve_newUserExistingServiceInviteCompleter() {
-        String inviteCode = "a-code";
         InviteEntity inviteEntity = anInvite(NEW_USER_INVITED_TO_EXISTING_SERVICE);
-        when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
         when(inviteServiceFactory.completeNewUserExistingServiceInvite()).thenReturn(new NewUserExistingServiceInviteCompleter(null, null, null));
-        Optional<InviteCompleter> result = inviteRouter.routeComplete(inviteCode);
+        InviteCompleter inviteCompleter = inviteRouter.routeComplete(inviteEntity);
 
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get(), is(instanceOf(NewUserExistingServiceInviteCompleter.class)));
+        assertThat(inviteCompleter, is(instanceOf(NewUserExistingServiceInviteCompleter.class)));
     }
 
     @Test
     public void shouldResolve_existingUserInviteCompleter() {
-        String inviteCode = "a-code";
         InviteEntity inviteEntity = anInvite(EXISTING_USER_INVITED_TO_EXISTING_SERVICE);
-        when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
         when(inviteServiceFactory.completeExistingUserInvite()).thenReturn(new ExistingUserInviteCompleter(null, null));
-        Optional<InviteCompleter> result = inviteRouter.routeComplete(inviteCode);
-
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get(), is(instanceOf(ExistingUserInviteCompleter.class)));
+        InviteCompleter inviteCompleter = inviteRouter.routeComplete(inviteEntity);
+        
+        assertThat(inviteCompleter, is(instanceOf(ExistingUserInviteCompleter.class)));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/service/InviteRouterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/InviteRouterTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.adminusers.service;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,7 +41,7 @@ public class InviteRouterTest {
     @Test
     public void shouldResolve_selfSignupInviteCompleter_withValidation() {
         String inviteCode = "a-code";
-        InviteEntity inviteEntity = anInvite(inviteCode, SERVICE);
+        InviteEntity inviteEntity = anInvite(SERVICE);
         when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
         when(inviteServiceFactory.completeSelfSignupInvite()).thenReturn(new SelfSignupInviteCompleter(null, null, null, null));
         Optional<InviteCompleter> result = inviteRouter.routeComplete(inviteCode);
@@ -54,7 +53,7 @@ public class InviteRouterTest {
     @Test
     public void shouldResolve_existingUserInviteCompleter_withoutValidation() {
         String inviteCode = "a-code";
-        InviteEntity inviteEntity = anInvite(inviteCode, USER);
+        InviteEntity inviteEntity = anInvite(USER);
         when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
         when(inviteServiceFactory.completeExistingUserInvite()).thenReturn(new ExistingUserInviteCompleter(null, null));
         Optional<InviteCompleter> result = inviteRouter.routeComplete(inviteCode);
@@ -64,35 +63,27 @@ public class InviteRouterTest {
     }
 
     @Test
-    public void shouldResolve_existingUserInviteDispatcher_withValidation() {
-        String inviteCode = "a-code";
-        InviteEntity inviteEntity = anInvite(inviteCode, USER);
-        when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
+    public void shouldResolve_existingUserInviteDispatcher_forUserInviteType() {
+        InviteEntity inviteEntity = anInvite(USER);
         when(inviteServiceFactory.dispatchUserOtp()).thenReturn(new UserOtpDispatcher(null, null, null, null));
-        Optional<Pair<InviteOtpDispatcher, Boolean>> result = inviteRouter.routeOtpDispatch(inviteCode);
-
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get().getLeft(), is(instanceOf(UserOtpDispatcher.class)));
-        assertThat(result.get().getRight(), is(true));
+        InviteOtpDispatcher otpDispatcher = inviteRouter.routeOtpDispatch(inviteEntity);
+        
+        assertThat(otpDispatcher, is(instanceOf(UserOtpDispatcher.class)));
     }
 
     @Test
-    public void shouldResolve_selfSignupInviteDispatcher_withoutValidation() {
-        String inviteCode = "a-code";
-        InviteEntity inviteEntity = anInvite(inviteCode, SERVICE);
-        when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
+    public void shouldResolve_selfSignupInviteDispatcher_forServiceInviteType() {
+        InviteEntity inviteEntity = anInvite(SERVICE);
         when(inviteServiceFactory.dispatchServiceOtp()).thenReturn(new ServiceOtpDispatcher(null, null, null, null));
-        Optional<Pair<InviteOtpDispatcher, Boolean>> result = inviteRouter.routeOtpDispatch(inviteCode);
-
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get().getLeft(), is(instanceOf(ServiceOtpDispatcher.class)));
-        assertThat(result.get().getRight(), is(false));
+        InviteOtpDispatcher otpDispatcher = inviteRouter.routeOtpDispatch(inviteEntity);
+        
+        assertThat(otpDispatcher, is(instanceOf(ServiceOtpDispatcher.class)));
     }
 
     @Test
     public void shouldResolve_selfSignupInviteCompleter() {
         String inviteCode = "a-code";
-        InviteEntity inviteEntity = anInvite(inviteCode, NEW_USER_AND_NEW_SERVICE_SELF_SIGNUP);
+        InviteEntity inviteEntity = anInvite(NEW_USER_AND_NEW_SERVICE_SELF_SIGNUP);
         when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
         when(inviteServiceFactory.completeSelfSignupInvite()).thenReturn(new SelfSignupInviteCompleter(null, null, null, null));
         Optional<InviteCompleter> result = inviteRouter.routeComplete(inviteCode);
@@ -104,7 +95,7 @@ public class InviteRouterTest {
     @Test
     public void shouldResolve_newUserExistingServiceInviteCompleter() {
         String inviteCode = "a-code";
-        InviteEntity inviteEntity = anInvite(inviteCode, NEW_USER_INVITED_TO_EXISTING_SERVICE);
+        InviteEntity inviteEntity = anInvite(NEW_USER_INVITED_TO_EXISTING_SERVICE);
         when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
         when(inviteServiceFactory.completeNewUserExistingServiceInvite()).thenReturn(new NewUserExistingServiceInviteCompleter(null, null, null));
         Optional<InviteCompleter> result = inviteRouter.routeComplete(inviteCode);
@@ -116,7 +107,7 @@ public class InviteRouterTest {
     @Test
     public void shouldResolve_existingUserInviteCompleter() {
         String inviteCode = "a-code";
-        InviteEntity inviteEntity = anInvite(inviteCode, EXISTING_USER_INVITED_TO_EXISTING_SERVICE);
+        InviteEntity inviteEntity = anInvite(EXISTING_USER_INVITED_TO_EXISTING_SERVICE);
         when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
         when(inviteServiceFactory.completeExistingUserInvite()).thenReturn(new ExistingUserInviteCompleter(null, null));
         Optional<InviteCompleter> result = inviteRouter.routeComplete(inviteCode);
@@ -127,42 +118,32 @@ public class InviteRouterTest {
 
     @Test
     public void shouldResolve_selfSignupInviteDispatcher() {
-        String inviteCode = "a-code";
-        InviteEntity inviteEntity = anInvite(inviteCode, NEW_USER_AND_NEW_SERVICE_SELF_SIGNUP);
-        when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
+        InviteEntity inviteEntity = anInvite(NEW_USER_AND_NEW_SERVICE_SELF_SIGNUP);
         when(inviteServiceFactory.dispatchServiceOtp()).thenReturn(new ServiceOtpDispatcher(null, null, null, null));
-        Optional<Pair<InviteOtpDispatcher, Boolean>> result = inviteRouter.routeOtpDispatch(inviteCode);
-
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get().getLeft(), is(instanceOf(ServiceOtpDispatcher.class)));
-        assertThat(result.get().getRight(), is(false));
+        InviteOtpDispatcher otpDispatcher = inviteRouter.routeOtpDispatch(inviteEntity);
+        
+        assertThat(otpDispatcher, is(instanceOf(ServiceOtpDispatcher.class)));
     }
 
     @Test
     public void shouldResolve_newUserExistingServiceInviteDispatcher() {
-        String inviteCode = "a-code";
-        InviteEntity inviteEntity = anInvite(inviteCode, NEW_USER_INVITED_TO_EXISTING_SERVICE);
-        when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
+        InviteEntity inviteEntity = anInvite(NEW_USER_INVITED_TO_EXISTING_SERVICE);
         when(inviteServiceFactory.dispatchUserOtp()).thenReturn(new UserOtpDispatcher(null, null, null, null));
-        Optional<Pair<InviteOtpDispatcher, Boolean>> result = inviteRouter.routeOtpDispatch(inviteCode);
-
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get().getLeft(), is(instanceOf(UserOtpDispatcher.class)));
-        assertThat(result.get().getRight(), is(true));
+        InviteOtpDispatcher otpDispatcher = inviteRouter.routeOtpDispatch(inviteEntity);
+        
+        assertThat(otpDispatcher, is(instanceOf(UserOtpDispatcher.class)));
     }
 
     @Test
     public void shouldResolve_existingUserInviteDispatcher() {
-        String inviteCode = "a-code";
-        InviteEntity inviteEntity = anInvite(inviteCode, EXISTING_USER_INVITED_TO_EXISTING_SERVICE);
-        when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.of(inviteEntity));
+        InviteEntity inviteEntity = anInvite(EXISTING_USER_INVITED_TO_EXISTING_SERVICE);
 
-        assertThrows(IllegalArgumentException.class, () -> inviteRouter.routeOtpDispatch(inviteCode));
+        assertThrows(IllegalArgumentException.class, () -> inviteRouter.routeOtpDispatch(inviteEntity));
     }
 
-    private InviteEntity anInvite(String code, InviteType inviteType) {
+    private InviteEntity anInvite(InviteType inviteType) {
         InviteEntity inviteEntity = new InviteEntity();
-        inviteEntity.setCode(code);
+        inviteEntity.setCode("a-code");
         inviteEntity.setEmail("example@example.com");
         inviteEntity.setTelephoneNumber("+441134960000");
         inviteEntity.setOtpKey("u73t2b7");

--- a/src/test/java/uk/gov/pay/adminusers/service/NewUserExistingServiceInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/NewUserExistingServiceInviteCompleterTest.java
@@ -69,9 +69,8 @@ public class NewUserExistingServiceInviteCompleterTest {
         InviteEntity anInvite = createInvite();
         anInvite.setType(InviteType.NEW_USER_INVITED_TO_EXISTING_SERVICE);
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
 
-        InviteCompleteResponse inviteResponse = newUserExistingServiceInviteCompleter.withData(new InviteCompleteRequest()).complete(anInvite.getCode());
+        InviteCompleteResponse inviteResponse = newUserExistingServiceInviteCompleter.withData(new InviteCompleteRequest()).complete(anInvite);
 
         verify(mockUserDao).persist(expectedInvitedUser.capture());
         verify(mockInviteDao).merge(expectedInvite.capture());
@@ -97,28 +96,11 @@ public class NewUserExistingServiceInviteCompleterTest {
         InviteEntity anInvite = createInvite();
         anInvite.setType(InviteType.NEW_USER_INVITED_TO_EXISTING_SERVICE);
 
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
         when(mockUserDao.findByEmail(anInvite.getEmail())).thenReturn(Optional.of(mock(UserEntity.class)));
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> newUserExistingServiceInviteCompleter.complete(anInvite.getCode()));
+                () -> newUserExistingServiceInviteCompleter.complete(anInvite));
         assertThat(exception.getMessage(), is("HTTP 409 Conflict"));
-    }
-
-    @Test
-    public void shouldThrowEmailExistsException_whenPassedUnrecognisedInviteCode() {
-        ServiceEntity service = new ServiceEntity();
-        service.setId(serviceId);
-
-        InviteEntity anInvite = createInvite();
-        anInvite.setType(InviteType.NEW_USER_INVITED_TO_EXISTING_SERVICE);
-        anInvite.setDisabled(true);
-
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.empty());
-
-        WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> newUserExistingServiceInviteCompleter.complete(anInvite.getCode()));
-        assertThat(exception.getMessage(), is("HTTP 404 Not Found"));
     }
 
     @Test
@@ -130,10 +112,8 @@ public class NewUserExistingServiceInviteCompleterTest {
         anInvite.setType(InviteType.NEW_USER_INVITED_TO_EXISTING_SERVICE);
         anInvite.setDisabled(true);
 
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
-
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> newUserExistingServiceInviteCompleter.complete(anInvite.getCode()));
+                () -> newUserExistingServiceInviteCompleter.complete(anInvite));
         assertThat(exception.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -146,10 +126,8 @@ public class NewUserExistingServiceInviteCompleterTest {
         anInvite.setType(InviteType.NEW_USER_INVITED_TO_EXISTING_SERVICE);
         anInvite.setExpiryDate(ZonedDateTime.now().minusDays(1));
 
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
-
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> newUserExistingServiceInviteCompleter.complete(anInvite.getCode()));
+                () -> newUserExistingServiceInviteCompleter.complete(anInvite));
         assertThat(exception.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -161,11 +139,10 @@ public class NewUserExistingServiceInviteCompleterTest {
         InviteEntity anInvite = createInvite();
         anInvite.setType(InviteType.EXISTING_USER_INVITED_TO_EXISTING_SERVICE);
 
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> newUserExistingServiceInviteCompleter.complete(anInvite.getCode()));
+                () -> newUserExistingServiceInviteCompleter.complete(anInvite));
         assertThat(exception.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 
@@ -177,11 +154,10 @@ public class NewUserExistingServiceInviteCompleterTest {
         InviteEntity anInvite = createInvite();
         anInvite.setType(InviteType.NEW_USER_AND_NEW_SERVICE_SELF_SIGNUP);
 
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> newUserExistingServiceInviteCompleter.complete(anInvite.getCode()));
+                () -> newUserExistingServiceInviteCompleter.complete(anInvite));
         assertThat(exception.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/service/SelfSignupInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/SelfSignupInviteCompleterTest.java
@@ -80,11 +80,10 @@ public class SelfSignupInviteCompleterTest {
         InviteEntity anInvite = createInvite();
         anInvite.setType(InviteType.SERVICE);
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
 
         InviteCompleteRequest data = new InviteCompleteRequest();
         data.setGatewayAccountIds(asList("1", "2"));
-        InviteCompleteResponse inviteResponse = selfSignupInviteCompleter.withData(data).complete(anInvite.getCode());
+        InviteCompleteResponse inviteResponse = selfSignupInviteCompleter.withData(data).complete(anInvite);
 
         verify(mockServiceDao).persist(expectedService.capture());
         verify(mockUserDao).merge(expectedInvitedUser.capture());
@@ -110,9 +109,8 @@ public class SelfSignupInviteCompleterTest {
         InviteEntity anInvite = createInvite();
         anInvite.setType(InviteType.SERVICE);
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
 
-        InviteCompleteResponse inviteResponse = selfSignupInviteCompleter.withData(new InviteCompleteRequest()).complete(anInvite.getCode());
+        InviteCompleteResponse inviteResponse = selfSignupInviteCompleter.withData(new InviteCompleteRequest()).complete(anInvite);
 
         verify(mockServiceDao).persist(expectedService.capture());
         verify(mockUserDao).merge(expectedInvitedUser.capture());
@@ -141,28 +139,11 @@ public class SelfSignupInviteCompleterTest {
         InviteEntity anInvite = createInvite();
         anInvite.setType(InviteType.SERVICE);
 
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
         when(mockUserDao.findByEmail(anInvite.getEmail())).thenReturn(Optional.of(mock(UserEntity.class)));
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> selfSignupInviteCompleter.complete(anInvite.getCode()));
+                () -> selfSignupInviteCompleter.complete(anInvite));
         assertThat(exception.getMessage(), is("HTTP 409 Conflict"));
-    }
-
-    @Test
-    public void shouldThrowEmailExistsException_whenPassedUnrecognisedInviteCode() {
-        ServiceEntity service = new ServiceEntity();
-        service.setId(serviceId);
-
-        InviteEntity anInvite = createInvite();
-        anInvite.setType(InviteType.SERVICE);
-        anInvite.setDisabled(true);
-
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.empty());
-
-        WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> selfSignupInviteCompleter.complete(anInvite.getCode()));
-        assertThat(exception.getMessage(), is("HTTP 404 Not Found"));
     }
 
     @Test
@@ -174,10 +155,8 @@ public class SelfSignupInviteCompleterTest {
         anInvite.setType(InviteType.SERVICE);
         anInvite.setDisabled(true);
 
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
-
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> selfSignupInviteCompleter.complete(anInvite.getCode()));
+                () -> selfSignupInviteCompleter.complete(anInvite));
         assertThat(exception.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -190,10 +169,8 @@ public class SelfSignupInviteCompleterTest {
         anInvite.setType(InviteType.SERVICE);
         anInvite.setExpiryDate(ZonedDateTime.now().minusDays(1));
 
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
-
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> selfSignupInviteCompleter.complete(anInvite.getCode()));
+                () -> selfSignupInviteCompleter.complete(anInvite));
         assertThat(exception.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -204,12 +181,11 @@ public class SelfSignupInviteCompleterTest {
 
         InviteEntity anInvite = createInvite();
         anInvite.setType(InviteType.USER);
-
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
+        
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> selfSignupInviteCompleter.complete(anInvite.getCode()));
+                () -> selfSignupInviteCompleter.complete(anInvite));
         assertThat(exception.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 
@@ -222,10 +198,8 @@ public class SelfSignupInviteCompleterTest {
         anInvite.setType(InviteType.NEW_USER_AND_NEW_SERVICE_SELF_SIGNUP);
         anInvite.setExpiryDate(ZonedDateTime.now().minusDays(1));
 
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
-
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> selfSignupInviteCompleter.complete(anInvite.getCode()));
+                () -> selfSignupInviteCompleter.complete(anInvite));
         assertThat(exception.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -236,12 +210,11 @@ public class SelfSignupInviteCompleterTest {
 
         InviteEntity anInvite = createInvite();
         anInvite.setType(InviteType.NEW_USER_INVITED_TO_EXISTING_SERVICE);
-
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
+        
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> selfSignupInviteCompleter.complete(anInvite.getCode()));
+                () -> selfSignupInviteCompleter.complete(anInvite));
         assertThat(exception.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 
@@ -252,12 +225,11 @@ public class SelfSignupInviteCompleterTest {
 
         InviteEntity anInvite = createInvite();
         anInvite.setType(InviteType.EXISTING_USER_INVITED_TO_EXISTING_SERVICE);
-
-        when(mockInviteDao.findByCode(inviteCode)).thenReturn(Optional.of(anInvite));
+        
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> selfSignupInviteCompleter.complete(anInvite.getCode()));
+                () -> selfSignupInviteCompleter.complete(anInvite));
         assertThat(exception.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
@@ -19,6 +19,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.sql.Timestamp.from;
 import static java.sql.Types.OTHER;
@@ -308,12 +309,12 @@ public class DatabaseTestHelper {
         return this;
     }
 
-    public List<Map<String, Object>> findInviteByCode(String code) {
+    public Optional<Map<String, Object>> findInviteByCode(String code) {
         return jdbi.withHandle(h ->
                 h.createQuery("SELECT id, sender_id, service_id, role_id, email, code, otp_key, date, telephone_number, disabled, login_counter FROM invites " +
                         "WHERE code = :code")
                         .bind("code", code)
-                        .mapToMap().list());
+                        .mapToMap().findOne());
     }
 
     public List<Map<String, Object>> findServiceByExternalId(String serviceExternalId) {


### PR DESCRIPTION
PP-10041 Refactor InviteRouter#routeOtpDispatch

Refactor the InviteRouter#routeOtpDispatch to accept an InviteEntity
rather than a code. Instead, look up the InviteEntity in the resource.
This simplifies the code as InviteRouter#routeOtpDispatch no longer
needs to return a Pair with a boolean indicating whether or not the
telephone number and password should be expected in the HTTP request
body.

PP-10041 Refactor invite completer

Refactor invite completer resource so that the resource gets the
InviteEntity once and passes it to the code that needs to use it. This
avoids having to look up the invite multiple times and also simplifies
return types.

with @alan-gds 