### PR TITLE
PP-10048 Refactor exceptions from NotificationService

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -420,7 +420,7 @@
         "filename": "src/test/java/uk/gov/pay/adminusers/service/InviteServiceTest.java",
         "hashed_secret": "7300c52390b4026eb1a60642b0eabfb54475c21b",
         "is_verified": false,
-        "line_number": 48
+        "line_number": 51
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/service/ResetPasswordServiceTest.java": [
@@ -472,5 +472,5 @@
       }
     ]
   },
-  "generated_at": "2022-10-12T11:06:48Z"
+  "generated_at": "2022-10-13T10:08:59Z"
 }

--- a/src/main/java/uk/gov/pay/adminusers/exception/UserNotificationException.java
+++ b/src/main/java/uk/gov/pay/adminusers/exception/UserNotificationException.java
@@ -1,0 +1,7 @@
+package uk.gov.pay.adminusers.exception;
+
+public class UserNotificationException extends Exception {
+    public UserNotificationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/service/ExistingUserOtpDispatcher.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ExistingUserOtpDispatcher.java
@@ -3,6 +3,7 @@ package uk.gov.pay.adminusers.service;
 import com.google.inject.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.adminusers.exception.UserNotificationException;
 import uk.gov.pay.adminusers.model.SecondFactorToken;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
 
@@ -50,7 +51,7 @@ public class ExistingUserOtpDispatcher {
                             String notificationId = notificationService.sendSecondFactorPasscodeSms(userEntity.getTelephoneNumber(), token.getPasscode(),
                                     notifyTemplateId);
                             LOGGER.info("sent 2FA token successfully to user [{}], notification id [{}]", userExternalId, notificationId);
-                        } catch (Exception e) {
+                        } catch (UserNotificationException e) {
                             LOGGER.error("error sending 2FA token to user [{}]", userExternalId, e);
                         }
 

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteService.java
@@ -4,6 +4,7 @@ import com.google.inject.name.Named;
 import com.google.inject.persist.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.adminusers.exception.UserNotificationException;
 import uk.gov.pay.adminusers.model.Invite;
 import uk.gov.pay.adminusers.model.InviteOtpRequest;
 import uk.gov.pay.adminusers.model.InviteType;
@@ -73,7 +74,7 @@ public class InviteService {
                 String notificationId = notificationService.sendSecondFactorPasscodeSms(inviteOtpRequest.getTelephoneNumber(), passcode,
                         mapInviteTypeToOtpNotifySmsTemplateId(invite.getType()));
                 LOGGER.info("sent 2FA token successfully for invite code [{}], notification id [{}]", inviteOtpRequest.getCode(), notificationId);
-            } catch (Exception e) {
+            } catch (UserNotificationException e) {
                 LOGGER.error(String.format("error sending 2FA token for invite code [%s]", inviteOtpRequest.getCode()), e);
             }
         } else {

--- a/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.adminusers.app.config.NotifyConfiguration;
 import uk.gov.pay.adminusers.app.config.NotifyDirectDebitConfiguration;
+import uk.gov.pay.adminusers.exception.UserNotificationException;
 import uk.gov.pay.adminusers.utils.telephonenumber.TelephoneNumberUtility;
 import uk.gov.service.notify.NotificationClientException;
 import uk.gov.service.notify.SendEmailResponse;
@@ -77,7 +78,7 @@ public class NotificationService {
         return notifyDirectDebitConfiguration;
     }
 
-    public String sendSecondFactorPasscodeSms(String phoneNumber, String passcode, OtpNotifySmsTemplateId otpNotifySmsTemplateId) {
+    public String sendSecondFactorPasscodeSms(String phoneNumber, String passcode, OtpNotifySmsTemplateId otpNotifySmsTemplateId) throws UserNotificationException {
         Stopwatch responseTimeStopwatch = Stopwatch.createStarted();
         try {
             SendSmsResponse response = notifyClientProvider.get().sendSms(resolveOtpNotifySmsTemplateId(otpNotifySmsTemplateId),
@@ -86,7 +87,7 @@ public class NotificationService {
         } catch (NotificationClientException e) {
             metricRegistry.counter("notify-operations.sms.failures").inc();
             LOGGER.info("Error sending Sms: " + e.getMessage());
-            throw userNotificationError(e);
+            throw new UserNotificationException("Error sending SMS: " + e.getMessage(), e);
         } finally {
             responseTimeStopwatch.stop();
             metricRegistry.histogram("notify-operations.sms.response_time").update(responseTimeStopwatch.elapsed(TimeUnit.MILLISECONDS));

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcher.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcher.java
@@ -3,6 +3,7 @@ package uk.gov.pay.adminusers.service;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.adminusers.exception.UserNotificationException;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.utils.telephonenumber.TelephoneNumberUtility;
 
@@ -53,7 +54,7 @@ public class ServiceOtpDispatcher extends InviteOtpDispatcher {
                         String notificationId = notificationService.sendSecondFactorPasscodeSms(inviteEntity.getTelephoneNumber(), passcode,
                                 SELF_INITIATED_CREATE_NEW_USER_AND_SERVICE);
                         LOGGER.info("sent 2FA token successfully for invite code [{}], notification id [{}]", inviteEntity.getCode(), notificationId);
-                    } catch (Exception e) {
+                    } catch (UserNotificationException e) {
                         LOGGER.error(format("error sending 2FA token for invite code [%s]", inviteEntity.getCode()), e);
                     }
                     

--- a/src/main/java/uk/gov/pay/adminusers/service/UserOtpDispatcher.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserOtpDispatcher.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.adminusers.exception.UserNotificationException;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.utils.telephonenumber.TelephoneNumberUtility;
 
@@ -47,7 +48,7 @@ public class UserOtpDispatcher extends InviteOtpDispatcher {
                         String notificationId = notificationService.sendSecondFactorPasscodeSms(inviteOtpRequest.getTelephoneNumber(), passcode,
                                 CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE);
                         LOGGER.info("sent 2FA token successfully for invite code [{}], notification id [{}]", inviteCode, notificationId);
-                    } catch (Exception e) {
+                    } catch (UserNotificationException e) {
                         LOGGER.info(format("error sending 2FA token for invite code [%s]", inviteCode), e);
                     }
                     

--- a/src/test/java/uk/gov/pay/adminusers/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/NotificationServiceTest.java
@@ -92,7 +92,7 @@ public class NotificationServiceTest {
     }
 
     @Test
-    public void sendSecondFactorPasscodeSmsWithSignInTemplate() throws NotificationClientException {
+    public void sendSecondFactorPasscodeSmsWithSignInTemplate() throws Exception {
         given(mockMetricRegistry.histogram("notify-operations.sms.response_time")).willReturn(mock(Histogram.class));
         given(mockNotificationClient.sendSms(anyString(), anyString(), anyMap(), isNull())).willReturn(mockSendSmsResponse);
         given(mockSendSmsResponse.getNotificationId()).willReturn(NOTIFICATION_ID);
@@ -103,7 +103,7 @@ public class NotificationServiceTest {
     }
 
     @Test
-    public void sendSecondFactorPasscodeSmsWithChangeSignIn2faToSmsTemplate() throws NotificationClientException {
+    public void sendSecondFactorPasscodeSmsWithChangeSignIn2faToSmsTemplate() throws Exception {
         given(mockMetricRegistry.histogram("notify-operations.sms.response_time")).willReturn(mock(Histogram.class));
         given(mockNotificationClient.sendSms(anyString(), anyString(), anyMap(), isNull())).willReturn(mockSendSmsResponse);
         given(mockSendSmsResponse.getNotificationId()).willReturn(NOTIFICATION_ID);
@@ -114,7 +114,7 @@ public class NotificationServiceTest {
     }
 
     @Test
-    public void sendSecondFactorPasscodeSmsWithSelfInitiatedCreateNewUserAndServiceTemplate() throws NotificationClientException {
+    public void sendSecondFactorPasscodeSmsWithSelfInitiatedCreateNewUserAndServiceTemplate() throws Exception {
         given(mockMetricRegistry.histogram("notify-operations.sms.response_time")).willReturn(mock(Histogram.class));
         given(mockNotificationClient.sendSms(anyString(), anyString(), anyMap(), isNull())).willReturn(mockSendSmsResponse);
         given(mockSendSmsResponse.getNotificationId()).willReturn(NOTIFICATION_ID);
@@ -126,7 +126,7 @@ public class NotificationServiceTest {
     }
 
     @Test
-    public void sendSecondFactorPasscodeSmsWithCreateUserInResponseToInvitationToServiceTemplate() throws NotificationClientException {
+    public void sendSecondFactorPasscodeSmsWithCreateUserInResponseToInvitationToServiceTemplate() throws Exception {
         given(mockMetricRegistry.histogram("notify-operations.sms.response_time")).willReturn(mock(Histogram.class));
         given(mockNotificationClient.sendSms(anyString(), anyString(), anyMap(), isNull())).willReturn(mockSendSmsResponse);
         given(mockSendSmsResponse.getNotificationId()).willReturn(NOTIFICATION_ID);

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcherTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcherTest.java
@@ -46,7 +46,7 @@ public class ServiceOtpDispatcherTest {
     }
 
     @Test
-    public void shouldSuccess_whenDispatchServiceOtp_ifInviteEntityExist() {
+    public void shouldSuccess_whenDispatchServiceOtp_ifInviteEntityExist() throws Exception {
         String inviteCode = "valid-invite-code";
         String telephone = "+441134960000";
         InviteEntity inviteEntity = new InviteEntity();
@@ -65,7 +65,7 @@ public class ServiceOtpDispatcherTest {
     }
 
     @Test
-    public void shouldSuccess_whenDispatchServiceOtp_ifInviteEntityExist_butPhoneAndPasswordOnlyInRequest_andUpdateInviteEntityWithPhoneAndPassword() {
+    public void shouldSuccess_whenDispatchServiceOtp_ifInviteEntityExist_butPhoneAndPasswordOnlyInRequest_andUpdateInviteEntityWithPhoneAndPassword() throws Exception {
         String inviteCode = "valid-invite-code";
         InviteEntity inviteEntity = new InviteEntity();
         inviteEntity.setCode(inviteCode);
@@ -92,7 +92,7 @@ public class ServiceOtpDispatcherTest {
     }
 
     @Test
-    public void shouldSuccess_whenDispatchServiceOtp_ifInviteEntityExistWithPassword_butPhoneOnlyInRequest_andUpdateInviteEntityWithPhone() {
+    public void shouldSuccess_whenDispatchServiceOtp_ifInviteEntityExistWithPassword_butPhoneOnlyInRequest_andUpdateInviteEntityWithPhone() throws Exception {
         String inviteCode = "valid-invite-code";
         InviteEntity inviteEntity = new InviteEntity();
         inviteEntity.setCode(inviteCode);
@@ -118,7 +118,7 @@ public class ServiceOtpDispatcherTest {
     }
 
     @Test
-    public void shouldSuccess_whenDispatchServiceOtp_ifInviteEntityExist__newEnumValue() {
+    public void shouldSuccess_whenDispatchServiceOtp_ifInviteEntityExist__newEnumValue() throws Exception {
         String inviteCode = "valid-invite-code";
         String telephone = "+441134960000";
         InviteEntity inviteEntity = new InviteEntity();
@@ -137,7 +137,7 @@ public class ServiceOtpDispatcherTest {
     }
 
     @Test
-    public void shouldSuccess_whenDispatchServiceOtp_ifInviteEntityExist_butPhoneAndPasswordOnlyInRequest_andUpdateInviteEntityWithPhoneAndPassword__newEnumValue() {
+    public void shouldSuccess_whenDispatchServiceOtp_ifInviteEntityExist_butPhoneAndPasswordOnlyInRequest_andUpdateInviteEntityWithPhoneAndPassword__newEnumValue() throws Exception {
         String inviteCode = "valid-invite-code";
         InviteEntity inviteEntity = new InviteEntity();
         inviteEntity.setCode(inviteCode);
@@ -164,7 +164,7 @@ public class ServiceOtpDispatcherTest {
     }
 
     @Test
-    public void shouldSuccess_whenDispatchServiceOtp_ifInviteEntityExistWithPassword_butPhoneOnlyInRequest_andUpdateInviteEntityWithPhone__newEnumValue() {
+    public void shouldSuccess_whenDispatchServiceOtp_ifInviteEntityExistWithPassword_butPhoneOnlyInRequest_andUpdateInviteEntityWithPhone__newEnumValue() throws Exception {
         String inviteCode = "valid-invite-code";
         InviteEntity inviteEntity = new InviteEntity();
         inviteEntity.setCode(inviteCode);

--- a/src/test/java/uk/gov/pay/adminusers/service/UserOtpDispatcherTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserOtpDispatcherTest.java
@@ -47,7 +47,7 @@ class UserOtpDispatcherTest {
     }
 
     @Test
-    void shouldSuccess_whenDispatchUserOtp_ifInviteEntityExist() {
+    void shouldSuccess_whenDispatchUserOtp_ifInviteEntityExist() throws Exception {
         String inviteCode = "valid-invite-code";
         InviteEntity inviteEntity = new InviteEntity();
         inviteEntity.setCode(inviteCode);
@@ -73,7 +73,7 @@ class UserOtpDispatcherTest {
     }
 
     @Test
-    void shouldSuccess_whenDispatchUserOtp_ifInviteEntityExist__newEnumValue() {
+    void shouldSuccess_whenDispatchUserOtp_ifInviteEntityExist__newEnumValue() throws Exception {
         String inviteCode = "valid-invite-code";
         InviteEntity inviteEntity = new InviteEntity();
         inviteEntity.setCode(inviteCode);


### PR DESCRIPTION
When the Notify client returns an exception, wrap the exception in a UserNotificationException and explicitly handle this in calling methods. Previously, we wrapped the exception in a WebApplicationException which extends RuntimeException and in the calling method were catching all Exceptions.

This change makes it easier to understand when exceptions might be thrown.