### PR TITLE
PP-10052 Include otp_key in Invite response

### DIFF
--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -1224,6 +1224,9 @@ components:
         inviteLink:
           type: string
           writeOnly: true
+        otp_key:
+          type: string
+          example: ABC123
         password_set:
           type: boolean
           example: false

--- a/src/main/java/uk/gov/pay/adminusers/model/Invite.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Invite.java
@@ -28,8 +28,18 @@ public class Invite {
     private boolean expired;
     private boolean passwordSet;
 
-    public Invite(String code, String email, String telephoneNumber,
-                  Boolean disabled, Integer attemptCounter, String type, String role, Boolean expired, boolean passwordSet) {
+    private String otpKey;
+
+    public Invite(String code,
+                  String email,
+                  String telephoneNumber,
+                  Boolean disabled,
+                  Integer attemptCounter,
+                  String type,
+                  String role,
+                  Boolean expired,
+                  boolean passwordSet,
+                  String otpKey) {
         this.code = code;
         this.email = email;
         this.telephoneNumber = telephoneNumber;
@@ -39,27 +49,24 @@ public class Invite {
         this.role = role;
         this.expired = expired;
         this.passwordSet = passwordSet;
+        this.otpKey = otpKey;
     }
 
-    @JsonProperty("email")
     @Schema(example = "example@example.gov.uk")
     public String getEmail() {
         return email;
     }
 
-    @JsonProperty("telephone_number")
     @Schema(example = "+440787654534")
     public String getTelephoneNumber() {
         return telephoneNumber;
     }
 
-    @JsonProperty("disabled")
     @Schema(example = "false")
     public Boolean isDisabled() {
         return disabled;
     }
-
-    @JsonProperty("attempt_counter")
+    
     @Schema(example = "0")
     public Integer getAttemptCounter() {
         return attemptCounter;
@@ -70,22 +77,24 @@ public class Invite {
         return links;
     }
 
-    @JsonProperty("role")
     @Schema(example = "view-only")
     public String getRole() {
         return role;
     }
 
-    @JsonProperty("expired")
     @Schema(example = "false")
     public Boolean isExpired() {
         return expired;
     }
 
-    @JsonProperty("password_set")
     @Schema(example = "false")
     public boolean isPasswordSet() {
         return passwordSet;
+    }
+
+    @Schema(example = "ABC123")
+    public String getOtpKey() {
+        return otpKey;
     }
 
     public void setInviteLink(String targetUrl) {
@@ -114,6 +123,7 @@ public class Invite {
     /**
      * Derived attribute only to indicate if a user with the specified email already exits in the system.
      * This is not stored in database rather populated at runtime every time at the usage.
+     *
      * @param userExist
      */
     public void setUserExist(boolean userExist) {

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
@@ -222,7 +222,8 @@ public class InviteEntity extends AbstractEntity {
 
     public Invite toInvite() {
         String roleName = getRole().map(RoleEntity::getName).orElse(null);
-        return new Invite(code, email, telephoneNumber, disabled, loginCounter, type.getType(), roleName, isExpired(), hasPassword());
+        return new Invite(code, email, telephoneNumber, disabled, loginCounter, type.getType(), roleName, isExpired(),
+                hasPassword(), otpKey);
     }
 
     public boolean isExpired() {

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGetIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGetIT.java
@@ -6,18 +6,21 @@ import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.Response.Status.GONE;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.adminusers.fixtures.InviteDbFixture.inviteDbFixture;
 
-public class InviteResourceGetIT extends IntegrationTest {
+class InviteResourceGetIT extends IntegrationTest {
 
     @Test
-    public void getInvitation_shouldSucceed() {
+    void getInvitation_shouldSucceed() {
 
         String email = "user@example.com";
+        String otpKey = "ABC12";
         String inviteCode = inviteDbFixture(databaseHelper)
                 .withEmail(email)
+                .withOtpKey(otpKey)
                 .insertInviteToAddUserToService();
 
         givenSetup()
@@ -31,7 +34,8 @@ public class InviteResourceGetIT extends IntegrationTest {
                 .body("disabled", is(false))
                 .body("user_exist", is(false))
                 .body("attempt_counter", is(0))
-                .body("password_set", is(false));
+                .body("password_set", is(false))
+                .body("otp_key", is(otpKey));
     }
 
     @Test
@@ -39,7 +43,7 @@ public class InviteResourceGetIT extends IntegrationTest {
      *  This situation happens when OTP is generated (with telephone_number) and then the GET Invite is again requested
      *  (still non-expired invite link)
      */
-    public void getInvitation_shouldSucceedWithTelephoneNumber_whenIsAvailable() {
+    void getInvitation_shouldSucceedWithTelephoneNumber_whenIsAvailable() {
 
         String email = "user@example.com";
         String telephoneNumber = "+440787654534";
@@ -62,7 +66,7 @@ public class InviteResourceGetIT extends IntegrationTest {
     }
 
     @Test
-    public void getInvitation_shouldFail_whenExpired() {
+    void getInvitation_shouldFail_whenExpired() {
 
         String expiredCode = inviteDbFixture(databaseHelper).expired().insertInviteToAddUserToService();
 
@@ -75,7 +79,7 @@ public class InviteResourceGetIT extends IntegrationTest {
     }
 
     @Test
-    public void getInvitation_shouldFail_whenDisabled() {
+    void getInvitation_shouldFail_whenDisabled() {
 
         String expiredCode = inviteDbFixture(databaseHelper).disabled().insertInviteToAddUserToService();
 
@@ -88,7 +92,7 @@ public class InviteResourceGetIT extends IntegrationTest {
     }
 
     @Test
-    public void createInvitation_shouldFail_whenInvalidCode() {
+    void createInvitation_shouldFail_whenInvalidCode() {
 
         givenSetup()
                 .when()
@@ -99,7 +103,7 @@ public class InviteResourceGetIT extends IntegrationTest {
     }
 
     @Test
-    public void getInvitations_shouldSucceed() {
+    void getInvitations_shouldSucceed() {
         String serviceExternalId = "sdfgsdgytgkh";
         String email = "user@example.com";
         inviteDbFixture(databaseHelper)


### PR DESCRIPTION
Include the otp_key in API responses that return an Invite. This is so that the key can be displayed on the selfservice page to set up an authenticator app.