### PR TITLE
PP-10260 Refactor complete invite resource

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -180,7 +180,7 @@
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "3660e32cde5fccc8d1e4521d0c831c2012388720",
         "is_verified": false,
-        "line_number": 1139
+        "line_number": 1149
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/model/CreateUserRequest.java": [
@@ -472,5 +472,5 @@
       }
     ]
   },
-  "generated_at": "2022-10-28T15:31:54Z"
+  "generated_at": "2022-10-28T17:32:35Z"
 }

--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -200,7 +200,7 @@ paths:
         content:
           '*/*':
             schema:
-              $ref: '#/components/schemas/InviteCompleteRequest'
+              $ref: '#/components/schemas/CompleteInviteRequest'
       responses:
         "200":
           content:
@@ -1089,6 +1089,16 @@ paths:
       - Invites
 components:
   schemas:
+    CompleteInviteRequest:
+      type: object
+      properties:
+        gateway_account_ids:
+          type: array
+          items:
+            type: string
+            description: gateway_account_ids that needs to be associated for the new
+              service. Only applicable for invite type `service`
+            example: "1"
     CreateUserRequest:
       type: object
       properties:
@@ -1184,13 +1194,6 @@ components:
           example: service
         user_exist:
           type: boolean
-    InviteCompleteRequest:
-      type: object
-      properties:
-        gateway_account_ids:
-          type: array
-          items:
-            type: string
     InviteCompleteResponse:
       type: object
       properties:

--- a/src/main/java/uk/gov/pay/adminusers/model/CompleteInviteRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/CompleteInviteRequest.java
@@ -5,19 +5,21 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class InviteCompleteRequest {
+public class CompleteInviteRequest {
 
-    public static final String FIELD_GATEWAY_ACCOUNT_IDS = "gateway_account_ids";
-
-    @ArraySchema(schema = @Schema(implementation = String.class, example = "1,2",
+    @ArraySchema(schema = @Schema(example = "1",
             description = "gateway_account_ids that needs to be associated for the new service. Only applicable for invite type `service`"))
-    private List<String> gatewayAccountIds = new ArrayList<>();
-
-    public void setGatewayAccountIds(List<String> gatewayAccountIds) {
+    private List<String> gatewayAccountIds = Collections.emptyList();
+    
+    public CompleteInviteRequest() {
+        // for Jackson deserialisation
+    }
+    
+    public CompleteInviteRequest(List<String> gatewayAccountIds) {
         this.gatewayAccountIds = gatewayAccountIds;
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleter.java
@@ -2,6 +2,7 @@ package uk.gov.pay.adminusers.service;
 
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
+import uk.gov.pay.adminusers.model.CompleteInviteRequest;
 import uk.gov.pay.adminusers.model.InviteCompleteResponse;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
@@ -26,7 +27,7 @@ public class ExistingUserInviteCompleter extends InviteCompleter {
 
     @Override
     @Transactional
-    public InviteCompleteResponse complete(InviteEntity inviteEntity) {
+    public InviteCompleteResponse complete(InviteEntity inviteEntity, CompleteInviteRequest completeInviteRequest) {
         if (inviteEntity.isExpired() || Boolean.TRUE.equals(inviteEntity.isDisabled())) {
             throw inviteLockedException(inviteEntity.getCode());
         }

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteCompleter.java
@@ -1,17 +1,10 @@
 package uk.gov.pay.adminusers.service;
 
-import uk.gov.pay.adminusers.model.InviteCompleteRequest;
+import uk.gov.pay.adminusers.model.CompleteInviteRequest;
 import uk.gov.pay.adminusers.model.InviteCompleteResponse;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
 
 public abstract class InviteCompleter {
-
-    /* default */ InviteCompleteRequest data = null;
-
-    public abstract InviteCompleteResponse complete(InviteEntity inviteEntity);
-
-    public InviteCompleter withData(InviteCompleteRequest data) {
-        this.data = data;
-        return this;
-    }
+    
+    public abstract InviteCompleteResponse complete(InviteEntity inviteEntity, CompleteInviteRequest completeInviteRequest);
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/NewUserExistingServiceInviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NewUserExistingServiceInviteCompleter.java
@@ -5,6 +5,7 @@ import com.google.inject.persist.Transactional;
 import net.logstash.logback.marker.Markers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.adminusers.model.CompleteInviteRequest;
 import uk.gov.pay.adminusers.model.Invite;
 import uk.gov.pay.adminusers.model.InviteCompleteResponse;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
@@ -39,7 +40,7 @@ public class NewUserExistingServiceInviteCompleter extends InviteCompleter {
 
     @Override
     @Transactional
-    public InviteCompleteResponse complete(InviteEntity inviteEntity) {
+    public InviteCompleteResponse complete(InviteEntity inviteEntity, CompleteInviteRequest completeInviteRequest) {
         if (inviteEntity.isExpired() || Boolean.TRUE.equals(inviteEntity.isDisabled())) {
             throw inviteLockedException(inviteEntity.getCode());
         }

--- a/src/main/java/uk/gov/pay/adminusers/service/SelfSignupInviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/SelfSignupInviteCompleter.java
@@ -2,6 +2,7 @@ package uk.gov.pay.adminusers.service;
 
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
+import uk.gov.pay.adminusers.model.CompleteInviteRequest;
 import uk.gov.pay.adminusers.model.Invite;
 import uk.gov.pay.adminusers.model.InviteCompleteResponse;
 import uk.gov.pay.adminusers.model.Service;
@@ -41,7 +42,7 @@ public class SelfSignupInviteCompleter extends InviteCompleter {
      */
     @Override
     @Transactional
-    public InviteCompleteResponse complete(InviteEntity inviteEntity) {
+    public InviteCompleteResponse complete(InviteEntity inviteEntity, CompleteInviteRequest completeInviteRequest) {
         if (inviteEntity.isExpired() || inviteEntity.isDisabled()) {
             throw inviteLockedException(inviteEntity.getCode());
         }
@@ -52,8 +53,8 @@ public class SelfSignupInviteCompleter extends InviteCompleter {
         if (inviteEntity.isServiceType()) {
             UserEntity userEntity = inviteEntity.mapToUserEntity();
             ServiceEntity serviceEntity = ServiceEntity.from(Service.from());
-            if (!data.getGatewayAccountIds().isEmpty()) {
-                serviceEntity.addGatewayAccountIds(data.getGatewayAccountIds().toArray(new String[0]));
+            if (completeInviteRequest != null && !completeInviteRequest.getGatewayAccountIds().isEmpty()) {
+                serviceEntity.addGatewayAccountIds(completeInviteRequest.getGatewayAccountIds().toArray(new String[0]));
             }
             serviceDao.persist(serviceEntity);
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceServiceCompleteIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceServiceCompleteIT.java
@@ -22,11 +22,11 @@ import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.InviteDbFixture.inviteDbFixture;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
 
-public class InviteResourceServiceCompleteIT extends IntegrationTest {
+class InviteResourceServiceCompleteIT extends IntegrationTest {
     public static final String INVITES_RESOURCE_URL = "/v1/api/invites";
 
     @Test
-    public void shouldReturn200withDisabledInviteLinkingToCreatedUser_WhenPassedAValidInviteCode_withoutGatewayAccountIds() {
+    void shouldReturn200withDisabledInviteLinkingToCreatedUser_WhenPassedAValidInviteCode_withoutGatewayAccountIds() {
         String email = format("%s@example.gov.uk", randomUuid());
         String telephoneNumber = "+447700900000";
         String password = "valid_password";
@@ -63,7 +63,7 @@ public class InviteResourceServiceCompleteIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldReturn200withDisabledInviteLinkingToCreatedUser_WhenPassedAValidInviteCode_withGatewayAccountIds() throws Exception {
+    void shouldReturn200withDisabledInviteLinkingToCreatedUser_WhenPassedAValidInviteCode_withGatewayAccountIds() throws Exception {
         String email = format("%s@example.gov.uk", randomUuid());
         String telephoneNumber = "+447700900000";
         String password = "valid_password";
@@ -107,7 +107,7 @@ public class InviteResourceServiceCompleteIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldReturn410_WhenSameInviteCodeCompletedTwice() {
+    void shouldReturn410_WhenSameInviteCodeCompletedTwice() {
         String email = format("%s@example.gov.uk", randomUuid());
         String telephoneNumber = "+447700900000";
         String password = "valid_password";
@@ -132,7 +132,7 @@ public class InviteResourceServiceCompleteIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldReturn409_ifAUserExistsWithTheSameEmail_whenServiceInviteCompletes() {
+    void shouldReturn409_ifAUserExistsWithTheSameEmail_whenServiceInviteCompletes() {
         String email = format("%s@example.gov.uk", randomUuid());
         String username = email;
         String telephoneNumber = "+447700900000";
@@ -157,7 +157,7 @@ public class InviteResourceServiceCompleteIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldReturn410_WheninviteIsDisabled() {
+    void shouldReturn410_WheninviteIsDisabled() {
         String email = format("%s@example.gov.uk", randomUuid());
         String telephoneNumber = "+447700900000";
         String password = "valid_password";

--- a/src/test/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleterTest.java
@@ -75,7 +75,7 @@ public class ExistingUserInviteCompleterTest {
 
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(user));
 
-        InviteCompleteResponse completedInvite = existingUserInviteCompleter.complete(anInvite);
+        InviteCompleteResponse completedInvite = existingUserInviteCompleter.complete(anInvite, null);
 
         ArgumentCaptor<UserEntity> persistedUser = ArgumentCaptor.forClass(UserEntity.class);
         verify(mockUserDao).merge(persistedUser.capture());
@@ -99,7 +99,7 @@ public class ExistingUserInviteCompleterTest {
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(user));
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(anInvite));
+                () -> existingUserInviteCompleter.complete(anInvite, null));
         assertThat(webApplicationException.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 
@@ -118,7 +118,7 @@ public class ExistingUserInviteCompleterTest {
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(user));
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(anInvite));
+                () -> existingUserInviteCompleter.complete(anInvite, null));
         assertThat(webApplicationException.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 
@@ -130,7 +130,7 @@ public class ExistingUserInviteCompleterTest {
         anInvite.setDisabled(true);
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(anInvite));
+                () -> existingUserInviteCompleter.complete(anInvite, null));
         assertThat(webApplicationException.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -141,7 +141,7 @@ public class ExistingUserInviteCompleterTest {
         anInvite.setExpiryDate(ZonedDateTime.now().minusDays(1));
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(anInvite));
+                () -> existingUserInviteCompleter.complete(anInvite, null));
         assertThat(webApplicationException.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -153,7 +153,7 @@ public class ExistingUserInviteCompleterTest {
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(anInvite));
+                () -> existingUserInviteCompleter.complete(anInvite, null));
         assertThat(webApplicationException.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/service/NewUserExistingServiceInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/NewUserExistingServiceInviteCompleterTest.java
@@ -1,13 +1,12 @@
 package uk.gov.pay.adminusers.service;
 
-import org.apache.commons.lang3.NotImplementedException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.pay.adminusers.model.InviteCompleteRequest;
+import uk.gov.pay.adminusers.model.CompleteInviteRequest;
 import uk.gov.pay.adminusers.model.InviteCompleteResponse;
 import uk.gov.pay.adminusers.model.InviteType;
 import uk.gov.pay.adminusers.model.Link;
@@ -71,7 +70,7 @@ public class NewUserExistingServiceInviteCompleterTest {
         anInvite.setType(InviteType.USER);
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
 
-        InviteCompleteResponse inviteResponse = newUserExistingServiceInviteCompleter.withData(new InviteCompleteRequest()).complete(anInvite);
+        InviteCompleteResponse inviteResponse = newUserExistingServiceInviteCompleter.complete(anInvite, null);
 
         verify(mockUserDao).persist(expectedInvitedUser.capture());
         verify(mockInviteDao).merge(expectedInvite.capture());
@@ -100,7 +99,7 @@ public class NewUserExistingServiceInviteCompleterTest {
         when(mockUserDao.findByEmail(anInvite.getEmail())).thenReturn(Optional.of(mock(UserEntity.class)));
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> newUserExistingServiceInviteCompleter.complete(anInvite));
+                () -> newUserExistingServiceInviteCompleter.complete(anInvite, null));
         assertThat(exception.getMessage(), is("HTTP 409 Conflict"));
     }
 
@@ -114,7 +113,7 @@ public class NewUserExistingServiceInviteCompleterTest {
         anInvite.setDisabled(true);
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> newUserExistingServiceInviteCompleter.complete(anInvite));
+                () -> newUserExistingServiceInviteCompleter.complete(anInvite, null));
         assertThat(exception.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -128,7 +127,7 @@ public class NewUserExistingServiceInviteCompleterTest {
         anInvite.setExpiryDate(ZonedDateTime.now().minusDays(1));
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> newUserExistingServiceInviteCompleter.complete(anInvite));
+                () -> newUserExistingServiceInviteCompleter.complete(anInvite, null));
         assertThat(exception.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -143,7 +142,7 @@ public class NewUserExistingServiceInviteCompleterTest {
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> newUserExistingServiceInviteCompleter.complete(anInvite));
+                () -> newUserExistingServiceInviteCompleter.complete(anInvite, null));
         assertThat(exception.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 


### PR DESCRIPTION
Accept a POJO in the method signature for deserialising the request body.

Refactor InviteCompleter to remove the `withData` method and instead pass in the CompleteInviteRequest as an argument of `InviteCompleter#complete` to make it easier to understand. The `CompleteInviteRequest` will be null if the request was made with no body.