### PR TITLE
PP-10048 Return error for reset second factor

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
@@ -112,6 +112,11 @@ public class AdminUsersExceptions {
         String error = format("Unable to send second factor code as user [%s] does not have a telephone number set", userExternalId);
         return buildWebApplicationException(error, PRECONDITION_FAILED.getStatusCode());
     }
+    
+    public static WebApplicationException cannotResetSecondFactorToSmsError(String userExternalId) {
+        String error = format("Unable to reset second factor method to SMS as user [%s] does not have a telephone number set", userExternalId);
+        return buildWebApplicationException(error, PRECONDITION_FAILED.getStatusCode());
+    }
 
     private static WebApplicationException buildWebApplicationException(String error, int status) {
         return buildWebApplicationException(error, status, null);

--- a/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserServices.java
@@ -219,6 +219,9 @@ public class UserServices {
                 logger.info("Second factor method is already SMS, doing nothing");
                 return linksBuilder.decorate(userEntity.toUser());
             }
+            if (userEntity.getTelephoneNumber().isEmpty()) {
+                throw AdminUsersExceptions.cannotResetSecondFactorToSmsError(externalId);
+            }
             
             logger.info("Resetting OTP method to SMS for user {}", userEntity.getExternalId());
             userEntity.setOtpKey(secondFactorAuthenticator.generateNewBase32EncodedSecret());


### PR DESCRIPTION
Return a 412 error when the /v1/api/users/{userExternalId}/reset-second-factor endpoint is called if the user does not have a telephone number set.

This is because We don't want to allow resetting a user's method from APP to SMS in Toolbox if the user does not have a telephone number set.