### PR TITLE
PP-10260 Return POJO from resource methods

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -357,7 +357,7 @@
         "filename": "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGenerateOtpIT.java",
         "hashed_secret": "833b5c8e76b19b617849d9a67a5980f08c784882",
         "is_verified": false,
-        "line_number": 25
+        "line_number": 26
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpIT.java": [
@@ -472,5 +472,5 @@
       }
     ]
   },
-  "generated_at": "2022-10-28T15:31:54Z"
+  "generated_at": "2022-10-28T16:50:43Z"
 }

--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -100,8 +100,8 @@ paths:
             schema:
               $ref: '#/components/schemas/InviteOtpRequest'
       responses:
-        "200":
-          description: OK
+        "204":
+          description: No content
         "400":
           description: Invalid payload
       summary: Resend OTP
@@ -144,7 +144,7 @@ paths:
             schema:
               $ref: '#/components/schemas/InviteUserRequest'
       responses:
-        "200":
+        "201":
           content:
             application/json:
               schema:

--- a/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
@@ -64,7 +64,7 @@ public class AdminUsersExceptions {
     public static WebApplicationException notFoundException() {
         return new WebApplicationException(Response.status(NOT_FOUND.getStatusCode()).build());
     }
-
+    
     public static WebApplicationException notFoundInviteException(String inviteCode) {
         String error = format("Invite for code %s provided does not exist", inviteCode);
         return buildWebApplicationException(error, NOT_FOUND.getStatusCode());

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteOtpDispatcher.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteOtpDispatcher.java
@@ -8,7 +8,7 @@ public abstract class InviteOtpDispatcher {
 
     /* default */ InviteOtpRequest inviteOtpRequest = null;
 
-    public abstract boolean dispatchOtp(String inviteCode);
+    public abstract void dispatchOtp(String inviteCode);
 
     public InviteOtpDispatcher withData(InviteOtpRequest data){
         this.inviteOtpRequest = data;

--- a/src/main/java/uk/gov/pay/adminusers/service/UserOtpDispatcher.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/UserOtpDispatcher.java
@@ -5,9 +5,11 @@ import com.google.inject.persist.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
+import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
 import uk.gov.pay.adminusers.utils.telephonenumber.TelephoneNumberUtility;
 
 import java.util.Locale;
+import java.util.Optional;
 
 import static java.lang.String.format;
 import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE;
@@ -33,28 +35,22 @@ public class UserOtpDispatcher extends InviteOtpDispatcher {
 
     @Transactional
     @Override
-    public boolean dispatchOtp(String inviteCode) {
-        return inviteDao.findByCode(inviteCode)
-                .map(inviteEntity -> {
-                    inviteEntity.setTelephoneNumber(TelephoneNumberUtility.formatToE164(inviteOtpRequest.getTelephoneNumber()));
-                    inviteEntity.setPassword(passwordHasher.hash(inviteOtpRequest.getPassword()));
-                    inviteDao.merge(inviteEntity);
-                    int newPassCode = secondFactorAuthenticator.newPassCode(inviteEntity.getOtpKey());
-                    String passcode = format(Locale.ENGLISH, SIX_DIGITS_WITH_LEADING_ZEROS, newPassCode);
-                    LOGGER.info("New 2FA token generated for invite code [{}]", inviteCode);
-                    
-                    try {
-                        String notificationId = notificationService.sendSecondFactorPasscodeSms(inviteOtpRequest.getTelephoneNumber(), passcode,
-                                CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE);
-                        LOGGER.info("sent 2FA token successfully for invite code [{}], notification id [{}]", inviteCode, notificationId);
-                    } catch (Exception e) {
-                        LOGGER.info(format("error sending 2FA token for invite code [%s]", inviteCode), e);
-                    }
-                    
-                    return true;
-                }).orElseGet(() -> {
-                    LOGGER.info("New 2FA token generated for invite code [{}]", inviteCode);
-                    return false;
-                });
+    public void dispatchOtp(String inviteCode) {
+        InviteEntity inviteEntity = inviteDao.findByCode(inviteCode).orElseThrow(AdminUsersExceptions::notFoundException);
+
+        inviteEntity.setTelephoneNumber(TelephoneNumberUtility.formatToE164(inviteOtpRequest.getTelephoneNumber()));
+        inviteEntity.setPassword(passwordHasher.hash(inviteOtpRequest.getPassword()));
+        inviteDao.merge(inviteEntity);
+        int newPassCode = secondFactorAuthenticator.newPassCode(inviteEntity.getOtpKey());
+        String passcode = format(Locale.ENGLISH, SIX_DIGITS_WITH_LEADING_ZEROS, newPassCode);
+        LOGGER.info("New 2FA token generated for invite code [{}]", inviteCode);
+
+        try {
+            String notificationId = notificationService.sendSecondFactorPasscodeSms(inviteOtpRequest.getTelephoneNumber(), passcode,
+                    CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE);
+            LOGGER.info("sent 2FA token successfully for invite code [{}], notification id [{}]", inviteCode, notificationId);
+        } catch (Exception e) {
+            LOGGER.info(format("error sending 2FA token for invite code [%s]", inviteCode), e);
+        }
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateUserIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateUserIT.java
@@ -32,13 +32,13 @@ import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
 import static uk.gov.pay.adminusers.persistence.entity.Role.ADMIN;
 
-public class InviteResourceCreateUserIT extends IntegrationTest {
+class InviteResourceCreateUserIT extends IntegrationTest {
     private Service service;
     private String roleAdminName;
     private String senderExternalId;
 
     @BeforeEach
-    public void givenAnExistingServiceAndARole() {
+    void givenAnExistingServiceAndARole() {
 
         service = serviceDbFixture(databaseHelper)
                 .insertService();
@@ -57,7 +57,7 @@ public class InviteResourceCreateUserIT extends IntegrationTest {
     }
 
     @Test
-    public void createInvitation_shouldSucceed_whenInvitingANewUser() throws Exception {
+    void createInvitation_shouldSucceed_whenInvitingANewUser() throws Exception {
 
         String email = randomAlphanumeric(5) + "-invite@example.com";
 
@@ -83,7 +83,7 @@ public class InviteResourceCreateUserIT extends IntegrationTest {
     }
 
     @Test
-    public void createInvitation_shouldFail_whenAnInviteWithTheGivenEmailAlreadyExists() throws Exception {
+    void createInvitation_shouldFail_whenAnInviteWithTheGivenEmailAlreadyExists() throws Exception {
 
         String existingUserEmail = randomAlphanumeric(5) + "-invite@example.com";
 
@@ -112,7 +112,7 @@ public class InviteResourceCreateUserIT extends IntegrationTest {
     }
 
     @Test
-    public void createInvitation_shouldFail_ifUserAlreadyBelongToService() throws Exception {
+    void createInvitation_shouldFail_ifUserAlreadyBelongToService() throws Exception {
 
         String existingUserUsername = randomUuid();
         String existingUserEmail = existingUserUsername + "-invite@example.com";
@@ -150,7 +150,7 @@ public class InviteResourceCreateUserIT extends IntegrationTest {
     }
 
     @Test
-    public void createInvitation_shouldFail_whenServiceDoesNotExist() throws Exception {
+    void createInvitation_shouldFail_whenServiceDoesNotExist() throws Exception {
 
         String nonExistentServiceId = "non existant service external id";
         Map<Object, Object> invitationRequest = Map.of(
@@ -166,12 +166,11 @@ public class InviteResourceCreateUserIT extends IntegrationTest {
                 .accept(ContentType.JSON)
                 .post(INVITE_USER_RESOURCE_URL)
                 .then()
-                .statusCode(NOT_FOUND.getStatusCode())
-                .body(emptyString());
+                .statusCode(NOT_FOUND.getStatusCode());
     }
 
     @Test
-    public void createInvitation_shouldFail_whenRoleDoesNotExist() throws Exception {
+    void createInvitation_shouldFail_whenRoleDoesNotExist() throws Exception {
 
         Map<Object, Object> invitationRequest = Map.of(
                 "sender", senderExternalId,
@@ -192,7 +191,7 @@ public class InviteResourceCreateUserIT extends IntegrationTest {
     }
 
     @Test
-    public void createInvitation_shouldFail_whenSenderDoesNotExist() throws Exception {
+    void createInvitation_shouldFail_whenSenderDoesNotExist() throws Exception {
 
         String email = randomAlphanumeric(5) + "-invite@example.com";
 
@@ -212,7 +211,7 @@ public class InviteResourceCreateUserIT extends IntegrationTest {
     }
 
     @Test
-    public void createInvitation_shouldFail_whenSenderDoesNotHaveAdminRole() throws Exception {
+    void createInvitation_shouldFail_whenSenderDoesNotHaveAdminRole() throws Exception {
 
         int otherRoleId = roleDbFixture(databaseHelper).insertRole().getId();
         String senderUsername = randomUuid();
@@ -240,7 +239,7 @@ public class InviteResourceCreateUserIT extends IntegrationTest {
     }
 
     @Test
-    public void createInvitation_shouldFail_whenSenderDoesNotBelongToTheGivenService() throws Exception {
+    void createInvitation_shouldFail_whenSenderDoesNotBelongToTheGivenService() throws Exception {
 
         Service otherService = serviceDbFixture(databaseHelper)
                 .insertService();

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGenerateOtpIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGenerateOtpIT.java
@@ -10,6 +10,7 @@ import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang3.RandomStringUtils.random;
 import static org.hamcrest.CoreMatchers.is;
@@ -38,7 +39,7 @@ class InviteResourceGenerateOtpIT extends IntegrationTest {
                 .contentType(ContentType.JSON)
                 .post(format(INVITES_GENERATE_OTP_RESOURCE_URL, code))
                 .then()
-                .statusCode(OK.getStatusCode());
+                .statusCode(NO_CONTENT.getStatusCode());
 
         Map<String, Object> invite = databaseHelper.findInviteByCode(code).get();
         assertThat(invite.get("telephone_number"), is(TELEPHONE_NUMBER));
@@ -81,7 +82,7 @@ class InviteResourceGenerateOtpIT extends IntegrationTest {
                 .contentType(ContentType.JSON)
                 .post(format(INVITES_GENERATE_OTP_RESOURCE_URL, code))
                 .then()
-                .statusCode(OK.getStatusCode());
+                .statusCode(NO_CONTENT.getStatusCode());
     }
 
     @Test
@@ -95,7 +96,7 @@ class InviteResourceGenerateOtpIT extends IntegrationTest {
                 .contentType(ContentType.JSON)
                 .post(format(INVITES_GENERATE_OTP_RESOURCE_URL, code))
                 .then()
-                .statusCode(OK.getStatusCode());
+                .statusCode(NO_CONTENT.getStatusCode());
     }
 
     @Test
@@ -111,7 +112,7 @@ class InviteResourceGenerateOtpIT extends IntegrationTest {
                 .contentType(ContentType.JSON)
                 .post(format(INVITES_GENERATE_OTP_RESOURCE_URL, code))
                 .then()
-                .statusCode(OK.getStatusCode());
+                .statusCode(NO_CONTENT.getStatusCode());
 
         Map<String, Object> invite = databaseHelper.findInviteByCode(code).get();
         assertThat(invite.get("telephone_number"), is(TELEPHONE_NUMBER));

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpIT.java
@@ -190,7 +190,7 @@ class InviteResourceOtpIT extends IntegrationTest {
                 .contentType(JSON)
                 .post(INVITES_RESEND_OTP_RESOURCE_URL)
                 .then()
-                .statusCode(OK.getStatusCode());
+                .statusCode(NO_CONTENT.getStatusCode());
 
         // check if we are using the newTelephoneNumber in the invitation
         Map<String, Object> foundInvite = databaseHelper.findInviteByCode(code).get();

--- a/src/test/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcherTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ServiceOtpDispatcherTest.java
@@ -12,17 +12,20 @@ import uk.gov.pay.adminusers.model.InviteType;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
 
+import javax.ws.rs.WebApplicationException;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.SELF_INITIATED_CREATE_NEW_USER_AND_SERVICE;
 
 @ExtendWith(MockitoExtension.class)
-public class ServiceOtpDispatcherTest {
+class ServiceOtpDispatcherTest {
 
     @Mock
     private InviteDao inviteDao;
@@ -35,18 +38,18 @@ public class ServiceOtpDispatcherTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    private ArgumentCaptor<InviteEntity> expectedInvite = ArgumentCaptor.forClass(InviteEntity.class);
+    private final ArgumentCaptor<InviteEntity> expectedInvite = ArgumentCaptor.forClass(InviteEntity.class);
 
     private InviteOtpDispatcher serviceOtpDispatcher;
 
     @BeforeEach
-    public void before() {
+    void before() {
         serviceOtpDispatcher = new ServiceOtpDispatcher(inviteDao, secondFactorAuthenticator, passwordHasher, notificationService);
         serviceOtpDispatcher.withData(InviteOtpRequest.from(objectMapper.valueToTree(Map.of())));
     }
 
     @Test
-    public void shouldSuccess_whenDispatchServiceOtp_ifInviteEntityExist() {
+    void shouldSuccess_whenDispatchServiceOtp_ifInviteEntityExist() {
         String inviteCode = "valid-invite-code";
         String telephone = "+441134960000";
         InviteEntity inviteEntity = new InviteEntity();
@@ -59,13 +62,11 @@ public class ServiceOtpDispatcherTest {
         when(secondFactorAuthenticator.newPassCode("otp-key")).thenReturn(123456);
         when(notificationService.sendSecondFactorPasscodeSms(telephone, "123456", SELF_INITIATED_CREATE_NEW_USER_AND_SERVICE))
                 .thenReturn("success code from notify");
-        boolean dispatched = serviceOtpDispatcher.dispatchOtp(inviteCode);
-
-        assertThat(dispatched,is(true));
+        assertDoesNotThrow(() -> serviceOtpDispatcher.dispatchOtp(inviteCode));
     }
 
     @Test
-    public void shouldSuccess_whenDispatchServiceOtp_ifInviteEntityExist_butPhoneAndPasswordOnlyInRequest_andUpdateInviteEntityWithPhoneAndPassword() {
+    void shouldSuccess_whenDispatchServiceOtp_ifInviteEntityExist_butPhoneAndPasswordOnlyInRequest_andUpdateInviteEntityWithPhoneAndPassword() {
         String inviteCode = "valid-invite-code";
         InviteEntity inviteEntity = new InviteEntity();
         inviteEntity.setCode(inviteCode);
@@ -81,18 +82,15 @@ public class ServiceOtpDispatcherTest {
         when(secondFactorAuthenticator.newPassCode("otp-key")).thenReturn(123456);
         when(notificationService.sendSecondFactorPasscodeSms(telephone, "123456", SELF_INITIATED_CREATE_NEW_USER_AND_SERVICE))
                 .thenReturn("success code from notify");
-        boolean dispatched = serviceOtpDispatcher.dispatchOtp(inviteCode);
-
-        assertThat(dispatched,is(true));
+        serviceOtpDispatcher.dispatchOtp(inviteCode);
 
         verify(inviteDao).merge(expectedInvite.capture());
-        assertThat(dispatched, is(true));
         assertThat(expectedInvite.getValue().getTelephoneNumber(), is(telephone));
-        assertThat(expectedInvite.getValue().getPassword(),is("hashed-password"));
+        assertThat(expectedInvite.getValue().getPassword(), is("hashed-password"));
     }
 
     @Test
-    public void shouldSuccess_whenDispatchServiceOtp_ifInviteEntityExistWithPassword_butPhoneOnlyInRequest_andUpdateInviteEntityWithPhone() {
+    void shouldSuccess_whenDispatchServiceOtp_ifInviteEntityExistWithPassword_butPhoneOnlyInRequest_andUpdateInviteEntityWithPhone() {
         String inviteCode = "valid-invite-code";
         InviteEntity inviteEntity = new InviteEntity();
         inviteEntity.setCode(inviteCode);
@@ -107,24 +105,19 @@ public class ServiceOtpDispatcherTest {
         when(secondFactorAuthenticator.newPassCode("otp-key")).thenReturn(123456);
         when(notificationService.sendSecondFactorPasscodeSms(telephone, "123456", SELF_INITIATED_CREATE_NEW_USER_AND_SERVICE))
                 .thenReturn("success code from notify");
-        boolean dispatched = serviceOtpDispatcher.dispatchOtp(inviteCode);
-
-        assertThat(dispatched,is(true));
+        serviceOtpDispatcher.dispatchOtp(inviteCode);
 
         verify(inviteDao).merge(expectedInvite.capture());
-        assertThat(dispatched, is(true));
         assertThat(expectedInvite.getValue().getTelephoneNumber(), is(telephone));
-        assertThat(expectedInvite.getValue().getPassword(),is("hashed-password"));
+        assertThat(expectedInvite.getValue().getPassword(), is("hashed-password"));
     }
 
     @Test
-    public void shouldFail_whenDispatchServiceOtp_ifInviteEntityNotFound() {
+    void shouldFail_whenDispatchServiceOtp_ifInviteEntityNotFound() {
 
         String inviteCode = "non-existent-code";
         when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.empty());
 
-        boolean dispatched = serviceOtpDispatcher.dispatchOtp(inviteCode);
-
-        assertThat(dispatched,is(false));
+        assertThrows(WebApplicationException.class, () -> serviceOtpDispatcher.dispatchOtp(inviteCode));
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/service/UserOtpDispatcherTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserOtpDispatcherTest.java
@@ -13,12 +13,14 @@ import uk.gov.pay.adminusers.model.InviteType;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
 
+import javax.ws.rs.WebApplicationException;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.adminusers.service.NotificationService.OtpNotifySmsTemplateId.CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE;
@@ -64,10 +66,10 @@ class UserOtpDispatcherTest {
         when(secondFactorAuthenticator.newPassCode("otp-key")).thenReturn(123456);
         when(notificationService.sendSecondFactorPasscodeSms(telephone, "123456", CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE))
                 .thenReturn("success code from notify");
-        boolean dispatched = userOtpDispatcher.dispatchOtp(inviteCode);
+        
+        userOtpDispatcher.dispatchOtp(inviteCode);
 
         verify(inviteDao).merge(expectedInvite.capture());
-        assertThat(dispatched, is(true));
         assertThat(expectedInvite.getValue().getTelephoneNumber(),is(telephone));
         assertThat(expectedInvite.getValue().getPassword(),is(notNullValue()));
     }
@@ -77,8 +79,6 @@ class UserOtpDispatcherTest {
         String inviteCode = "non-existent-code";
         when(inviteDao.findByCode(inviteCode)).thenReturn(Optional.empty());
 
-        boolean dispatched = userOtpDispatcher.dispatchOtp(inviteCode);
-
-        assertThat(dispatched,is(false));
+        assertThrows(WebApplicationException.class, () -> userOtpDispatcher.dispatchOtp(inviteCode));
     }
 }


### PR DESCRIPTION
Instead of constructing and returning a `Response` in resource methods, it is clearer to return a POJO which will be magically serialised by Dropwizard using Jackson. For error responses, throw a WebApplicationException which is serialised to an error response.

Change some response codes from 200 -> 204 when no response body is returned. Selfservice handles all success codes in the same way so no updates to the consumer are required.

Only continue returning a `Response` when we want to return a 201 response rather than 200 when a resource is created.