### PR TITLE
PP-10055 Amend invite exists pact state

### DIFF
--- a/src/test/java/uk/gov/pay/adminusers/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/pact/ContractTest.java
@@ -194,6 +194,7 @@ public abstract class ContractTest {
         inviteDbFixture(dbHelper)
                 .withCode("an-invite-code")
                 .withPassword("a-password")
+                .withTelephoneNumber("+441134960000")
                 .insertInviteToAddUserToService();
     }
 


### PR DESCRIPTION
Amend the pact state that sets up an invite with a telephone number set. This is so that the selfservice Pact test to get an invite can check that the telephone number field is returned in the response.