### PR TITLE
PP-10041: Start using new InviteType enum values

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceInviteCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceInviteCreator.java
@@ -21,7 +21,7 @@ import java.util.function.Function;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toUnmodifiableList;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
-import static uk.gov.pay.adminusers.model.InviteType.SERVICE;
+import static uk.gov.pay.adminusers.model.InviteType.NEW_USER_AND_NEW_SERVICE_SELF_SIGNUP;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.conflictingEmail;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.internalServerError;
 
@@ -87,7 +87,7 @@ public class ServiceInviteCreator {
                 .map(roleEntity -> {
                     String otpKey = secondFactorAuthenticator.generateNewBase32EncodedSecret();
                     InviteEntity inviteEntity = new InviteEntity(requestEmail, randomUuid(), otpKey, roleEntity);
-                    inviteEntity.setType(SERVICE);
+                    inviteEntity.setType(NEW_USER_AND_NEW_SERVICE_SELF_SIGNUP);
                     return constructInviteAndSendEmail(inviteServiceRequest, inviteEntity, inviteToPersist -> {
                         inviteDao.persist(inviteToPersist);
                         return null;

--- a/src/main/java/uk/gov/pay/adminusers/service/UserInviteCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserInviteCreator.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.adminusers.app.config.LinksConfig;
 import uk.gov.pay.adminusers.model.Invite;
+import uk.gov.pay.adminusers.model.InviteType;
 import uk.gov.pay.adminusers.model.InviteUserRequest;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.dao.RoleDao;
@@ -23,7 +24,8 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.toUnmodifiableList;
 import static javax.ws.rs.core.UriBuilder.fromUri;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
-import static uk.gov.pay.adminusers.model.InviteType.USER;
+import static uk.gov.pay.adminusers.model.InviteType.EXISTING_USER_INVITED_TO_EXISTING_SERVICE;
+import static uk.gov.pay.adminusers.model.InviteType.NEW_USER_INVITED_TO_EXISTING_SERVICE;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.conflictingInvite;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.forbiddenOperationException;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.undefinedRoleException;
@@ -92,6 +94,7 @@ public class UserInviteCreator {
         }
 
         ServiceEntity serviceEntity = serviceEntityOptional.get();
+        InviteType inviteType = existingUser.isPresent() ? EXISTING_USER_INVITED_TO_EXISTING_SERVICE : NEW_USER_INVITED_TO_EXISTING_SERVICE;
 
         return roleDao.findByRoleName(inviteUserRequest.getRoleName())
                 .map(role -> {
@@ -101,7 +104,7 @@ public class UserInviteCreator {
                         InviteEntity inviteEntity = new InviteEntity(inviteUserRequest.getEmail(), randomUuid(), otpKey, role);
                         inviteEntity.setSender(userSender.get());
                         inviteEntity.setService(serviceEntity);
-                        inviteEntity.setType(USER);
+                        inviteEntity.setType(inviteType);
                         inviteDao.persist(inviteEntity);
                         String inviteUrl = fromUri(linksConfig.getSelfserviceInvitesUrl()).path(inviteEntity.getCode()).build().toString();
                         sendUserInviteNotification(inviteEntity, inviteUrl, serviceEntity, existingUser);

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceInviteCreatorTest.java
@@ -82,7 +82,7 @@ class ServiceInviteCreatorTest {
         verify(inviteDao, times(1)).persist(persistedInviteEntity.capture());
         assertThat(invite.getEmail(), is(request.getEmail()));
         assertThat(invite.getTelephoneNumber(), is("+441134960000"));
-        assertThat(invite.getType(), is("service"));
+        assertThat(invite.getType(), is("new_user_and_new_service_self_signup"));
         assertThat(invite.getLinks().get(0).getHref(), matchesPattern("^http://selfservice/invites/[0-9a-z]{32}$"));
 
         assertThat(persistedInviteEntity.getValue().getPassword(), is("encrypted-password"));
@@ -104,7 +104,7 @@ class ServiceInviteCreatorTest {
         verify(inviteDao, times(1)).persist(persistedInviteEntity.capture());
         assertThat(invite.getEmail(), is(request.getEmail()));
         assertThat(invite.getTelephoneNumber(), is(nullValue()));
-        assertThat(invite.getType(), is("service"));
+        assertThat(invite.getType(), is("new_user_and_new_service_self_signup"));
         assertThat(invite.getLinks().get(0).getHref(), matchesPattern("^http://selfservice/invites/[0-9a-z]{32}$"));
 
         assertThat(persistedInviteEntity.getValue().getTelephoneNumber(), is(nullValue()));
@@ -126,7 +126,7 @@ class ServiceInviteCreatorTest {
         verify(inviteDao, times(1)).persist(persistedInviteEntity.capture());
         assertThat(invite.getEmail(), is(request.getEmail()));
         assertThat(invite.getTelephoneNumber(), is("+441134960000"));
-        assertThat(invite.getType(), is("service"));
+        assertThat(invite.getType(), is("new_user_and_new_service_self_signup"));
         assertThat(invite.getLinks().get(0).getHref(), matchesPattern("^http://selfservice/invites/[0-9a-z]{32}$"));
 
     }
@@ -205,7 +205,7 @@ class ServiceInviteCreatorTest {
         Invite invite = serviceInviteCreator.doInvite(request);
 
         assertThat(invite.getEmail(), is(request.getEmail()));
-        assertThat(invite.getType(), is("service"));
+        assertThat(invite.getType(), is("new_user_and_new_service_self_signup"));
         assertThat(invite.getLinks().get(0).getHref().matches("^http://selfservice/invites/[0-9a-z]{32}$"), is(true));
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
@@ -11,6 +11,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.adminusers.app.config.LinksConfig;
 import uk.gov.pay.adminusers.model.Invite;
+import uk.gov.pay.adminusers.model.InviteType;
 import uk.gov.pay.adminusers.model.InviteUserRequest;
 import uk.gov.pay.adminusers.model.SecondFactorMethod;
 import uk.gov.pay.adminusers.model.Service;
@@ -49,6 +50,8 @@ import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.model.InviteRequest.FIELD_EMAIL;
 import static uk.gov.pay.adminusers.model.InviteRequest.FIELD_ROLE_NAME;
+import static uk.gov.pay.adminusers.model.InviteType.EXISTING_USER_INVITED_TO_EXISTING_SERVICE;
+import static uk.gov.pay.adminusers.model.InviteType.NEW_USER_INVITED_TO_EXISTING_SERVICE;
 import static uk.gov.pay.adminusers.model.InviteUserRequest.FIELD_SENDER;
 import static uk.gov.pay.adminusers.model.InviteUserRequest.FIELD_SERVICE_EXTERNAL_ID;
 import static uk.gov.pay.adminusers.model.Role.role;
@@ -75,12 +78,13 @@ class UserInviteCreatorTest {
     private UserInviteCreator userInviteCreator;
     @Captor
     private ArgumentCaptor<InviteEntity> expectedInvite;
-    private String senderEmail = "sender@example.com";
-    private String email = "invited@example.com";
-    private int serviceId = 1;
-    private String serviceExternalId = "3453rmeuty87t";
-    private String senderExternalId = "12345";
-    private String roleName = "view-only";
+    private final String senderEmail = "sender@example.com";
+    private final String email = "invited@example.com";
+    private final int serviceId = 1;
+    private final String serviceExternalId = "3453rmeuty87t";
+    private final String externalId = "54321";
+    private final String senderExternalId = "12345";
+    private final String roleName = "view-only";
 
     @BeforeEach
     void setUp() {
@@ -116,6 +120,40 @@ class UserInviteCreatorTest {
         Optional<Invite> invite = userInviteCreator.doInvite(inviteUserRequest);
 
         assertFalse(invite.isPresent());
+    }
+
+    @Test
+    void create_shouldCorrectlySetInviteType_forExistingUser() {
+        mockInviteSuccessForExistingUserNonExistingInvite();
+
+        when(linksConfig.getSelfserviceInvitesUrl()).thenReturn("http://selfservice/invites");
+        String otpKey = "an-otp-key";
+        when(secondFactorAuthenticator.generateNewBase32EncodedSecret()).thenReturn(otpKey);
+
+        userInviteCreator.doInvite(inviteRequestFrom(senderExternalId, email, roleName));
+
+        verify(mockInviteDao).persist(expectedInvite.capture());
+        InviteEntity savedInvite = expectedInvite.getValue();
+
+        assertThat(savedInvite.getType(), is(EXISTING_USER_INVITED_TO_EXISTING_SERVICE));
+    }
+
+    @Test
+    void create_shouldCorrectlySetInviteType_forNewUser() {
+        mockInviteSuccessForNonExistingUserNonExistingInvite();
+
+        when(mockNotificationService.sendInviteEmail(eq(senderEmail), eq(email), matches("^http://selfservice/invites/[0-9a-z]{32}$")))
+                .thenReturn("random-notify-id");
+        when(linksConfig.getSelfserviceInvitesUrl()).thenReturn("http://selfservice/invites");
+        String otpKey = "an-otp-key";
+        when(secondFactorAuthenticator.generateNewBase32EncodedSecret()).thenReturn(otpKey);
+
+        userInviteCreator.doInvite(inviteRequestFrom(senderExternalId, email, roleName));
+
+        verify(mockInviteDao).persist(expectedInvite.capture());
+        InviteEntity savedInvite = expectedInvite.getValue();
+
+        assertThat(savedInvite.getType(), is(NEW_USER_INVITED_TO_EXISTING_SERVICE));
     }
 
     @Test
@@ -332,8 +370,34 @@ class UserInviteCreatorTest {
 
         String inviteCode = "code";
         InviteEntity anInvite = anInvite(email, inviteCode, "otpKey", senderUser, service, role);
-        
+
         return anInvite;
+    }
+
+    private InviteEntity mockInviteSuccessForExistingUserNonExistingInvite() {
+        ServiceEntity service = new ServiceEntity();
+        service.setId(serviceId);
+        service.setExternalId(serviceExternalId);
+
+        UserEntity invitedUser = new UserEntity();
+        invitedUser.setExternalId(externalId);
+        invitedUser.setEmail(email);
+
+        when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(invitedUser));
+        when(mockInviteDao.findByEmail(email)).thenReturn(emptyList());
+        when(mockServiceDao.findByExternalId(serviceExternalId)).thenReturn(Optional.of(service));
+        when(mockRoleDao.findByRoleName(roleName)).thenReturn(Optional.of(new RoleEntity()));
+
+        UserEntity senderUser = new UserEntity();
+        senderUser.setExternalId(senderExternalId);
+        senderUser.setEmail(senderEmail);
+        RoleEntity role = new RoleEntity(role(ADMIN.getId(), "admin", "Admin Role"));
+        senderUser.addServiceRole(new ServiceRoleEntity(service, role));
+        when(mockUserDao.findByExternalId(senderExternalId)).thenReturn(Optional.of(senderUser));
+
+        String inviteCode = "code";
+
+        return anInvite(email, inviteCode, "otpKey", senderUser, service, role);
     }
 
     private InviteEntity anInvite(String email, String code, String otpKey, UserEntity userEntity, ServiceEntity serviceEntity, RoleEntity roleEntity) {


### PR DESCRIPTION
## WHAT YOU DID
Start using the new InviteType enum values.  The old values will still be present in the database on older invites, until they either expire after 2 days or we do a migration - so, we're not removing support for the old values yet.