### PR TITLE
PP-10038: Persist 2FA method when creating user

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -125,49 +125,49 @@
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "0ea7458942ab65e0a340cf4fd28ca00d93c494f3",
         "is_verified": false,
-        "line_number": 262
+        "line_number": 267
       },
       {
         "type": "Secret Keyword",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "675fecb5af336276574d3d88a4d382d961cf7418",
         "is_verified": false,
-        "line_number": 286
+        "line_number": 291
       },
       {
         "type": "Secret Keyword",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "fefda504251b73d30a7cf3d047d241388a3c11b3",
         "is_verified": false,
-        "line_number": 287
+        "line_number": 292
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_verified": false,
-        "line_number": 399
+        "line_number": 404
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "1976a945a8d2733655e4b2453bd49fb59cb7ba19",
         "is_verified": false,
-        "line_number": 659
+        "line_number": 664
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "a31519136d26754afeb0df49b5f066f387091f88",
         "is_verified": false,
-        "line_number": 693
+        "line_number": 698
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "3660e32cde5fccc8d1e4521d0c831c2012388720",
         "is_verified": false,
-        "line_number": 1169
+        "line_number": 1193
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/model/CreateUserRequest.java": [
@@ -371,7 +371,7 @@
         "filename": "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceServiceCompleteIT.java",
         "hashed_secret": "969c35357bb1a825bf84783da60799e29511e357",
         "is_verified": false,
-        "line_number": 26
+        "line_number": 28
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceUpdateIT.java": [
@@ -484,5 +484,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-11T16:54:27Z"
+  "generated_at": "2022-11-14T14:08:26Z"
 }

--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -229,12 +229,17 @@ paths:
         required: true
         schema:
           type: string
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/CompleteInviteRequest'
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InviteCompleteResponse'
+                $ref: '#/components/schemas/CompleteInviteResponse'
           description: OK
         "404":
           description: Not found
@@ -1119,6 +1124,25 @@ paths:
       - Invites
 components:
   schemas:
+    CompleteInviteRequest:
+      type: object
+      properties:
+        second_factor:
+          type: string
+          enum:
+          - sms
+          - app
+    CompleteInviteResponse:
+      type: object
+      properties:
+        invite:
+          $ref: '#/components/schemas/Invite'
+        service_external_id:
+          type: string
+          example: 89wi6il2364328
+        user_external_id:
+          type: string
+          example: 287cg75v3737
     CreateUserRequest:
       type: object
       properties:
@@ -1214,17 +1238,6 @@ components:
           example: service
         user_exist:
           type: boolean
-    InviteCompleteResponse:
-      type: object
-      properties:
-        invite:
-          $ref: '#/components/schemas/Invite'
-        service_external_id:
-          type: string
-          example: 89wi6il2364328
-        user_external_id:
-          type: string
-          example: 287cg75v3737
     InviteServiceRequest:
       type: object
       properties:

--- a/src/main/java/uk/gov/pay/adminusers/model/CompleteInviteRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/CompleteInviteRequest.java
@@ -2,28 +2,26 @@ package uk.gov.pay.adminusers.model;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
-import io.swagger.v3.oas.annotations.media.Schema;
 
-import java.util.Collections;
-import java.util.List;
+import javax.annotation.Nullable;
+import javax.validation.Valid;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class CompleteInviteRequest {
 
-    @ArraySchema(schema = @Schema(example = "1",
-            description = "gateway_account_ids that needs to be associated for the new service. Only applicable for invite type `service`"))
-    private List<String> gatewayAccountIds = Collections.emptyList();
-    
+    @Valid
+    @Nullable
+    private SecondFactorMethod secondFactor;
+
     public CompleteInviteRequest() {
         // for Jackson deserialisation
     }
-    
-    public CompleteInviteRequest(List<String> gatewayAccountIds) {
-        this.gatewayAccountIds = gatewayAccountIds;
+
+    public SecondFactorMethod getSecondFactor() {
+        return secondFactor;
     }
 
-    public List<String> getGatewayAccountIds() {
-        return gatewayAccountIds;
+    public void setSecondFactor(SecondFactorMethod secondFactor) {
+        this.secondFactor = secondFactor;
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/model/CompleteInviteResponse.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/CompleteInviteResponse.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class InviteCompleteResponse {
+public class CompleteInviteResponse {
 
     private Invite invite;
     @Schema(example = "287cg75v3737")
@@ -14,7 +14,7 @@ public class InviteCompleteResponse {
     @Schema(example = "89wi6il2364328")
     private String serviceExternalId;
 
-    public InviteCompleteResponse(@JsonProperty("invite") Invite invite) {
+    public CompleteInviteResponse(@JsonProperty("invite") Invite invite) {
         this.invite = invite;
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
@@ -233,7 +233,7 @@ public class InviteEntity extends AbstractEntity {
         return password != null;
     }
 
-    public UserEntity mapToUserEntity() {
+    public UserEntity mapToUserEntity(SecondFactorMethod secondFactor) {
         UserEntity userEntity = new UserEntity();
         userEntity.setExternalId(RandomIdGenerator.randomUuid());
         userEntity.setUsername(email);
@@ -243,7 +243,7 @@ public class InviteEntity extends AbstractEntity {
         if (telephoneNumber != null) {
             userEntity.setTelephoneNumber(TelephoneNumberUtility.formatToE164(telephoneNumber));
         }
-        userEntity.setSecondFactor(SecondFactorMethod.SMS);
+        userEntity.setSecondFactor(secondFactor);
         userEntity.setLoginCounter(0);
         userEntity.setDisabled(Boolean.FALSE);
         userEntity.setSessionVersion(0);

--- a/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
@@ -13,7 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.adminusers.model.Invite;
-import uk.gov.pay.adminusers.model.InviteCompleteResponse;
+import uk.gov.pay.adminusers.model.CompleteInviteResponse;
 import uk.gov.pay.adminusers.model.InviteOtpRequest;
 import uk.gov.pay.adminusers.model.InviteServiceRequest;
 import uk.gov.pay.adminusers.model.InviteUserRequest;
@@ -139,11 +139,11 @@ public class InviteResource {
                     "The response contains the user and the service id's affected as part of the invite completion in addition to the invite",
             responses = {
                     @ApiResponse(responseCode = "200", description = "OK",
-                            content = @Content(schema = @Schema(implementation = InviteCompleteResponse.class))),
+                            content = @Content(schema = @Schema(implementation = CompleteInviteResponse.class))),
                     @ApiResponse(responseCode = "404", description = "Not found")
             }
     )
-    public InviteCompleteResponse completeInvite(@Parameter(example = "d02jddeib0lqpsir28fbskg9v0rv") @PathParam("code") String inviteCode) {
+    public CompleteInviteResponse completeInvite(@Parameter(example = "d02jddeib0lqpsir28fbskg9v0rv") @PathParam("code") String inviteCode) {
         LOGGER.info("Invite  complete POST request for code - [ {} ]", inviteCode);
 
         if (isNotBlank(inviteCode) && inviteCode.length() > MAX_LENGTH_CODE) {

--- a/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
@@ -22,6 +22,11 @@ public class AdminUsersExceptions {
         return buildWebApplicationException(error, BAD_REQUEST.getStatusCode());
     }
 
+    public static WebApplicationException missingSecondFactorMethod(String inviteCode) {
+        String error = format("Second factor not provided when attempting to complete an invite for a non-existent user. invite-code = %s", inviteCode);
+        return buildWebApplicationException(error, BAD_REQUEST.getStatusCode());
+    }
+
     public static WebApplicationException conflictingUsername(String username) {
         String error = format("username [%s] already exists", username);
         return buildWebApplicationException(error, CONFLICT.getStatusCode());

--- a/src/main/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleter.java
@@ -3,6 +3,7 @@ package uk.gov.pay.adminusers.service;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 import uk.gov.pay.adminusers.model.CompleteInviteResponse;
+import uk.gov.pay.adminusers.model.SecondFactorMethod;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
@@ -10,7 +11,7 @@ import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
 
-import javax.ws.rs.WebApplicationException;
+import javax.annotation.Nullable;
 
 import static java.lang.String.format;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.internalServerError;
@@ -30,7 +31,11 @@ public class ExistingUserInviteCompleter extends InviteCompleter {
 
     @Override
     @Transactional
-    public CompleteInviteResponse complete(InviteEntity inviteEntity) {
+    public CompleteInviteResponse complete(InviteEntity inviteEntity, @Nullable SecondFactorMethod secondFactor) {
+        return complete(inviteEntity);
+    }
+
+    private CompleteInviteResponse complete(InviteEntity inviteEntity) {
         if (inviteEntity.isExpired() || Boolean.TRUE.equals(inviteEntity.isDisabled())) {
             throw inviteLockedException(inviteEntity.getCode());
         }

--- a/src/main/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleter.java
@@ -2,7 +2,7 @@ package uk.gov.pay.adminusers.service;
 
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
-import uk.gov.pay.adminusers.model.InviteCompleteResponse;
+import uk.gov.pay.adminusers.model.CompleteInviteResponse;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
@@ -30,7 +30,7 @@ public class ExistingUserInviteCompleter extends InviteCompleter {
 
     @Override
     @Transactional
-    public InviteCompleteResponse complete(InviteEntity inviteEntity) {
+    public CompleteInviteResponse complete(InviteEntity inviteEntity) {
         if (inviteEntity.isExpired() || Boolean.TRUE.equals(inviteEntity.isDisabled())) {
             throw inviteLockedException(inviteEntity.getCode());
         }
@@ -49,7 +49,7 @@ public class ExistingUserInviteCompleter extends InviteCompleter {
                     inviteEntity.setDisabled(true);
                     inviteDao.merge(inviteEntity);
 
-                    InviteCompleteResponse response = new InviteCompleteResponse(inviteEntity.toInvite());
+                    CompleteInviteResponse response = new CompleteInviteResponse(inviteEntity.toInvite());
                     response.setUserExternalId(userEntity.getExternalId());
                     response.setServiceExternalId(serviceEntity.getExternalId());
                     return response;

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteCompleter.java
@@ -1,9 +1,12 @@
 package uk.gov.pay.adminusers.service;
 
 import uk.gov.pay.adminusers.model.CompleteInviteResponse;
+import uk.gov.pay.adminusers.model.SecondFactorMethod;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
+
+import javax.annotation.Nullable;
 
 public abstract class InviteCompleter {
     
-    public abstract CompleteInviteResponse complete(InviteEntity inviteEntity);
+    public abstract CompleteInviteResponse complete(InviteEntity inviteEntity, @Nullable SecondFactorMethod secondFactor);
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteCompleter.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.adminusers.service;
 
-import uk.gov.pay.adminusers.model.InviteCompleteResponse;
+import uk.gov.pay.adminusers.model.CompleteInviteResponse;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
 
 public abstract class InviteCompleter {
     
-    public abstract InviteCompleteResponse complete(InviteEntity inviteEntity);
+    public abstract CompleteInviteResponse complete(InviteEntity inviteEntity);
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/NewUserExistingServiceInviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NewUserExistingServiceInviteCompleter.java
@@ -6,7 +6,7 @@ import net.logstash.logback.marker.Markers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.adminusers.model.Invite;
-import uk.gov.pay.adminusers.model.InviteCompleteResponse;
+import uk.gov.pay.adminusers.model.CompleteInviteResponse;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
 import uk.gov.pay.adminusers.persistence.entity.InviteEntity;
@@ -39,7 +39,7 @@ public class NewUserExistingServiceInviteCompleter extends InviteCompleter {
 
     @Override
     @Transactional
-    public InviteCompleteResponse complete(InviteEntity inviteEntity) {
+    public CompleteInviteResponse complete(InviteEntity inviteEntity) {
         if (inviteEntity.isExpired() || Boolean.TRUE.equals(inviteEntity.isDisabled())) {
             throw inviteLockedException(inviteEntity.getCode());
         }
@@ -66,7 +66,7 @@ public class NewUserExistingServiceInviteCompleter extends InviteCompleter {
         );
 
         Invite invite = linksBuilder.addUserLink(userEntity.toUser(), inviteEntity.toInvite());
-        InviteCompleteResponse response = new InviteCompleteResponse(invite);
+        CompleteInviteResponse response = new CompleteInviteResponse(invite);
         response.setUserExternalId(userEntity.getExternalId());
 
         return response;

--- a/src/main/java/uk/gov/pay/adminusers/service/SelfSignupInviteCompleter.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/SelfSignupInviteCompleter.java
@@ -3,7 +3,7 @@ package uk.gov.pay.adminusers.service;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 import uk.gov.pay.adminusers.model.Invite;
-import uk.gov.pay.adminusers.model.InviteCompleteResponse;
+import uk.gov.pay.adminusers.model.CompleteInviteResponse;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
@@ -42,7 +42,7 @@ public class SelfSignupInviteCompleter extends InviteCompleter {
      */
     @Override
     @Transactional
-    public InviteCompleteResponse complete(InviteEntity inviteEntity) {
+    public CompleteInviteResponse complete(InviteEntity inviteEntity) {
         if (inviteEntity.isExpired() || inviteEntity.isDisabled()) {
             throw inviteLockedException(inviteEntity.getCode());
         }
@@ -65,7 +65,7 @@ public class SelfSignupInviteCompleter extends InviteCompleter {
             inviteDao.merge(inviteEntity);
 
             Invite invite = linksBuilder.addUserLink(userEntity.toUser(), inviteEntity.toInvite());
-            InviteCompleteResponse response = new InviteCompleteResponse(invite);
+            CompleteInviteResponse response = new CompleteInviteResponse(invite);
             response.setServiceExternalId(serviceEntity.getExternalId());
             response.setUserExternalId(userEntity.getExternalId());
             return response;

--- a/src/test/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleterTest.java
@@ -65,7 +65,7 @@ public class ExistingUserInviteCompleterTest {
     }
 
     @Test
-    public void shouldSuccess_whenSubscribingAServiceToAnExistingUser_forValidInvite() {
+    public void shouldSuccess_whenSubscribingAServiceToAnExistingUser_forValidInvite_without2FAMethod() {
         ServiceEntity service = new ServiceEntity();
         service.setId(serviceId);
         service.setExternalId(serviceExternalId);
@@ -77,7 +77,7 @@ public class ExistingUserInviteCompleterTest {
 
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(user));
 
-        CompleteInviteResponse completedInvite = existingUserInviteCompleter.complete(anInvite);
+        CompleteInviteResponse completedInvite = existingUserInviteCompleter.complete(anInvite, null);
 
         ArgumentCaptor<UserEntity> persistedUser = ArgumentCaptor.forClass(UserEntity.class);
         verify(mockUserDao).merge(persistedUser.capture());
@@ -101,7 +101,7 @@ public class ExistingUserInviteCompleterTest {
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(user));
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(anInvite));
+                () -> existingUserInviteCompleter.complete(anInvite, null));
         assertThat(webApplicationException.getResponse().getStatus(), is(500));
         Map<String, List<String>> entity = (Map<String, List<String>>) webApplicationException.getResponse().getEntity();
         assertThat(entity.get("errors").get(0), is("Invite with code code to invite an existing user to a service does not have a service set"));
@@ -120,7 +120,7 @@ public class ExistingUserInviteCompleterTest {
         UserEntity user = UserEntity.from(aUser(anInvite.getEmail()));
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(anInvite));
+                () -> existingUserInviteCompleter.complete(anInvite, null));
         assertThat(webApplicationException.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 
@@ -132,7 +132,7 @@ public class ExistingUserInviteCompleterTest {
         anInvite.setDisabled(true);
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(anInvite));
+                () -> existingUserInviteCompleter.complete(anInvite, null));
         assertThat(webApplicationException.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -143,7 +143,7 @@ public class ExistingUserInviteCompleterTest {
         anInvite.setExpiryDate(ZonedDateTime.now().minusDays(1));
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(anInvite));
+                () -> existingUserInviteCompleter.complete(anInvite, null));
         assertThat(webApplicationException.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -155,7 +155,7 @@ public class ExistingUserInviteCompleterTest {
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
 
         WebApplicationException webApplicationException = assertThrows(WebApplicationException.class,
-                () -> existingUserInviteCompleter.complete(anInvite));
+                () -> existingUserInviteCompleter.complete(anInvite, null));
         assertThat(webApplicationException.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/ExistingUserInviteCompleterTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.pay.adminusers.model.InviteCompleteResponse;
+import uk.gov.pay.adminusers.model.CompleteInviteResponse;
 import uk.gov.pay.adminusers.model.InviteType;
 import uk.gov.pay.adminusers.model.SecondFactorMethod;
 import uk.gov.pay.adminusers.model.Service;
@@ -77,7 +77,7 @@ public class ExistingUserInviteCompleterTest {
 
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.of(user));
 
-        InviteCompleteResponse completedInvite = existingUserInviteCompleter.complete(anInvite);
+        CompleteInviteResponse completedInvite = existingUserInviteCompleter.complete(anInvite);
 
         ArgumentCaptor<UserEntity> persistedUser = ArgumentCaptor.forClass(UserEntity.class);
         verify(mockUserDao).merge(persistedUser.capture());

--- a/src/test/java/uk/gov/pay/adminusers/service/NewUserExistingServiceInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/NewUserExistingServiceInviteCompleterTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.pay.adminusers.model.InviteCompleteResponse;
+import uk.gov.pay.adminusers.model.CompleteInviteResponse;
 import uk.gov.pay.adminusers.model.InviteType;
 import uk.gov.pay.adminusers.model.Link;
 import uk.gov.pay.adminusers.model.Service;
@@ -69,7 +69,7 @@ public class NewUserExistingServiceInviteCompleterTest {
         anInvite.setType(InviteType.USER);
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
 
-        InviteCompleteResponse inviteResponse = newUserExistingServiceInviteCompleter.complete(anInvite);
+        CompleteInviteResponse inviteResponse = newUserExistingServiceInviteCompleter.complete(anInvite);
 
         verify(mockUserDao).persist(expectedInvitedUser.capture());
         verify(mockInviteDao).merge(expectedInvite.capture());

--- a/src/test/java/uk/gov/pay/adminusers/service/NewUserExistingServiceInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/NewUserExistingServiceInviteCompleterTest.java
@@ -9,6 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.adminusers.model.CompleteInviteResponse;
 import uk.gov.pay.adminusers.model.InviteType;
 import uk.gov.pay.adminusers.model.Link;
+import uk.gov.pay.adminusers.model.SecondFactorMethod;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
@@ -64,12 +65,12 @@ public class NewUserExistingServiceInviteCompleterTest {
     }
 
     @Test
-    public void shouldCreateUserAndAssignThemToService_whenPassedValidServiceInviteCode() {
+    public void shouldCreateUserAndAssignThemToService_whenPassedValidServiceInviteCode_with2FAMethod() {
         InviteEntity anInvite = createInvite();
         anInvite.setType(InviteType.USER);
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
 
-        CompleteInviteResponse inviteResponse = newUserExistingServiceInviteCompleter.complete(anInvite);
+        CompleteInviteResponse inviteResponse = newUserExistingServiceInviteCompleter.complete(anInvite, SecondFactorMethod.APP);
 
         verify(mockUserDao).persist(expectedInvitedUser.capture());
         verify(mockInviteDao).merge(expectedInvite.capture());
@@ -80,11 +81,23 @@ public class NewUserExistingServiceInviteCompleterTest {
         assertThat(inviteResponse.getInvite().getLinks().get(0).getRel(), is(Link.Rel.USER));
         assertThat(inviteResponse.getInvite().getLinks().get(0).getHref(), matchesPattern("^" + baseUrl + "/v1/api/users/[0-9a-z]{32}$"));
         assertThat(inviteResponse.getUserExternalId(), is(user.getExternalId()));
+        assertThat(user.getSecondFactor(), is(SecondFactorMethod.APP));
 
         assertThat(user.getServicesRoles().size(), is(1));
         assertThat(user.getServicesRoles().get(0).getRole(), is(anInvite.getRole().get()));
         assertThat(user.getServicesRoles().get(0).getService(), is(anInvite.getService().get()));
         assertThat(user.getServicesRoles().get(0).getUser(), is(user));
+    }
+
+    @Test
+    public void shouldThrowMissingSecondFactorMethod_whenNo2FAMethodSupplied() {
+        InviteEntity anInvite = createInvite();
+        anInvite.setType(InviteType.USER);
+        when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
+
+        WebApplicationException exception = assertThrows(WebApplicationException.class,
+                () -> newUserExistingServiceInviteCompleter.complete(anInvite, null));
+        assertThat(exception.getMessage(), is("HTTP 400 Bad Request"));
     }
 
     @Test
@@ -98,7 +111,7 @@ public class NewUserExistingServiceInviteCompleterTest {
         when(mockUserDao.findByEmail(anInvite.getEmail())).thenReturn(Optional.of(mock(UserEntity.class)));
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> newUserExistingServiceInviteCompleter.complete(anInvite));
+                () -> newUserExistingServiceInviteCompleter.complete(anInvite, SecondFactorMethod.SMS));
         assertThat(exception.getMessage(), is("HTTP 409 Conflict"));
     }
 
@@ -112,7 +125,7 @@ public class NewUserExistingServiceInviteCompleterTest {
         anInvite.setDisabled(true);
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> newUserExistingServiceInviteCompleter.complete(anInvite));
+                () -> newUserExistingServiceInviteCompleter.complete(anInvite, SecondFactorMethod.SMS));
         assertThat(exception.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -126,7 +139,7 @@ public class NewUserExistingServiceInviteCompleterTest {
         anInvite.setExpiryDate(ZonedDateTime.now().minusDays(1));
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> newUserExistingServiceInviteCompleter.complete(anInvite));
+                () -> newUserExistingServiceInviteCompleter.complete(anInvite, SecondFactorMethod.SMS));
         assertThat(exception.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -141,7 +154,7 @@ public class NewUserExistingServiceInviteCompleterTest {
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> newUserExistingServiceInviteCompleter.complete(anInvite));
+                () -> newUserExistingServiceInviteCompleter.complete(anInvite, SecondFactorMethod.SMS));
         assertThat(exception.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/service/SelfSignupInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/SelfSignupInviteCompleterTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.pay.adminusers.model.InviteCompleteResponse;
+import uk.gov.pay.adminusers.model.CompleteInviteResponse;
 import uk.gov.pay.adminusers.model.InviteType;
 import uk.gov.pay.adminusers.model.Link;
 import uk.gov.pay.adminusers.model.Service;
@@ -73,7 +73,7 @@ class SelfSignupInviteCompleterTest {
         anInvite.setType(InviteType.SERVICE);
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
 
-        InviteCompleteResponse inviteResponse = selfSignupInviteCompleter.complete(anInvite);
+        CompleteInviteResponse inviteResponse = selfSignupInviteCompleter.complete(anInvite);
 
         verify(mockServiceDao).persist(expectedService.capture());
         verify(mockUserDao).merge(expectedInvitedUser.capture());

--- a/src/test/java/uk/gov/pay/adminusers/service/SelfSignupInviteCompleterTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/SelfSignupInviteCompleterTest.java
@@ -9,6 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.adminusers.model.CompleteInviteResponse;
 import uk.gov.pay.adminusers.model.InviteType;
 import uk.gov.pay.adminusers.model.Link;
+import uk.gov.pay.adminusers.model.SecondFactorMethod;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
@@ -26,6 +27,7 @@ import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -68,12 +70,12 @@ class SelfSignupInviteCompleterTest {
     }
 
     @Test
-    void shouldCreateServiceAndUser_whenPassedValidServiceInviteCode() {
+    void shouldCreateServiceAndUser_whenPassedValidServiceInviteCode_with2FAMethod() {
         InviteEntity anInvite = createInvite();
         anInvite.setType(InviteType.SERVICE);
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
 
-        CompleteInviteResponse inviteResponse = selfSignupInviteCompleter.complete(anInvite);
+        CompleteInviteResponse inviteResponse = selfSignupInviteCompleter.complete(anInvite, SecondFactorMethod.APP);
 
         verify(mockServiceDao).persist(expectedService.capture());
         verify(mockUserDao).merge(expectedInvitedUser.capture());
@@ -87,11 +89,26 @@ class SelfSignupInviteCompleterTest {
         assertThat(serviceEntity.isRedirectToServiceImmediatelyOnTerminalState(), is(false));
         assertThat(serviceEntity.isCollectBillingAddress(), is(true));
         assertThat(serviceEntity.getDefaultBillingAddressCountry(), is("GB"));
+        
+        UserEntity userEntity = expectedInvitedUser.getValue();
+        assertThat(userEntity.getSecondFactor(), is(SecondFactorMethod.APP));
+        assertThat(expectedInvitedUser.getValue().getServicesRole(serviceEntity.getExternalId()).isPresent(), is(true));
 
         assertThat(inviteResponse.getInvite().isDisabled(), is(true));
         assertThat(inviteResponse.getInvite().getLinks().size(), is(1));
         assertThat(inviteResponse.getInvite().getLinks().get(0).getRel(), is(Link.Rel.USER));
         assertThat(inviteResponse.getInvite().getLinks().get(0).getHref(), matchesPattern("^" + baseUrl + "/v1/api/users/[0-9a-z]{32}$"));
+    }
+
+    @Test
+    void shouldThrowMissingSecondFactorMethod_whenNo2FAMethodSupplied() {
+        InviteEntity anInvite = createInvite();
+        anInvite.setType(InviteType.SERVICE);
+        when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
+
+        WebApplicationException exception = assertThrows(WebApplicationException.class,
+                () -> selfSignupInviteCompleter.complete(anInvite, null));
+        assertThat(exception.getMessage(), is("HTTP 400 Bad Request"));
     }
 
     @Test
@@ -105,7 +122,7 @@ class SelfSignupInviteCompleterTest {
         when(mockUserDao.findByEmail(anInvite.getEmail())).thenReturn(Optional.of(mock(UserEntity.class)));
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> selfSignupInviteCompleter.complete(anInvite));
+                () -> selfSignupInviteCompleter.complete(anInvite, SecondFactorMethod.SMS));
         assertThat(exception.getMessage(), is("HTTP 409 Conflict"));
     }
 
@@ -119,7 +136,7 @@ class SelfSignupInviteCompleterTest {
         anInvite.setDisabled(true);
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> selfSignupInviteCompleter.complete(anInvite));
+                () -> selfSignupInviteCompleter.complete(anInvite, SecondFactorMethod.SMS));
         assertThat(exception.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -133,7 +150,7 @@ class SelfSignupInviteCompleterTest {
         anInvite.setExpiryDate(ZonedDateTime.now().minusDays(1));
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> selfSignupInviteCompleter.complete(anInvite));
+                () -> selfSignupInviteCompleter.complete(anInvite, SecondFactorMethod.SMS));
         assertThat(exception.getMessage(), is("HTTP 410 Gone"));
     }
 
@@ -148,7 +165,7 @@ class SelfSignupInviteCompleterTest {
         when(mockUserDao.findByEmail(email)).thenReturn(Optional.empty());
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-                () -> selfSignupInviteCompleter.complete(anInvite));
+                () -> selfSignupInviteCompleter.complete(anInvite, SecondFactorMethod.SMS));
         assertThat(exception.getMessage(), is("HTTP 500 Internal Server Error"));
     }
 


### PR DESCRIPTION
The `/v1/api/invites/{code}/complete` endpoint now reads a `secondFactor` value from the request body and passes it on to the InviteCompleter.  The two InviteCompleters that create a new user now add the `secondFactor` to the user entity before it is persisted.