### PR TITLE
PP-10116 update secrets baseline, pre-commit conf

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,6 +8,14 @@ permissions:
   contents: read
 
 jobs:
+  detect-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - name: Detect secrets
+        uses: alphagov/pay-ci/actions/detect-secrets@master
+
   integration-tests:
     name: Unit and Integration tests
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,6 @@
 repos:
-- repo: https://github.com/Yelp/detect-secrets
-  rev: 70e6cf69f2d544a49729039a374d86d7b3e472d9
-  hooks:
-    - id: detect-secrets
-      args: ['--baseline', '.secrets.baseline']
-      exclude: package.lock.json
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+        args: [ '--baseline', '.secrets.baseline' ]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.0",
+  "version": "1.4.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -19,6 +19,9 @@
     },
     {
       "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
     },
     {
       "name": "GitHubTokenDetector"
@@ -73,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -109,15 +108,6 @@
     }
   ],
   "results": {
-    ".pre-commit-config.yaml": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".pre-commit-config.yaml",
-        "hashed_secret": "7480301177f005722b05b9c2b80ec86d9d74b9fd",
-        "is_verified": false,
-        "line_number": 3
-      }
-    ],
     "openapi/adminusers_spec.yaml": [
       {
         "type": "Hex High Entropy String",
@@ -332,7 +322,16 @@
         "filename": "src/test/java/uk/gov/pay/adminusers/pact/ContractTest.java",
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_verified": false,
-        "line_number": 132
+        "line_number": 72
+      }
+    ],
+    "src/test/java/uk/gov/pay/adminusers/persistence/dao/GovUkPayAgreementDaoIT.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/adminusers/persistence/dao/GovUkPayAgreementDaoIT.java",
+        "hashed_secret": "c3a8fcf85a56dee95cff4ce7adf0bb9a4c18f747",
+        "is_verified": false,
+        "line_number": 77
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGenerateOtpIT.java": [
@@ -456,5 +455,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-03T12:31:55Z"
+  "generated_at": "2022-11-08T12:45:29Z"
 }


### PR DESCRIPTION
### WHAT

- added a new github action to run `detect-secrets`
- updated the pre-commit config to update the detect-secrets hook to version `1.4`
- rebaselined the repository's secrets baseline

#### For reviewers

- ensure your local version of `detect-secrets` matches the latest version in use on this branch
- run `detect-secrets scan` and ensure output matches the latest `.secrets.baseline`, the only change should be the generated timestamp