### PR TITLE
PP-10004 M1 support for integration tests

### DIFF
--- a/.github/workflows/_run-pact-provider-tests.yml
+++ b/.github/workflows/_run-pact-provider-tests.yml
@@ -47,7 +47,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Pull docker image dependencies
         run: |
-          docker pull govukpay/postgres:11.1
+          docker pull postgres:11.16
       - name: Run provider pact tests
         run: |
           export MAVEN_REPO="$HOME/.m2"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,6 +32,6 @@ jobs:
           key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}-pacts
       - name: Pull docker image dependencies
         run: |
-          docker pull govukpay/postgres:11.1
+          docker pull postgres:11.16
       - name: Run integration tests
         run: mvn clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <guava.version>31.1-jre</guava.version>
         <jackson.version>2.13.4</jackson.version>
         <pact.version>3.6.15</pact.version>
-        <pay-java-commons.version>1.0.20221017095941</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20221018103433</pay-java-commons.version>
         <junit5.version>5.9.1</junit5.version>
         <swaggger-version>2.2.4</swaggger-version>
         <testcontainers.version>1.17.5</testcontainers.version>
@@ -480,8 +480,10 @@
                         </goals>
                         <configuration>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>uk.gov.pay.adminusers.app.AdminUsersApp</mainClass>
                                 </transformer>
                             </transformers>

--- a/src/test/java/uk/gov/pay/adminusers/infra/SqsTestDocker.java
+++ b/src/test/java/uk/gov/pay/adminusers/infra/SqsTestDocker.java
@@ -31,17 +31,11 @@ public class SqsTestDocker {
         if (sqsContainer == null) {
             logger.info("Creating SQS Container");
 
-            sqsContainer = new GenericContainer("mvisonneau/alpine-sqs:1.2.0")
+            sqsContainer = new GenericContainer("softwaremill/elasticmq-native")
                     .withExposedPorts(9324)
-                    .waitingFor(Wait.forHttp("/?Action=GetQueueUrl&QueueName=default"));
-
+                    .waitingFor(Wait.forLogMessage(".*ElasticMQ server.*.*started.*", 1));
             sqsContainer.start();
         }
-    }
-
-    public static void stopContainer() {
-        sqsContainer.stop();
-        sqsContainer = null;
     }
 
     private static AmazonSQS createQueues(List<String> queueNames) {

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/DaoTestBase.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/DaoTestBase.java
@@ -26,7 +26,7 @@ public class DaoTestBase {
 
     private static Logger logger = LoggerFactory.getLogger(DaoTestBase.class);
 
-    public static PostgresDockerExtension postgres = new PostgresDockerExtension();
+    public static PostgresDockerExtension postgres = new PostgresDockerExtension("11.16");
 
     protected static DatabaseTestHelper databaseHelper;
     protected static GuicedTestEnvironment env;
@@ -46,7 +46,7 @@ public class DaoTestBase {
         try (Connection connection = DriverManager.getConnection(postgres.getConnectionUrl(), postgres.getUsername(), postgres.getPassword())) {
 
             Liquibase migrator = new Liquibase("config/initial-db-state.xml", new ClassLoaderResourceAccessor(), new JdbcConnection(connection));
-            Liquibase migrator2 = new Liquibase("migrations.xml", new ClassLoaderResourceAccessor(), new JdbcConnection(connection));
+            Liquibase migrator2 = new Liquibase("it-migrations.xml", new ClassLoaderResourceAccessor(), new JdbcConnection(connection));
             migrator.update("");
             migrator2.update("");
         }
@@ -61,7 +61,7 @@ public class DaoTestBase {
                 postgres.getUsername(),
                 postgres.getPassword())) {
             Liquibase migrator = new Liquibase("config/initial-db-state.xml", new ClassLoaderResourceAccessor(), new JdbcConnection(connection));
-            Liquibase migrator2 = new Liquibase("migrations.xml", new ClassLoaderResourceAccessor(), new JdbcConnection(connection));
+            Liquibase migrator2 = new Liquibase("it-migrations.xml", new ClassLoaderResourceAccessor(), new JdbcConnection(connection));
             migrator2.dropAll();
             migrator.dropAll();
         } catch (Exception e) {

--- a/src/test/resources/it-migrations.xml
+++ b/src/test/resources/it-migrations.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="install necessary extensions for integration tests" author="">
+        <sql>
+            CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+            CREATE EXTENSION IF NOT EXISTS "pg_trgm" WITH SCHEMA "pg_catalog";
+        </sql>
+    </changeSet>
+
+    <include file="migrations.xml" relativeToChangelogFile="false"/>
+
+</databaseChangeLog>


### PR DESCRIPTION
## WHAT YOU DID

- removed use of `govuk/postgres:11`, baselining on architecture agnostic `postgres:11.16`
- updated test bases and rules to enable cross architecture support
- added integration tests specific liquibase changelog (`it-migrations.xml`) to initialise the database before migrations can be run
- updated local sqs image to be consistent with other Pay applications
- updated GHA to use new images