### PR TITLE
PP-10048 Make telephone number nullable on users

### DIFF
--- a/src/main/resources/migrations/00081_alter_users_set_telephone_number_nullable.sql
+++ b/src/main/resources/migrations/00081_alter_users_set_telephone_number_nullable.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_table_users_set_column_telephone_number_to_nullable
+ALTER TABLE users ALTER column telephone_number DROP NOT NULL;
+
+-- rollback ALTER TABLE users ALTER column telephone_number SET NOT NULL;


### PR DESCRIPTION
Make the telephone_number column on the users table nullable. This is to allow for users to sign-up to pay with authenticator apps, which will not require them to enter a phone number.