### PR TITLE
PP-10048 Refactor ExistingUserOtpDispatcher

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -314,14 +314,14 @@
         "filename": "src/main/java/uk/gov/pay/adminusers/resources/UserResource.java",
         "hashed_secret": "a31519136d26754afeb0df49b5f066f387091f88",
         "is_verified": false,
-        "line_number": 117
+        "line_number": 121
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/main/java/uk/gov/pay/adminusers/resources/UserResource.java",
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_verified": false,
-        "line_number": 433
+        "line_number": 440
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/service/ForgottenPasswordServices.java": [
@@ -472,5 +472,5 @@
       }
     ]
   },
-  "generated_at": "2022-10-12T11:06:48Z"
+  "generated_at": "2022-10-13T10:46:04Z"
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
@@ -102,6 +102,11 @@ public class AdminUsersExceptions {
     public static WebApplicationException userNotificationError(Exception cause) {
         return buildWebApplicationException("error sending user notification", INTERNAL_SERVER_ERROR.getStatusCode(), cause);
     }
+    
+    public static WebApplicationException otpKeyMissingException(String userExternalId) {
+        String error = format("Attempted to send a 2FA token attempted for user without an OTP key [%s]", userExternalId);
+        return buildWebApplicationException(error, BAD_REQUEST.getStatusCode());
+    }
 
     private static WebApplicationException buildWebApplicationException(String error, int status) {
         return buildWebApplicationException(error, status, null);

--- a/src/main/java/uk/gov/pay/adminusers/service/ExistingUserOtpDispatcher.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ExistingUserOtpDispatcher.java
@@ -4,10 +4,9 @@ import com.google.inject.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.adminusers.model.SecondFactorToken;
-import uk.gov.pay.adminusers.persistence.dao.UserDao;
+import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 
 import javax.inject.Inject;
-import java.util.Optional;
 
 import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.CHANGE_SIGN_IN_2FA_TO_SMS;
 import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.SIGN_IN;
@@ -18,63 +17,52 @@ public class ExistingUserOtpDispatcher {
 
     private final NotificationService notificationService;
     private final SecondFactorAuthenticator secondFactorAuthenticator;
-    private final UserDao userDao;
 
     @Inject
-    public ExistingUserOtpDispatcher(Provider<NotificationService> notificationService, SecondFactorAuthenticator secondFactorAuthenticator,
-                                     UserDao userDao) {
+    public ExistingUserOtpDispatcher(Provider<NotificationService> notificationService, SecondFactorAuthenticator secondFactorAuthenticator) {
         this.notificationService = notificationService.get();
         this.secondFactorAuthenticator = secondFactorAuthenticator;
-        this.userDao = userDao;
-    }
-    
-    public Optional<SecondFactorToken> sendSignInOtp(String externalId) {
-        return sendOtp(externalId, false);
     }
 
-    public Optional<SecondFactorToken> sendChangeSignMethodToSmsOtp(String externalId) {
-        return sendOtp(externalId, true);
+    public SecondFactorToken sendSignInOtp(UserEntity userEntity) {
+        return sendOtp(userEntity, false);
     }
 
-    private Optional<SecondFactorToken> sendOtp(String externalId, boolean changingSignInMethodToSms) {
-        return userDao.findByExternalId(externalId)
-                .map(userEntity -> {
-                    String otpKeyOrProvisionalOtpKey = changingSignInMethodToSms ? userEntity.getProvisionalOtpKey() : userEntity.getOtpKey();
-                    return Optional.ofNullable(otpKeyOrProvisionalOtpKey).map(otpKey -> {
-                        int newPassCode = secondFactorAuthenticator.newPassCode(otpKey);
-                        SecondFactorToken token = SecondFactorToken.from(externalId, newPassCode);
-                        String userExternalId = userEntity.getExternalId();
-                        NotificationService.OtpNotifySmsTemplateId notifyTemplateId = changingSignInMethodToSms ? CHANGE_SIGN_IN_2FA_TO_SMS : SIGN_IN;
+    public SecondFactorToken sendChangeSignMethodToSmsOtp(UserEntity userEntity) {
+        return sendOtp(userEntity, true);
+    }
 
-                        try {
-                            String notificationId = notificationService.sendSecondFactorPasscodeSms(userEntity.getTelephoneNumber(), token.getPasscode(),
-                                    notifyTemplateId);
-                            LOGGER.info("sent 2FA token successfully to user [{}], notification id [{}]", userExternalId, notificationId);
-                        } catch (Exception e) {
-                            LOGGER.error("error sending 2FA token to user [{}]", userExternalId, e);
-                        }
+    private SecondFactorToken sendOtp(UserEntity userEntity, boolean changingSignInMethodToSms) {
+        String otpKeyOrProvisionalOtpKey = changingSignInMethodToSms ? userEntity.getProvisionalOtpKey() : userEntity.getOtpKey();
+        if (otpKeyOrProvisionalOtpKey == null) {
+            if (changingSignInMethodToSms) {
+                LOGGER.error("New provisional 2FA token attempted for user without a provisional OTP key [{}]", userEntity.getExternalId());
+            } else {
+                // Realistically, this will never happen
+                LOGGER.error("New 2FA token attempted for user without an OTP key [{}]", userEntity.getExternalId());
+            }
+            throw AdminUsersExceptions.otpKeyMissingException(userEntity.getExternalId());
+        }
 
-                        if (changingSignInMethodToSms) {
-                            LOGGER.info("New 2FA token generated for User [{}] from provisional OTP key", userExternalId);
-                        } else {
-                            LOGGER.info("New 2FA token generated for User [{}]", userExternalId);
-                        }
-                        return Optional.of(token);
-                    }).orElseGet(() -> {
-                        if (changingSignInMethodToSms) {
-                            LOGGER.error("New provisional 2FA token attempted for user without a provisional OTP key [{}]", externalId);
-                        } else {
-                            // Realistically, this will never happen
-                            LOGGER.error("New 2FA token attempted for user without an OTP key [{}]", externalId);
-                        }
-                        return Optional.empty();
-                    });
-                })
-                .orElseGet(() -> {
-                    //this cannot happen unless a bug in selfservice
-                    LOGGER.error("New 2FA token attempted for non-existent User [{}]", externalId);
-                    return Optional.empty();
-                });
+        int newPassCode = secondFactorAuthenticator.newPassCode(otpKeyOrProvisionalOtpKey);
+        SecondFactorToken token = SecondFactorToken.from(userEntity.getExternalId(), newPassCode);
+        String userExternalId = userEntity.getExternalId();
+        NotificationService.OtpNotifySmsTemplateId notifyTemplateId = changingSignInMethodToSms ? CHANGE_SIGN_IN_2FA_TO_SMS : SIGN_IN;
+
+        try {
+            String notificationId = notificationService.sendSecondFactorPasscodeSms(userEntity.getTelephoneNumber(), token.getPasscode(),
+                    notifyTemplateId);
+            LOGGER.info("sent 2FA token successfully to user [{}], notification id [{}]", userExternalId, notificationId);
+        } catch (Exception e) {
+            LOGGER.error("error sending 2FA token to user [{}]", userExternalId, e);
+        }
+
+        if (changingSignInMethodToSms) {
+            LOGGER.info("New 2FA token generated for User [{}] from provisional OTP key", userExternalId);
+        } else {
+            LOGGER.info("New 2FA token generated for User [{}]", userExternalId);
+        }
+        return token;
     }
 
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
@@ -90,9 +90,8 @@ public class UserServices {
         }
     }
 
-    public Optional<User> findUserByExternalId(String externalId) {
-        Optional<UserEntity> userEntityOptional = userDao.findByExternalId(externalId);
-        return userEntityOptional.map(userEntity -> linksBuilder.decorate(userEntity.toUser()));
+    public Optional<UserEntity> findUserByExternalId(String externalId) {
+        return userDao.findByExternalId(externalId);
     }
 
     public List<User> findUsersByExternalIds(List<String> externalIds) {

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceSecondFactorAuthenticationIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceSecondFactorAuthenticationIT.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.User;
 
+import java.util.List;
 import java.util.Map;
 
 import static com.google.common.io.BaseEncoding.base32;
@@ -73,7 +74,7 @@ public class UserResourceSecondFactorAuthenticationIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldReturnNotFound_forAValidNewSecondFactorPasscodeRequest_withProvisionalTrue_ifNoProvisionalOtpKey() throws JsonProcessingException {
+    public void shouldReturnBadRequest_forAValidNewSecondFactorPasscodeRequest_withProvisionalTrue_ifNoProvisionalOtpKey() throws JsonProcessingException {
         Map<String, Boolean> body = Map.of("provisional", true);
 
         givenSetup()
@@ -82,7 +83,8 @@ public class UserResourceSecondFactorAuthenticationIT extends IntegrationTest {
                 .body(mapper.writeValueAsString(body))
                 .post(format(USER_2FA_URL, externalId))
                 .then()
-                .statusCode(404);
+                .statusCode(400)
+                .body("errors", is(List.of(format("Attempted to send a 2FA token attempted for user without an OTP key [%s]", externalId))));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/service/ExistingUserOtpDispatcherTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ExistingUserOtpDispatcherTest.java
@@ -11,6 +11,7 @@ import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 
+import javax.ws.rs.WebApplicationException;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
@@ -18,6 +19,7 @@ import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -31,13 +33,11 @@ import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemp
 import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.SIGN_IN;
 
 @ExtendWith(MockitoExtension.class)
-public class ExistingUserOtpDispatcherTest {
+class ExistingUserOtpDispatcherTest {
 
     private static final String USER_EXTERNAL_ID = "7d19aff33f8948deb97ed16b2912dcd3";
     private static final String USER_USERNAME = "random-name";
-
-    @Mock
-    private UserDao userDao;
+    
     @Mock
     private NotificationService notificationService;
     @Mock
@@ -46,134 +46,97 @@ public class ExistingUserOtpDispatcherTest {
     private ExistingUserOtpDispatcher existingUserOtpDispatcher;
 
     @BeforeEach
-    public void before() {
-        existingUserOtpDispatcher = new ExistingUserOtpDispatcher(() -> notificationService, secondFactorAuthenticator, userDao);
+    void before() {
+        existingUserOtpDispatcher = new ExistingUserOtpDispatcher(() -> notificationService, secondFactorAuthenticator);
     }
 
     @Test
-    public void shouldSendSignInOtpIfUserFound() {
+    void shouldSendSignInOtpIfUserFound() {
         User user = aUser();
         UserEntity userEntity = UserEntity.from(user);
-        when(userDao.findByExternalId(user.getExternalId())).thenReturn(Optional.of(userEntity));
         when(secondFactorAuthenticator.newPassCode(user.getOtpKey())).thenReturn(123456);
         when(notificationService.sendSecondFactorPasscodeSms(any(String.class), eq("123456"), eq(SIGN_IN))).thenReturn("random-notify-id");
 
-        Optional<SecondFactorToken> tokenOptional = existingUserOtpDispatcher.sendSignInOtp(user.getExternalId());
-
-        assertTrue(tokenOptional.isPresent());
-        assertThat(tokenOptional.get().getPasscode(), is("123456"));
+        SecondFactorToken token = existingUserOtpDispatcher.sendSignInOtp(userEntity);
+        
+        assertThat(token.getPasscode(), is("123456"));
     }
 
     @Test
-    public void shouldPadSignInOtpToSixDigits() {
+    void shouldPadSignInOtpToSixDigits() {
         User user = aUser();
         UserEntity userEntity = UserEntity.from(user);
-        when(userDao.findByExternalId(user.getExternalId())).thenReturn(Optional.of(userEntity));
         when(secondFactorAuthenticator.newPassCode(user.getOtpKey())).thenReturn(12345);
         when(notificationService.sendSecondFactorPasscodeSms(any(String.class), eq("012345"), eq(SIGN_IN))).thenReturn("random-notify-id");
 
-        Optional<SecondFactorToken> tokenOptional = existingUserOtpDispatcher.sendSignInOtp(user.getExternalId());
-
-        assertTrue(tokenOptional.isPresent());
-        assertThat(tokenOptional.get().getPasscode(), is("012345"));
+        SecondFactorToken token = existingUserOtpDispatcher.sendSignInOtp(userEntity);
+        
+        assertThat(token.getPasscode(), is("012345"));
     }
 
     @Test
-    public void shouldGracefullyHandleNotifyErrorSendingSignInOtp() {
+    void shouldGracefullyHandleNotifyErrorSendingSignInOtp() {
         User user = aUser();
         UserEntity userEntity = UserEntity.from(user);
-        when(userDao.findByExternalId(user.getExternalId())).thenReturn(Optional.of(userEntity));
         when(secondFactorAuthenticator.newPassCode(user.getOtpKey())).thenReturn(654321);
 
         when(notificationService.sendSecondFactorPasscodeSms(any(String.class), eq("654321"), eq(SIGN_IN)))
                 .thenThrow(AdminUsersExceptions.userNotificationError(new Exception("Cause")));
 
-        Optional<SecondFactorToken> tokenOptional = existingUserOtpDispatcher.sendSignInOtp(user.getExternalId());
+        SecondFactorToken token = existingUserOtpDispatcher.sendSignInOtp(userEntity);
 
-        assertTrue(tokenOptional.isPresent());
-        assertThat(tokenOptional.get().getPasscode(), is("654321"));
+        assertThat(token.getPasscode(), is("654321"));
     }
 
     @Test
-    public void shouldNotSendSignInOtpIfUserDoesNotExist() {
-        String nonExistentExternalId = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
-        when(userDao.findByExternalId(nonExistentExternalId)).thenReturn(Optional.empty());
-
-        Optional<SecondFactorToken> tokenOptional = existingUserOtpDispatcher.sendSignInOtp(nonExistentExternalId);
-
-        assertFalse(tokenOptional.isPresent());
-    }
-
-    @Test
-    public void shouldSendChangeSignInMethodOtpIfUserFound() {
+    void shouldSendChangeSignInMethodOtp() {
         User user = aUserWithProvisionalOtpKey();
         UserEntity userEntity = UserEntity.from(user);
-        when(userDao.findByExternalId(user.getExternalId())).thenReturn(Optional.of(userEntity));
         when(secondFactorAuthenticator.newPassCode(user.getProvisionalOtpKey())).thenReturn(654321);
         when(notificationService.sendSecondFactorPasscodeSms(any(String.class), eq("654321"), eq(CHANGE_SIGN_IN_2FA_TO_SMS)))
                 .thenReturn("random-notify-id");
 
-        Optional<SecondFactorToken> tokenOptional = existingUserOtpDispatcher.sendChangeSignMethodToSmsOtp(user.getExternalId());
+        SecondFactorToken token = existingUserOtpDispatcher.sendChangeSignMethodToSmsOtp(userEntity);
 
-        assertTrue(tokenOptional.isPresent());
-        assertThat(tokenOptional.get().getPasscode(), is("654321"));
+        assertThat(token.getPasscode(), is("654321"));
 
         verify(notificationService, never()).sendSecondFactorPasscodeSms(any(String.class), eq(user.getOtpKey()),
                 any(NotificationService.OtpNotifySmsTemplateId.class));
     }
 
     @Test
-    public void shouldPadChangeSignInMethodOtpToSixDigits() {
+    void shouldPadChangeSignInMethodOtpToSixDigits() {
         User user = aUserWithProvisionalOtpKey();
         UserEntity userEntity = UserEntity.from(user);
-        when(userDao.findByExternalId(user.getExternalId())).thenReturn(Optional.of(userEntity));
         when(secondFactorAuthenticator.newPassCode(user.getProvisionalOtpKey())).thenReturn(12345);
         when(notificationService.sendSecondFactorPasscodeSms(any(String.class), eq("012345"), eq(CHANGE_SIGN_IN_2FA_TO_SMS)))
                 .thenReturn("random-notify-id");
 
-        Optional<SecondFactorToken> tokenOptional = existingUserOtpDispatcher.sendChangeSignMethodToSmsOtp(user.getExternalId());
+        SecondFactorToken token = existingUserOtpDispatcher.sendChangeSignMethodToSmsOtp(userEntity);
 
-        assertTrue(tokenOptional.isPresent());
-        assertThat(tokenOptional.get().getPasscode(), is("012345"));
+        assertThat(token.getPasscode(), is("012345"));
     }
 
     @Test
-    public void shouldNotSendChangeSignInOtpIfProvisionalOtpKeyNotSet() {
+    void shouldNotSendChangeSignInOtpIfProvisionalOtpKeyNotSet() {
         User user = aUser();
         UserEntity userEntity = UserEntity.from(user);
-        when(userDao.findByExternalId(user.getExternalId())).thenReturn(Optional.of(userEntity));
-
-        Optional<SecondFactorToken> tokenOptional = existingUserOtpDispatcher.sendChangeSignMethodToSmsOtp(user.getExternalId());
-
-        assertFalse(tokenOptional.isPresent());
-
-        verifyNoInteractions(secondFactorAuthenticator);
+        
+        assertThrows(WebApplicationException.class, () -> existingUserOtpDispatcher.sendChangeSignMethodToSmsOtp(userEntity));
     }
 
     @Test
-    public void shouldGracefullyHandleNotifyErrorSendingChangeSignInOtp() {
+    void shouldGracefullyHandleNotifyErrorSendingChangeSignInOtp() {
         User user = aUserWithProvisionalOtpKey();
         UserEntity userEntity = UserEntity.from(user);
-        when(userDao.findByExternalId(user.getExternalId())).thenReturn(Optional.of(userEntity));
         when(secondFactorAuthenticator.newPassCode(user.getProvisionalOtpKey())).thenReturn(654321);
 
         when(notificationService.sendSecondFactorPasscodeSms(any(String.class), eq("654321"), eq(CHANGE_SIGN_IN_2FA_TO_SMS)))
                 .thenThrow(AdminUsersExceptions.userNotificationError(new Exception("Cause")));
 
-        Optional<SecondFactorToken> tokenOptional = existingUserOtpDispatcher.sendChangeSignMethodToSmsOtp(user.getExternalId());
+        SecondFactorToken token = existingUserOtpDispatcher.sendChangeSignMethodToSmsOtp(userEntity);
 
-        assertTrue(tokenOptional.isPresent());
-        assertThat(tokenOptional.get().getPasscode(), is("654321"));
-    }
-
-    @Test
-    public void shouldNotSendChangeSignInOtpIfUserDoesNotExist() {
-        String nonExistentExternalId = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
-        when(userDao.findByExternalId(nonExistentExternalId)).thenReturn(Optional.empty());
-
-        Optional<SecondFactorToken> tokenOptional = existingUserOtpDispatcher.sendChangeSignMethodToSmsOtp(nonExistentExternalId);
-
-        assertFalse(tokenOptional.isPresent());
+        assertThat(token.getPasscode(), is("654321"));
     }
 
     private User aUser() {

--- a/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
@@ -94,7 +94,7 @@ public class UserServicesTest {
         Optional<UserEntity> userEntityOptional = Optional.of(userEntity);
         when(mockUserDao.findByExternalId(USER_EXTERNAL_ID)).thenReturn(userEntityOptional);
 
-        Optional<User> userOptional = underTest.findUserByExternalId(USER_EXTERNAL_ID);
+        Optional<UserEntity> userOptional = underTest.findUserByExternalId(USER_EXTERNAL_ID);
         assertTrue(userOptional.isPresent());
 
         assertThat(userOptional.get().getExternalId(), is(USER_EXTERNAL_ID));
@@ -121,7 +121,7 @@ public class UserServicesTest {
     void shouldReturnEmpty_WhenFindByExternalId_ifNotFound() {
         when(mockUserDao.findByExternalId(USER_EXTERNAL_ID)).thenReturn(Optional.empty());
 
-        Optional<User> userOptional = underTest.findUserByExternalId(USER_EXTERNAL_ID);
+        Optional<UserEntity> userOptional = underTest.findUserByExternalId(USER_EXTERNAL_ID);
         assertFalse(userOptional.isPresent());
     }
 


### PR DESCRIPTION
Simplify the code in ExistingUserOtpDispatcher by accepting the UserEntity as a parameter and looking up the UserEntity at the resource level.

If sending a 2FA code fails because an OTP key isn't present on the user, throw a WebApplication rather than returning an empty Optional. This also allows for a more specific error message to be returned in the HTTP response.

These changes reduce code nesting and avoid returning Optionals.
