### PR TITLE
PP-10329: Add send-otp endpoint to InviteResource

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -132,42 +132,42 @@
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "675fecb5af336276574d3d88a4d382d961cf7418",
         "is_verified": false,
-        "line_number": 291
+        "line_number": 313
       },
       {
         "type": "Secret Keyword",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "fefda504251b73d30a7cf3d047d241388a3c11b3",
         "is_verified": false,
-        "line_number": 292
+        "line_number": 314
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_verified": false,
-        "line_number": 404
+        "line_number": 426
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "1976a945a8d2733655e4b2453bd49fb59cb7ba19",
         "is_verified": false,
-        "line_number": 665
+        "line_number": 687
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "a31519136d26754afeb0df49b5f066f387091f88",
         "is_verified": false,
-        "line_number": 699
+        "line_number": 721
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "3660e32cde5fccc8d1e4521d0c831c2012388720",
         "is_verified": false,
-        "line_number": 1194
+        "line_number": 1216
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/model/CreateUserRequest.java": [
@@ -362,7 +362,7 @@
         "filename": "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpIT.java",
         "hashed_secret": "833b5c8e76b19b617849d9a67a5980f08c784882",
         "is_verified": false,
-        "line_number": 30
+        "line_number": 32
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceServiceCompleteIT.java": [
@@ -425,14 +425,14 @@
         "filename": "src/test/java/uk/gov/pay/adminusers/service/InviteServiceTest.java",
         "hashed_secret": "7300c52390b4026eb1a60642b0eabfb54475c21b",
         "is_verified": false,
-        "line_number": 58
+        "line_number": 59
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/pay/adminusers/service/InviteServiceTest.java",
         "hashed_secret": "6318553899daae2941718c02508aeee938af1a1c",
         "is_verified": false,
-        "line_number": 222
+        "line_number": 277
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/service/ResetPasswordServiceTest.java": [
@@ -484,5 +484,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-17T14:34:44Z"
+  "generated_at": "2022-11-22T15:43:38Z"
 }

--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -279,6 +279,28 @@ paths:
         in the invite.
       tags:
       - Invites
+  /v1/api/invites/{code}/send-otp:
+    post:
+      operationId: sendOtp
+      parameters:
+      - example: d02jddeib0lqpsir28fbskg9v0rv
+        in: path
+        name: code
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: No content
+        "400":
+          description: Invalid payload
+        "404":
+          description: Not found
+        "412":
+          description: Precondition failed
+      summary: Sends otp verification code to the phone number registered in the invite
+      tags:
+      - Invites
   /v1/api/reset-password:
     post:
       operationId: resetForgottenPassword

--- a/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/InviteResource.java
@@ -129,6 +129,28 @@ public class InviteResource {
                 .collect(Collectors.toList());
         return inviteService.updateInvite(inviteCode, updateRequests);
     }
+    
+    @POST
+    @Path("/v1/api/invites/{code}/send-otp")
+    @Produces(APPLICATION_JSON)
+    @Operation(
+            summary = "Sends otp verification code to the phone number registered in the invite",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "No content"),
+                    @ApiResponse(responseCode = "400", description = "Invalid payload"),
+                    @ApiResponse(responseCode = "404", description = "Not found"),
+                    @ApiResponse(responseCode = "412", description = "Precondition failed")
+            }
+    )
+    public void sendOtp(@Parameter(example = "d02jddeib0lqpsir28fbskg9v0rv") @PathParam("code") String inviteCode) {
+        LOGGER.info("Invite send OTP POST request for code - [ {} ]", inviteCode);
+
+        if (isNotBlank(inviteCode) && inviteCode.length() > MAX_LENGTH_CODE) {
+            throw new WebApplicationException(Response.Status.NOT_FOUND);
+        }
+
+        inviteService.sendOtp(inviteCode);
+    }
 
     @POST
     @Path("/v1/api/invites/{code}/complete")

--- a/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
@@ -27,6 +27,11 @@ public class AdminUsersExceptions {
         return buildWebApplicationException(error, BAD_REQUEST.getStatusCode());
     }
 
+    public static WebApplicationException inviteDoesNotHaveTelephoneNumberError(String inviteCode) {
+        String error = format("Unable to send second factor code as invite does not have a telephone number set. invite-code = %s", inviteCode);
+        return buildWebApplicationException(error, PRECONDITION_FAILED.getStatusCode());
+    }
+
     public static WebApplicationException conflictingUsername(String username) {
         String error = format("username [%s] already exists", username);
         return buildWebApplicationException(error, CONFLICT.getStatusCode());

--- a/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
@@ -37,6 +37,7 @@ public class IntegrationTest {
 
     /* default */ static final String INVITES_RESOURCE_URL = "/v1/api/invites";
     /* default */ static final String INVITES_GENERATE_OTP_RESOURCE_URL = "/v1/api/invites/%s/otp/generate";
+    /* default */ static final String INVITES_SEND_OTP_RESOURCE_URL = "/v1/api/invites/%s/send-otp";
     /* default */ static final String INVITES_RESEND_OTP_RESOURCE_URL = "/v1/api/invites/otp/resend";
     /* default */ static final String INVITES_VALIDATE_OTP_RESOURCE_URL = "/v2/api/invites/otp/validate";
     /* default */ static final String SERVICES_RESOURCE = "/v1/api/services";


### PR DESCRIPTION
New endpoint is `/v1/api/invites/{code}/send-otp`

This will later replace `/v1/api/invites/{code}/otp/generate` and `/v1/api/invites/otp/resend`