### PR TITLE
PP-10244 Make service and role Optional on InviteEntity

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
@@ -60,6 +60,16 @@ public class AdminUsersExceptions {
         String error = format("Service %s provided does not exist", serviceId);
         return buildWebApplicationException(error, BAD_REQUEST.getStatusCode());
     }
+    
+    public static WebApplicationException inviteDoesNotHaveRole(String inviteCode) {
+        String error = format("Invite with code %s to invite user to a service does not have a role set", inviteCode);
+        return buildWebApplicationException(error, INTERNAL_SERVER_ERROR.getStatusCode());
+    }
+    
+    public static WebApplicationException existingUserInviteDoesNotHaveService(String inviteCode) {
+        String error = format("Invite with code %s to invite an existing user to a service does not have a service set", inviteCode);
+        return buildWebApplicationException(error, INTERNAL_SERVER_ERROR.getStatusCode());
+    }
 
     public static WebApplicationException notFoundException() {
         return new WebApplicationException(Response.status(NOT_FOUND.getStatusCode()).build());

--- a/src/main/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleter.java
@@ -6,7 +6,11 @@ import uk.gov.pay.adminusers.model.InviteCompleteResponse;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
+import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
+import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
+
+import javax.ws.rs.WebApplicationException;
 
 import static java.lang.String.format;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.internalServerError;
@@ -30,23 +34,25 @@ public class ExistingUserInviteCompleter extends InviteCompleter {
         if (inviteEntity.isExpired() || Boolean.TRUE.equals(inviteEntity.isDisabled())) {
             throw inviteLockedException(inviteEntity.getCode());
         }
+        if (!inviteEntity.isUserType()) {
+            throw internalServerError(format("Attempting to complete a user invite for a non user invite. invite-code = %s", inviteEntity.getCode()));
+        }
+        
         return userDao.findByEmail(inviteEntity.getEmail())
                 .map(userEntity -> {
-                    if (inviteEntity.getService() != null && inviteEntity.isUserType()) {
-                        ServiceRoleEntity serviceRole = new ServiceRoleEntity(inviteEntity.getService(), inviteEntity.getRole());
-                        userEntity.addServiceRole(serviceRole);
-                        userDao.merge(userEntity);
+                    ServiceEntity serviceEntity = inviteEntity.getService().orElseThrow(() -> AdminUsersExceptions.existingUserInviteDoesNotHaveService(inviteEntity.getCode()));
+                    RoleEntity roleEntity = inviteEntity.getRole().orElseThrow(() -> AdminUsersExceptions.inviteDoesNotHaveRole(inviteEntity.getCode()));
+                    ServiceRoleEntity serviceRole = new ServiceRoleEntity(serviceEntity, roleEntity);
+                    userEntity.addServiceRole(serviceRole);
+                    userDao.merge(userEntity);
 
-                        inviteEntity.setDisabled(true);
-                        inviteDao.merge(inviteEntity);
+                    inviteEntity.setDisabled(true);
+                    inviteDao.merge(inviteEntity);
 
-                        InviteCompleteResponse response = new InviteCompleteResponse(inviteEntity.toInvite());
-                        response.setUserExternalId(userEntity.getExternalId());
-                        response.setServiceExternalId(inviteEntity.getService().getExternalId());
-                        return response;
-                    } else {
-                        throw internalServerError(format("Attempting to complete user subscription to a service for a non existent service. invite-code = %s", inviteEntity.getCode()));
-                    }
+                    InviteCompleteResponse response = new InviteCompleteResponse(inviteEntity.toInvite());
+                    response.setUserExternalId(userEntity.getExternalId());
+                    response.setServiceExternalId(serviceEntity.getExternalId());
+                    return response;
                 }).orElseThrow(() ->
                         internalServerError(format(
                                 "Attempting to complete user subscription to a service for a non existent user. invite-code = %s",

--- a/src/main/java/uk/gov/pay/adminusers/service/SelfSignupInviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/SelfSignupInviteCompleter.java
@@ -9,6 +9,7 @@ import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
+import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.UserEntity;
@@ -54,7 +55,8 @@ public class SelfSignupInviteCompleter extends InviteCompleter {
             ServiceEntity serviceEntity = ServiceEntity.from(Service.from());
             serviceDao.persist(serviceEntity);
 
-            ServiceRoleEntity serviceRoleEntity = new ServiceRoleEntity(serviceEntity, inviteEntity.getRole());
+            RoleEntity roleEntity = inviteEntity.getRole().orElseThrow(() -> AdminUsersExceptions.inviteDoesNotHaveRole(inviteEntity.getCode()));
+            ServiceRoleEntity serviceRoleEntity = new ServiceRoleEntity(serviceEntity, roleEntity);
             userEntity.addServiceRole(serviceRoleEntity);
             userDao.merge(userEntity);
 

--- a/src/test/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleterTest.java
@@ -24,6 +24,8 @@ import uk.gov.pay.adminusers.persistence.entity.UserEntity;
 import javax.ws.rs.WebApplicationException;
 import java.time.ZonedDateTime;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -100,7 +102,9 @@ public class ExistingUserInviteCompleterTest {
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
                 () -> existingUserInviteCompleter.complete(anInvite));
-        assertThat(webApplicationException.getMessage(), is("HTTP 500 Internal Server Error"));
+        assertThat(webApplicationException.getResponse().getStatus(), is(500));
+        Map<String, List<String>> entity = (Map<String, List<String>>) webApplicationException.getResponse().getEntity();
+        assertThat(entity.get("errors").get(0), is("Invite with code code to invite an existing user to a service does not have a service set"));
     }
 
     @Test
@@ -114,8 +118,6 @@ public class ExistingUserInviteCompleterTest {
         anInvite.setType(InviteType.SERVICE);
         anInvite.setService(service);
         UserEntity user = UserEntity.from(aUser(anInvite.getEmail()));
-
-        when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(user));
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
                 () -> existingUserInviteCompleter.complete(anInvite));

--- a/src/test/java/uk/gov/pay/adminusers/service/NewUserExistingServiceInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/NewUserExistingServiceInviteCompleterTest.java
@@ -82,8 +82,8 @@ public class NewUserExistingServiceInviteCompleterTest {
         assertThat(inviteResponse.getUserExternalId(), is(user.getExternalId()));
 
         assertThat(user.getServicesRoles().size(), is(1));
-        assertThat(user.getServicesRoles().get(0).getRole(), is(anInvite.getRole()));
-        assertThat(user.getServicesRoles().get(0).getService(), is(anInvite.getService()));
+        assertThat(user.getServicesRoles().get(0).getRole(), is(anInvite.getRole().get()));
+        assertThat(user.getServicesRoles().get(0).getService(), is(anInvite.getService().get()));
         assertThat(user.getServicesRoles().get(0).getUser(), is(user));
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/UserInviteCreatorTest.java
@@ -222,7 +222,7 @@ class UserInviteCreatorTest {
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(UserEntity.from(aUser(email))));
         InviteEntity anInvite = mockInviteSuccessExistingInvite();
         when(mockNotificationService.sendInviteExistingUserEmail(eq(senderEmail), eq(email), matches("^http://selfservice/invites/[0-9a-z]{32}$"),
-                eq(anInvite.getService().getServiceNames().get(SupportedLanguage.ENGLISH).getName()))).thenReturn("random-notify-id");
+                eq(anInvite.getService().get().getServiceNames().get(SupportedLanguage.ENGLISH).getName()))).thenReturn("random-notify-id");
 
         InviteUserRequest inviteUserRequest = new InviteUserRequest(senderExternalId, email, roleName, serviceExternalId);
         Optional<Invite> invite = userInviteCreator.doInvite(inviteUserRequest);
@@ -239,7 +239,7 @@ class UserInviteCreatorTest {
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(UserEntity.from(aUser(email))));
         InviteEntity anInvite = mockInviteSuccessExistingInvite();
         when(mockNotificationService.sendInviteExistingUserEmail(eq(senderEmail), eq(email), matches("^http://selfservice/invites/[0-9a-z]{32}$"),
-                eq(anInvite.getService().getServiceNames().get(SupportedLanguage.ENGLISH).getName())))
+                eq(anInvite.getService().get().getServiceNames().get(SupportedLanguage.ENGLISH).getName())))
                 .thenThrow(AdminUsersExceptions.userNotificationError(new Exception("Cause")));
 
         InviteUserRequest inviteUserRequest = new InviteUserRequest(senderExternalId, email, roleName, serviceExternalId);
@@ -256,12 +256,12 @@ class UserInviteCreatorTest {
         InviteEntity validInvite = mockInviteSuccessExistingInvite();
         InviteEntity expiredInvite = new InviteEntity();
         expiredInvite.setExpiryDate(ZonedDateTime.now().minusDays(2));
-        expiredInvite.setService(validInvite.getService());
+        expiredInvite.setService(validInvite.getService().get());
 
         InviteEntity disabledInvite = new InviteEntity();
         disabledInvite.setDisabled(true);
         disabledInvite.setExpiryDate(ZonedDateTime.now().plusDays(1));
-        disabledInvite.setService(validInvite.getService());
+        disabledInvite.setService(validInvite.getService().get());
 
         InviteEntity emptyServiceInvite = new InviteEntity();
         emptyServiceInvite.setExpiryDate(ZonedDateTime.now().plusDays(1));
@@ -275,7 +275,7 @@ class UserInviteCreatorTest {
 
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(UserEntity.from(aUser(email))));
         when(mockNotificationService.sendInviteExistingUserEmail(eq(senderEmail), eq(email), matches("^http://selfservice/invites/[0-9a-z]{32}$"),
-                eq(validInvite.getService().getServiceNames().get(SupportedLanguage.ENGLISH).getName()))).thenReturn("random-notify-id");
+                eq(validInvite.getService().get().getServiceNames().get(SupportedLanguage.ENGLISH).getName()))).thenReturn("random-notify-id");
 
         InviteUserRequest inviteUserRequest = new InviteUserRequest(senderExternalId, email, roleName, serviceExternalId);
         Optional<Invite> invite = userInviteCreator.doInvite(inviteUserRequest);


### PR DESCRIPTION
An InviteEntity doesn't have a service set on it if it is for a self-registration. Make the getter for the service return an Optional to ensure we do null checks correctly.

Currently an InviteEntity always has a role set. However, this will not need to be set in the future for self-registration. It was used to set the role when creating a new test service - which was always the admin role. But will not be used when a service is no longer created as part of a self-registration so shouldn't be set on the invite in this case.