### PR TITLE
PP-10038: Fix casing issue in openapi.yaml

### DIFF
--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -1130,8 +1130,8 @@ components:
         second_factor:
           type: string
           enum:
-          - sms
-          - app
+          - SMS
+          - APP
     CompleteInviteResponse:
       type: object
       properties:
@@ -1605,8 +1605,8 @@ components:
         second_factor:
           type: string
           enum:
-          - sms
-          - app
+          - SMS
+          - APP
           example: SMS
         service_roles:
           type: array

--- a/src/main/java/uk/gov/pay/adminusers/model/SecondFactorMethod.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/SecondFactorMethod.java
@@ -1,7 +1,10 @@
 package uk.gov.pay.adminusers.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public enum SecondFactorMethod {
 
+    @JsonProperty("SMS")
     SMS {
         @Override
         public String toString() {
@@ -9,6 +12,7 @@ public enum SecondFactorMethod {
         }
     },
 
+    @JsonProperty("APP")
     APP {
         @Override
         public String toString() {


### PR DESCRIPTION
#1724 added `CompleteInviteRequest`, and in the `openapi.yaml` that was generated for that change, the `SecondFactorMethod` enum constants were serialised as lowercased strings, but they should be uppercase.  This has now been fixed in the code and the openapi file will be generated correctly going forwards.