### PR TITLE
PP-10260 Remove request body for complete endpoint

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -131,49 +131,49 @@
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "0ea7458942ab65e0a340cf4fd28ca00d93c494f3",
         "is_verified": false,
-        "line_number": 228
+        "line_number": 223
       },
       {
         "type": "Secret Keyword",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "675fecb5af336276574d3d88a4d382d961cf7418",
         "is_verified": false,
-        "line_number": 252
+        "line_number": 247
       },
       {
         "type": "Secret Keyword",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "fefda504251b73d30a7cf3d047d241388a3c11b3",
         "is_verified": false,
-        "line_number": 253
+        "line_number": 248
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_verified": false,
-        "line_number": 365
+        "line_number": 360
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "1976a945a8d2733655e4b2453bd49fb59cb7ba19",
         "is_verified": false,
-        "line_number": 625
+        "line_number": 620
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "a31519136d26754afeb0df49b5f066f387091f88",
         "is_verified": false,
-        "line_number": 659
+        "line_number": 654
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "3660e32cde5fccc8d1e4521d0c831c2012388720",
         "is_verified": false,
-        "line_number": 1143
+        "line_number": 1128
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/model/CreateUserRequest.java": [
@@ -359,7 +359,7 @@
         "filename": "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceServiceCompleteIT.java",
         "hashed_secret": "969c35357bb1a825bf84783da60799e29511e357",
         "is_verified": false,
-        "line_number": 32
+        "line_number": 26
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceUserCompleteIT.java": [
@@ -456,5 +456,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-02T15:47:14Z"
+  "generated_at": "2022-11-03T11:28:21Z"
 }

--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -190,11 +190,6 @@ paths:
         required: true
         schema:
           type: string
-      requestBody:
-        content:
-          '*/*':
-            schema:
-              $ref: '#/components/schemas/CompleteInviteRequest'
       responses:
         "200":
           content:
@@ -1083,16 +1078,6 @@ paths:
       - Invites
 components:
   schemas:
-    CompleteInviteRequest:
-      type: object
-      properties:
-        gateway_account_ids:
-          type: array
-          items:
-            type: string
-            description: gateway_account_ids that needs to be associated for the new
-              service. Only applicable for invite type `service`
-            example: "1"
     CreateUserRequest:
       type: object
       properties:

--- a/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.adminusers.model.CompleteInviteRequest;
 import uk.gov.pay.adminusers.model.Invite;
 import uk.gov.pay.adminusers.model.InviteCompleteResponse;
 import uk.gov.pay.adminusers.model.InviteOtpRequest;
@@ -103,9 +102,7 @@ public class InviteResource {
                     @ApiResponse(responseCode = "404", description = "Not found")
             }
     )
-    public InviteCompleteResponse completeInvite(@Parameter(example = "d02jddeib0lqpsir28fbskg9v0rv") @PathParam("code") String inviteCode,
-                                                 @Parameter(schema = @Schema(implementation = CompleteInviteRequest.class))
-                                                 CompleteInviteRequest completeInviteRequest) {
+    public InviteCompleteResponse completeInvite(@Parameter(example = "d02jddeib0lqpsir28fbskg9v0rv") @PathParam("code") String inviteCode) {
         LOGGER.info("Invite  complete POST request for code - [ {} ]", inviteCode);
 
         if (isNotBlank(inviteCode) && inviteCode.length() > MAX_LENGTH_CODE) {
@@ -114,7 +111,7 @@ public class InviteResource {
 
         return inviteService.findInvite(inviteCode).map(inviteEntity -> {
             InviteCompleter inviteCompleter = inviteServiceFactory.inviteCompleteRouter().routeComplete(inviteEntity);
-            return inviteCompleter.complete(inviteEntity, completeInviteRequest);
+            return inviteCompleter.complete(inviteEntity);
         }).orElseThrow(() -> new WebApplicationException(Response.Status.NOT_FOUND));
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleter.java
@@ -2,7 +2,6 @@ package uk.gov.pay.adminusers.service;
 
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
-import uk.gov.pay.adminusers.model.CompleteInviteRequest;
 import uk.gov.pay.adminusers.model.InviteCompleteResponse;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
@@ -27,7 +26,7 @@ public class ExistingUserInviteCompleter extends InviteCompleter {
 
     @Override
     @Transactional
-    public InviteCompleteResponse complete(InviteEntity inviteEntity, CompleteInviteRequest completeInviteRequest) {
+    public InviteCompleteResponse complete(InviteEntity inviteEntity) {
         if (inviteEntity.isExpired() || Boolean.TRUE.equals(inviteEntity.isDisabled())) {
             throw inviteLockedException(inviteEntity.getCode());
         }

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteCompleter.java
@@ -1,10 +1,9 @@
 package uk.gov.pay.adminusers.service;
 
-import uk.gov.pay.adminusers.model.CompleteInviteRequest;
 import uk.gov.pay.adminusers.model.InviteCompleteResponse;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
 
 public abstract class InviteCompleter {
     
-    public abstract InviteCompleteResponse complete(InviteEntity inviteEntity, CompleteInviteRequest completeInviteRequest);
+    public abstract InviteCompleteResponse complete(InviteEntity inviteEntity);
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/NewUserExistingServiceInviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NewUserExistingServiceInviteCompleter.java
@@ -5,7 +5,6 @@ import com.google.inject.persist.Transactional;
 import net.logstash.logback.marker.Markers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.adminusers.model.CompleteInviteRequest;
 import uk.gov.pay.adminusers.model.Invite;
 import uk.gov.pay.adminusers.model.InviteCompleteResponse;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
@@ -40,7 +39,7 @@ public class NewUserExistingServiceInviteCompleter extends InviteCompleter {
 
     @Override
     @Transactional
-    public InviteCompleteResponse complete(InviteEntity inviteEntity, CompleteInviteRequest completeInviteRequest) {
+    public InviteCompleteResponse complete(InviteEntity inviteEntity) {
         if (inviteEntity.isExpired() || Boolean.TRUE.equals(inviteEntity.isDisabled())) {
             throw inviteLockedException(inviteEntity.getCode());
         }

--- a/src/main/java/uk/gov/pay/adminusers/service/SelfSignupInviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/SelfSignupInviteCompleter.java
@@ -2,7 +2,6 @@ package uk.gov.pay.adminusers.service;
 
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
-import uk.gov.pay.adminusers.model.CompleteInviteRequest;
 import uk.gov.pay.adminusers.model.Invite;
 import uk.gov.pay.adminusers.model.InviteCompleteResponse;
 import uk.gov.pay.adminusers.model.Service;
@@ -42,7 +41,7 @@ public class SelfSignupInviteCompleter extends InviteCompleter {
      */
     @Override
     @Transactional
-    public InviteCompleteResponse complete(InviteEntity inviteEntity, CompleteInviteRequest completeInviteRequest) {
+    public InviteCompleteResponse complete(InviteEntity inviteEntity) {
         if (inviteEntity.isExpired() || inviteEntity.isDisabled()) {
             throw inviteLockedException(inviteEntity.getCode());
         }
@@ -53,9 +52,6 @@ public class SelfSignupInviteCompleter extends InviteCompleter {
         if (inviteEntity.isServiceType()) {
             UserEntity userEntity = inviteEntity.mapToUserEntity();
             ServiceEntity serviceEntity = ServiceEntity.from(Service.from());
-            if (completeInviteRequest != null && !completeInviteRequest.getGatewayAccountIds().isEmpty()) {
-                serviceEntity.addGatewayAccountIds(completeInviteRequest.getGatewayAccountIds().toArray(new String[0]));
-            }
             serviceDao.persist(serviceEntity);
 
             ServiceRoleEntity serviceRoleEntity = new ServiceRoleEntity(serviceEntity, inviteEntity.getRole());

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceUserCompleteIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceUserCompleteIT.java
@@ -16,11 +16,11 @@ import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.InviteDbFixture.inviteDbFixture;
 import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
 
-public class InviteResourceUserCompleteIT extends IntegrationTest {
+class InviteResourceUserCompleteIT extends IntegrationTest {
     public static final String INVITES_RESOURCE_URL = "/v1/api/invites";
 
     @Test
-    public void shouldReturn200WithDisabledInvite_whenExistingUserSubscribingToAnExistingService() {
+    void shouldReturn200WithDisabledInvite_whenExistingUserSubscribingToAnExistingService() {
         String email = format("%s@example.gov.uk", randomUuid());
         String telephoneNumber = "+447700900000";
         String password = "valid_password";
@@ -69,7 +69,7 @@ public class InviteResourceUserCompleteIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldReturn404_whenInviteCodeNotFound() {
+    void shouldReturn404_whenInviteCodeNotFound() {
         givenSetup()
                 .when()
                 .post(INVITES_RESOURCE_URL + "/" + "non-existent-code" + "/complete")
@@ -79,7 +79,7 @@ public class InviteResourceUserCompleteIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldReturn410_withDisabledInvite() {
+    void shouldReturn410_withDisabledInvite() {
         String username = randomUuid();
         String email = format("%s@example.gov.uk", username);
         String telephoneNumber = "+447700900000";

--- a/src/test/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleterTest.java
@@ -75,7 +75,7 @@ public class ExistingUserInviteCompleterTest {
 
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(user));
 
-        InviteCompleteResponse completedInvite = existingUserInviteCompleter.complete(anInvite, null);
+        InviteCompleteResponse completedInvite = existingUserInviteCompleter.complete(anInvite);
 
         ArgumentCaptor<UserEntity> persistedUser = ArgumentCaptor.forClass(UserEntity.class);
         verify(mockUserDao).merge(persistedUser.capture());
@@ -99,7 +99,7 @@ public class ExistingUserInviteCompleterTest {
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(user));
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(anInvite, null));
+                () -> existingUserInviteCompleter.complete(anInvite));
         assertThat(webApplicationException.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 
@@ -118,7 +118,7 @@ public class ExistingUserInviteCompleterTest {
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(user));
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(anInvite, null));
+                () -> existingUserInviteCompleter.complete(anInvite));
         assertThat(webApplicationException.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 
@@ -130,7 +130,7 @@ public class ExistingUserInviteCompleterTest {
         anInvite.setDisabled(true);
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(anInvite, null));
+                () -> existingUserInviteCompleter.complete(anInvite));
         assertThat(webApplicationException.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -141,7 +141,7 @@ public class ExistingUserInviteCompleterTest {
         anInvite.setExpiryDate(ZonedDateTime.now().minusDays(1));
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(anInvite, null));
+                () -> existingUserInviteCompleter.complete(anInvite));
         assertThat(webApplicationException.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -153,7 +153,7 @@ public class ExistingUserInviteCompleterTest {
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(anInvite, null));
+                () -> existingUserInviteCompleter.complete(anInvite));
         assertThat(webApplicationException.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/service/NewUserExistingServiceInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/NewUserExistingServiceInviteCompleterTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.pay.adminusers.model.CompleteInviteRequest;
 import uk.gov.pay.adminusers.model.InviteCompleteResponse;
 import uk.gov.pay.adminusers.model.InviteType;
 import uk.gov.pay.adminusers.model.Link;
@@ -70,7 +69,7 @@ public class NewUserExistingServiceInviteCompleterTest {
         anInvite.setType(InviteType.USER);
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
 
-        InviteCompleteResponse inviteResponse = newUserExistingServiceInviteCompleter.complete(anInvite, null);
+        InviteCompleteResponse inviteResponse = newUserExistingServiceInviteCompleter.complete(anInvite);
 
         verify(mockUserDao).persist(expectedInvitedUser.capture());
         verify(mockInviteDao).merge(expectedInvite.capture());
@@ -99,7 +98,7 @@ public class NewUserExistingServiceInviteCompleterTest {
         when(mockUserDao.findByEmail(anInvite.getEmail())).thenReturn(Optional.of(mock(UserEntity.class)));
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> newUserExistingServiceInviteCompleter.complete(anInvite, null));
+                () -> newUserExistingServiceInviteCompleter.complete(anInvite));
         assertThat(exception.getMessage(), is("HTTP 409 Conflict"));
     }
 
@@ -113,7 +112,7 @@ public class NewUserExistingServiceInviteCompleterTest {
         anInvite.setDisabled(true);
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> newUserExistingServiceInviteCompleter.complete(anInvite, null));
+                () -> newUserExistingServiceInviteCompleter.complete(anInvite));
         assertThat(exception.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -127,7 +126,7 @@ public class NewUserExistingServiceInviteCompleterTest {
         anInvite.setExpiryDate(ZonedDateTime.now().minusDays(1));
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> newUserExistingServiceInviteCompleter.complete(anInvite, null));
+                () -> newUserExistingServiceInviteCompleter.complete(anInvite));
         assertThat(exception.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -142,7 +141,7 @@ public class NewUserExistingServiceInviteCompleterTest {
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> newUserExistingServiceInviteCompleter.complete(anInvite, null));
+                () -> newUserExistingServiceInviteCompleter.complete(anInvite));
         assertThat(exception.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 


### PR DESCRIPTION
The /complete endpoint accepts an optional request body containing a list of gateway account ids to attach to the service created for a self-signup.

However, the selfservice code has been modified so a request body is never provided. Instead, we now link the gateway account to the service in a separate PATCH request after the service has been created. So this request no longer needs to accept a request body.