### PR TITLE
PP-10048 Prepare for telephone number being nullable

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/UserEntity.java
@@ -137,8 +137,8 @@ public class UserEntity extends AbstractEntity {
         this.otpKey = otpKey;
     }
 
-    public String getTelephoneNumber() {
-        return telephoneNumber;
+    public Optional<String> getTelephoneNumber() {
+        return Optional.ofNullable(telephoneNumber);
     }
 
     public void setTelephoneNumber(String telephoneNumber) {

--- a/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
@@ -108,6 +108,11 @@ public class AdminUsersExceptions {
         return buildWebApplicationException(error, BAD_REQUEST.getStatusCode());
     }
 
+    public static WebApplicationException userDoesNotHaveTelephoneNumberError(String userExternalId) {
+        String error = format("Unable to send second factor code as user [%s] does not have a telephone number set", userExternalId);
+        return buildWebApplicationException(error, PRECONDITION_FAILED.getStatusCode());
+    }
+
     private static WebApplicationException buildWebApplicationException(String error, int status) {
         return buildWebApplicationException(error, status, null);
     }

--- a/src/test/java/uk/gov/pay/adminusers/model/UserEntityTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/model/UserEntityTest.java
@@ -40,7 +40,7 @@ class UserEntityTest {
         assertThat(userEntity.getUsername(), is(createUserRequest.getUsername()));
         assertThat(userEntity.getPassword(), is(createUserRequest.getPassword()));
         assertThat(userEntity.getOtpKey(), is(otpKey));
-        assertThat(userEntity.getTelephoneNumber(), is(createUserRequest.getTelephoneNumber()));
+        assertThat(userEntity.getTelephoneNumber().get(), is(createUserRequest.getTelephoneNumber()));
         assertThat(userEntity.getEmail(), is(createUserRequest.getEmail()));
         assertThat(userEntity.getSecondFactor(), is(SecondFactorMethod.SMS));
         assertThat(userEntity.getCreatedAt(), is(notNullValue()));

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoIT.java
@@ -97,7 +97,7 @@ public class UserDaoIT extends DaoTestBase {
         assertThat(savedUserData.get(0).get("password"), is(userEntity.getPassword()));
         assertThat(savedUserData.get(0).get("email"), is(userEntity.getEmail()));
         assertThat(savedUserData.get(0).get("otp_key"), is(userEntity.getOtpKey()));
-        assertThat(savedUserData.get(0).get("telephone_number"), is(userEntity.getTelephoneNumber()));
+        assertThat(savedUserData.get(0).get("telephone_number"), is(userEntity.getTelephoneNumber().get()));
         assertThat(savedUserData.get(0).get("disabled"), is(Boolean.FALSE));
         assertThat(savedUserData.get(0).get("session_version"), is(0));
         assertThat(savedUserData.get(0).get("createdat"), is(java.sql.Timestamp.from(timeNow.toInstant())));
@@ -138,7 +138,7 @@ public class UserDaoIT extends DaoTestBase {
         assertThat(foundUser.getUsername(), is(username));
         assertThat(foundUser.getEmail(), is(email));
         assertThat(foundUser.getOtpKey(), is(otpKey));
-        assertThat(foundUser.getTelephoneNumber(), is("+447700900000"));
+        assertThat(foundUser.getTelephoneNumber().get(), is("+447700900000"));
         assertThat(foundUser.isDisabled(), is(false));
         assertThat(foundUser.getLoginCounter(), is(0));
         assertThat(foundUser.getSessionVersion(), is(0));
@@ -190,7 +190,7 @@ public class UserDaoIT extends DaoTestBase {
         assertThat(foundUser1.getUsername(), is(user1.getUsername()));
         assertThat(foundUser1.getEmail(), is(user1.getEmail()));
         assertThat(foundUser1.getOtpKey(), is(user1.getOtpKey()));
-        assertThat(foundUser1.getTelephoneNumber(), is("+447700900000"));
+        assertThat(foundUser1.getTelephoneNumber().get(), is("+447700900000"));
         assertThat(foundUser1.isDisabled(), is(false));
         assertThat(foundUser1.getLoginCounter(), is(0));
         assertThat(foundUser1.getSessionVersion(), is(0));
@@ -203,7 +203,7 @@ public class UserDaoIT extends DaoTestBase {
         assertThat(foundUser2.getUsername(), is(user2.getUsername()));
         assertThat(foundUser2.getEmail(), is(user2.getEmail()));
         assertThat(foundUser2.getOtpKey(), is(user2.getOtpKey()));
-        assertThat(foundUser2.getTelephoneNumber(), is("+447700900000"));
+        assertThat(foundUser2.getTelephoneNumber().get(), is("+447700900000"));
         assertThat(foundUser2.isDisabled(), is(false));
         assertThat(foundUser2.getLoginCounter(), is(0));
         assertThat(foundUser2.getSessionVersion(), is(0));
@@ -231,7 +231,7 @@ public class UserDaoIT extends DaoTestBase {
         assertThat(foundUser.getEmail(), is(email));
         assertThat(foundUser.getUsername(), is(username));
         assertThat(foundUser.getOtpKey(), is(otpKey));
-        assertThat(foundUser.getTelephoneNumber(), is("+447700900000"));
+        assertThat(foundUser.getTelephoneNumber().get(), is("+447700900000"));
         assertThat(foundUser.isDisabled(), is(false));
         assertThat(foundUser.getLoginCounter(), is(0));
         assertThat(foundUser.getSessionVersion(), is(0));
@@ -257,7 +257,7 @@ public class UserDaoIT extends DaoTestBase {
         assertThat(foundUser.getUsername(), is(username));
         assertThat(foundUser.getEmail(), is(email));
         assertThat(foundUser.getOtpKey(), is(otpKey));
-        assertThat(foundUser.getTelephoneNumber(), is("+447700900000"));
+        assertThat(foundUser.getTelephoneNumber().get(), is("+447700900000"));
         assertThat(foundUser.isDisabled(), is(false));
         assertThat(foundUser.getLoginCounter(), is(0));
         assertThat(foundUser.getSessionVersion(), is(0));

--- a/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserServicesTest.java
@@ -302,7 +302,7 @@ public class UserServicesTest {
         verify(mockUserDao, times(1)).merge(userEntityArgumentCaptor.capture());
 
         UserEntity persistedUser = userEntityArgumentCaptor.getValue();
-        assertThat(persistedUser.getTelephoneNumber(), is(newTelephoneNumber));
+        assertThat(persistedUser.getTelephoneNumber().get(), is(newTelephoneNumber));
         assertTrue(userOptional.isPresent());
 
         assertThat(userOptional.get().getTelephoneNumber(), is(newTelephoneNumber));


### PR DESCRIPTION
The `telephone_number` column on the `users` table is going to be made nullable. Prepare for this by returning an Optional from the getter on the UserEntity, and handling it not being present by throwing an exception that is mapped to a 412 error response.