### PR TITLE
PP-10407: Replacement create invite endpoints

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -125,49 +125,49 @@
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "675fecb5af336276574d3d88a4d382d961cf7418",
         "is_verified": false,
-        "line_number": 285
+        "line_number": 330
       },
       {
         "type": "Secret Keyword",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "fefda504251b73d30a7cf3d047d241388a3c11b3",
         "is_verified": false,
-        "line_number": 286
+        "line_number": 331
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_verified": false,
-        "line_number": 398
+        "line_number": 443
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "1976a945a8d2733655e4b2453bd49fb59cb7ba19",
         "is_verified": false,
-        "line_number": 659
+        "line_number": 704
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "a31519136d26754afeb0df49b5f066f387091f88",
         "is_verified": false,
-        "line_number": 693
+        "line_number": 738
       },
       {
         "type": "Secret Keyword",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "0ea7458942ab65e0a340cf4fd28ca00d93c494f3",
         "is_verified": false,
-        "line_number": 792
+        "line_number": 837
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "3660e32cde5fccc8d1e4521d0c831c2012388720",
         "is_verified": false,
-        "line_number": 1188
+        "line_number": 1262
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/model/CreateUserRequest.java": [
@@ -484,5 +484,5 @@
       }
     ]
   },
-  "generated_at": "2022-12-08T15:27:16Z"
+  "generated_at": "2022-12-12T11:51:59Z"
 }

--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -91,6 +91,51 @@ paths:
       summary: List invites for a service
       tags:
       - Invites
+  /v1/api/invites/create-invite-to-join-service:
+    post:
+      operationId: createInviteToJoinService
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateInviteToJoinServiceRequest'
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Invite'
+          description: Created
+        "404":
+          description: Service or role not found
+        "422":
+          description: Missing required fields or invalid values
+      summary: Creates an invitation to allow a new team member to join an existing
+        service.
+      tags:
+      - Invites
+  /v1/api/invites/create-self-registration-invite:
+    post:
+      operationId: createSelfRegistrationInvite
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSelfRegistrationInviteRequest'
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Invite'
+          description: Created
+        "403":
+          description: The email is not an allowed public sector email address
+        "422":
+          description: Missing required fields or invalid values
+      summary: Creates an invitation to allow self provisioning new service with Pay
+      tags:
+      - Invites
   /v1/api/invites/service:
     post:
       operationId: createServiceInvite
@@ -98,7 +143,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/InviteServiceRequest'
+              $ref: '#/components/schemas/CreateSelfRegistrationInviteRequest'
       responses:
         "201":
           content:
@@ -120,7 +165,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/InviteUserRequest'
+              $ref: '#/components/schemas/CreateInviteToJoinServiceRequest'
       responses:
         "201":
           content:
@@ -1138,6 +1183,35 @@ components:
         user_external_id:
           type: string
           example: 287cg75v3737
+    CreateInviteToJoinServiceRequest:
+      type: object
+      properties:
+        email:
+          type: string
+          example: example@example.gov.uk
+        role_name:
+          type: string
+          example: view-only
+        sender:
+          type: string
+          description: User external ID
+          example: d0wksn12nklsdf1nd02nd9n2ndk
+        service_external_id:
+          type: string
+          example: dj2jkejke32jfhh3
+      required:
+      - email
+      - role_name
+      - sender
+      - service_external_id
+    CreateSelfRegistrationInviteRequest:
+      type: object
+      properties:
+        email:
+          type: string
+          example: example@example.gov.uk
+      required:
+      - email
     CreateUserRequest:
       type: object
       properties:
@@ -1236,35 +1310,6 @@ components:
           example: service
         user_exist:
           type: boolean
-    InviteServiceRequest:
-      type: object
-      properties:
-        email:
-          type: string
-          example: example@example.gov.uk
-      required:
-      - email
-    InviteUserRequest:
-      type: object
-      properties:
-        email:
-          type: string
-          example: example@example.gov.uk
-        role_name:
-          type: string
-          example: view-only
-        sender:
-          type: string
-          description: User external ID
-          example: d0wksn12nklsdf1nd02nd9n2ndk
-        service_external_id:
-          type: string
-          example: dj2jkejke32jfhh3
-      required:
-      - email
-      - role_name
-      - sender
-      - service_external_id
     InviteValidateOtpRequest:
       type: object
       properties:

--- a/src/main/java/uk/gov/pay/adminusers/model/CreateInviteToJoinServiceRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/CreateInviteToJoinServiceRequest.java
@@ -8,7 +8,7 @@ import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class InviteUserRequest {
+public class CreateInviteToJoinServiceRequest {
 
     @NotEmpty
     private String sender;
@@ -23,11 +23,11 @@ public class InviteUserRequest {
     @NotEmpty
     private String serviceExternalId;
     
-    public InviteUserRequest() {
+    public CreateInviteToJoinServiceRequest() {
         // for Jackson
     }
 
-    public InviteUserRequest(String sender, String email, String roleName, String serviceExternalId) {
+    public CreateInviteToJoinServiceRequest(String sender, String email, String roleName, String serviceExternalId) {
         this.sender = sender;
         this.email = email;
         this.roleName = roleName;

--- a/src/main/java/uk/gov/pay/adminusers/model/CreateSelfRegistrationInviteRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/CreateSelfRegistrationInviteRequest.java
@@ -3,23 +3,22 @@ package uk.gov.pay.adminusers.model;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
-import uk.gov.pay.adminusers.validations.ValidTelephoneNumber;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class InviteServiceRequest {
+public class CreateSelfRegistrationInviteRequest {
 
     @NotEmpty
     @Email
     protected String email;
     
-    public InviteServiceRequest() {
+    public CreateSelfRegistrationInviteRequest() {
         // for Jackson
     }
     
-    public InviteServiceRequest(String email) {
+    public CreateSelfRegistrationInviteRequest(String email) {
         this.email = email;
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteServiceFactory.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteServiceFactory.java
@@ -3,9 +3,9 @@ package uk.gov.pay.adminusers.service;
 
 public interface InviteServiceFactory {
 
-    ServiceInviteCreator serviceInvite();
+    SelfRegistrationInviteCreator selfRegistrationInviteCreator();
 
-    UserInviteCreator userInvite();
+    JoinServiceInviteCreator joinServiceInviteCreator();
 
     InviteFinder inviteFinder();
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/NotificationService.java
@@ -11,7 +11,6 @@ import uk.gov.service.notify.NotificationClientException;
 import uk.gov.service.notify.SendEmailResponse;
 import uk.gov.service.notify.SendSmsResponse;
 
-import java.time.Instant;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -93,14 +92,14 @@ public class NotificationService {
         }
     }
 
-    public String sendInviteEmail(String sender, String email, String inviteUrl) {
+    public String sendInviteNewUserToJoinServiceEmail(String sender, String email, String inviteUrl) {
         Map<String, String> personalisation = Map.of(
                 "username", sender,
                 "link", inviteUrl);
         return sendEmail(inviteEmailTemplateId, email, personalisation);
     }
 
-    public String sendServiceInviteEmail(String email, String inviteUrl) {
+    public String sendSelfRegistrationInviteEmail(String email, String inviteUrl) {
         Map<String, String> personalisation = Map.of(
                 "name", email,
                 "link", inviteUrl);
@@ -112,7 +111,7 @@ public class NotificationService {
         return sendEmail(forgottenPasswordEmailTemplateId, email, personalisation);
     }
 
-    public String sendServiceInviteUserExistsEmail(String email, String signInLink, String forgottenPasswordLink, String feedbackLink) {
+    public String sendSelfRegistrationInviteUserExistsEmail(String email, String signInLink, String forgottenPasswordLink, String feedbackLink) {
         Map<String, String> personalisation = Map.of(
                 "signin_link", signInLink,
                 "forgotten_password_link", forgottenPasswordLink,
@@ -120,12 +119,12 @@ public class NotificationService {
         return sendEmail(notifyConfiguration.getInviteServiceUserExistsEmailTemplateId(), email, personalisation);
     }
 
-    public String sendServiceInviteUserDisabledEmail(String email, String supportUrl) {
+    public String sendSelfRegistrationInviteUserExistsAndIsDisabledEmail(String email, String supportUrl) {
         Map<String, String> personalisation = Map.of("feedback_link", supportUrl);
         return sendEmail(notifyConfiguration.getInviteServiceUserDisabledEmailTemplateId(), email, personalisation);
     }
 
-    public String sendInviteExistingUserEmail(String sender, String email, String inviteUrl, String serviceName) {
+    public String sendInviteExistingUserToJoinServiceEmail(String sender, String email, String inviteUrl, String serviceName) {
         String collaborateServiceNamePart;
         String joinServiceNamePart;
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateInviteToJoinServiceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateInviteToJoinServiceIT.java
@@ -1,0 +1,310 @@
+package uk.gov.pay.adminusers.resources;
+
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.adminusers.model.Service;
+import uk.gov.pay.adminusers.model.ServiceName;
+import uk.gov.pay.adminusers.model.User;
+
+import java.util.Locale;
+import java.util.Map;
+
+import static java.lang.String.format;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.CONFLICT;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.text.MatchesPattern.matchesPattern;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
+import static uk.gov.pay.adminusers.fixtures.InviteDbFixture.inviteDbFixture;
+import static uk.gov.pay.adminusers.fixtures.RoleDbFixture.roleDbFixture;
+import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
+import static uk.gov.pay.adminusers.fixtures.UserDbFixture.userDbFixture;
+import static uk.gov.pay.adminusers.persistence.entity.Role.ADMIN;
+
+class InviteResourceCreateInviteToJoinServiceIT extends IntegrationTest {
+
+    private static final String CREATE_INVITE_TO_JOIN_SERVICE_RESOURCE_URL = "/v1/api/invites/create-invite-to-join-service";
+    
+    private Service service;
+    private String roleAdminName;
+    private String senderExternalId;
+
+    @BeforeEach
+    void givenAnExistingServiceAndARole() {
+
+        service = serviceDbFixture(databaseHelper)
+                .insertService();
+
+        roleAdminName = roleDbFixture(databaseHelper)
+                .insertAdmin().getName();
+
+        String username = randomUuid();
+        String email = username + "@example.com";
+        senderExternalId = userDbFixture(databaseHelper)
+                .withServiceRole(service.getId(), ADMIN.getId())
+                .withUsername(username)
+                .withEmail(email)
+                .insertUser()
+                .getExternalId();
+    }
+
+    @Test
+    void createInvitation_shouldSucceed_whenInvitingANewUser() throws Exception {
+
+        String email = randomAlphanumeric(5) + "-invite@example.com";
+
+        Map<Object, Object> invitationRequest = Map.of(
+                "sender", senderExternalId,
+                "email", email,
+                "role_name", roleAdminName,
+                "service_external_id", service.getExternalId());
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(invitationRequest))
+                .contentType(ContentType.JSON)
+                .post(CREATE_INVITE_TO_JOIN_SERVICE_RESOURCE_URL)
+                .then()
+                .statusCode(CREATED.getStatusCode())
+                .body("email", is(email.toLowerCase(Locale.ENGLISH)))
+                .body("telephone_number", is(nullValue()))
+                .body("_links", hasSize(1))
+                .body("_links[0].href", matchesPattern("^https://selfservice.pymnt.localdomain/invites/[0-9a-z]{32}$"))
+                .body("_links[0].method", is("GET"))
+                .body("_links[0].rel", is("invite"));
+    }
+
+    @Test
+    void createInvitation_shouldFail_whenAnInviteWithTheGivenEmailAlreadyExists() throws Exception {
+
+        String existingUserEmail = randomAlphanumeric(5) + "-invite@example.com";
+
+        String serviceExternalId = randomUuid();
+        inviteDbFixture(databaseHelper)
+                .withEmail(existingUserEmail)
+                .withServiceExternalId(serviceExternalId)
+                .insertInviteToAddUserToService();
+
+        Map<Object, Object> invitationRequest = Map.of(
+                "sender", senderExternalId,
+                "email", existingUserEmail,
+                "role_name", roleAdminName,
+                "service_external_id", serviceExternalId);
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(invitationRequest))
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .post(CREATE_INVITE_TO_JOIN_SERVICE_RESOURCE_URL)
+                .then()
+                .statusCode(CONFLICT.getStatusCode())
+                .body("errors", hasSize(1))
+                .body("errors", hasItems(format("invite with email [%s] already exists", existingUserEmail)));
+    }
+
+    @Test
+    void createInvitation_shouldFail_ifUserAlreadyBelongToService() throws Exception {
+
+        String existingUserUsername = randomUuid();
+        String existingUserEmail = existingUserUsername + "-invite@example.com";
+
+        String serviceExternalId = randomUuid();
+        Integer serviceId = randomInt();
+        inviteDbFixture(databaseHelper)
+                .withEmail(existingUserEmail)
+                .withServiceExternalId(serviceExternalId)
+                .withServiceId(serviceId)
+                .insertInviteToAddUserToService();
+        User user = userDbFixture(databaseHelper)
+                .withUsername(existingUserUsername)
+                .withEmail(existingUserEmail)
+                .withServiceRole(Service.from(serviceId, serviceExternalId, new ServiceName("service name")), 2)
+                .insertUser();
+
+
+        Map<Object, Object> invitationRequest = Map.of(
+                "sender", senderExternalId,
+                "email", existingUserEmail,
+                "role_name", roleAdminName,
+                "service_external_id", serviceExternalId);
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(invitationRequest))
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .post(CREATE_INVITE_TO_JOIN_SERVICE_RESOURCE_URL)
+                .then()
+                .statusCode(PRECONDITION_FAILED.getStatusCode())
+                .body("errors", hasSize(1))
+                .body("errors", hasItems(format("user [%s] already in service [%s]", user.getExternalId(), serviceExternalId)));
+    }
+
+    @Test
+    void createInvitation_shouldFail_whenServiceDoesNotExist() throws Exception {
+
+        String nonExistentServiceId = "non existant service external id";
+        Map<Object, Object> invitationRequest = Map.of(
+                "sender", senderExternalId,
+                "email", randomAlphanumeric(5) + "-invite@example.com",
+                "role_name", roleAdminName,
+                "service_external_id", nonExistentServiceId);
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(invitationRequest))
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .post(CREATE_INVITE_TO_JOIN_SERVICE_RESOURCE_URL)
+                .then()
+                .statusCode(NOT_FOUND.getStatusCode());
+    }
+
+    @Test
+    void createInvitation_shouldFail_whenRoleDoesNotExist() throws Exception {
+
+        Map<Object, Object> invitationRequest = Map.of(
+                "sender", senderExternalId,
+                "email", randomAlphanumeric(5) + "-invite@example.com",
+                "role_name", "non-existing-role",
+                "service_external_id", service.getExternalId());
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(invitationRequest))
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .post(CREATE_INVITE_TO_JOIN_SERVICE_RESOURCE_URL)
+                .then()
+                .statusCode(BAD_REQUEST.getStatusCode())
+                .body("errors", hasSize(1))
+                .body("errors", hasItems("role [non-existing-role] not recognised"));
+    }
+
+    @Test
+    void createInvitation_shouldFail_whenSenderDoesNotExist() throws Exception {
+
+        String email = randomAlphanumeric(5) + "-invite@example.com";
+
+        Map<Object, Object> invitationRequest = Map.of(
+                "sender", "does-not-exist",
+                "email", email,
+                "role_name", roleAdminName,
+                "service_external_id", service.getExternalId());
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(invitationRequest))
+                .contentType(ContentType.JSON)
+                .post(CREATE_INVITE_TO_JOIN_SERVICE_RESOURCE_URL)
+                .then()
+                .statusCode(FORBIDDEN.getStatusCode());
+    }
+
+    @Test
+    void createInvitation_shouldFail_whenSenderDoesNotHaveAdminRole() throws Exception {
+
+        int otherRoleId = roleDbFixture(databaseHelper).insertRole().getId();
+        String senderUsername = randomUuid();
+        String senderEmail = senderUsername + "@example.com";
+        String senderWithNoAdminRole = userDbFixture(databaseHelper)
+                .withServiceRole(service.getId(), otherRoleId)
+                .withUsername(senderUsername)
+                .withEmail(senderEmail)
+                .insertUser().getExternalId();
+
+        Map<Object, Object> invitationRequest = Map.of(
+                "sender", senderWithNoAdminRole,
+                "email", randomUuid() + "-invite@example.com",
+                "role_name", roleAdminName,
+                "service_external_id", service.getExternalId());
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(invitationRequest))
+                .contentType(ContentType.JSON)
+                .post(CREATE_INVITE_TO_JOIN_SERVICE_RESOURCE_URL)
+                .then()
+                .statusCode(FORBIDDEN.getStatusCode());
+
+    }
+
+    @Test
+    void createInvitation_shouldFail_whenSenderDoesNotBelongToTheGivenService() throws Exception {
+
+        Service otherService = serviceDbFixture(databaseHelper)
+                .insertService();
+
+        String senderUsername = randomUuid();
+        String senderEmail = senderUsername + "@example.com";
+        String senderExternalId = userDbFixture(databaseHelper)
+                .withServiceRole(otherService.getId(), ADMIN.getId())
+                .withUsername(senderUsername)
+                .withEmail(senderEmail)
+                .insertUser().getExternalId();
+
+        Map<Object, Object> invitationRequest = Map.of(
+                "sender", senderExternalId,
+                "email", randomUuid() + "-invite@example.com",
+                "role_name", roleAdminName,
+                "service_external_id", service.getExternalId());
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(invitationRequest))
+                .contentType(ContentType.JSON)
+                .post(CREATE_INVITE_TO_JOIN_SERVICE_RESOURCE_URL)
+                .then()
+                .statusCode(FORBIDDEN.getStatusCode());
+    }
+
+    @Test
+    void createInvitation_shouldFail_whenMissingMandatoryFields() throws Exception {
+        Map<Object, Object> invitationRequest = Map.of();
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(invitationRequest))
+                .contentType(ContentType.JSON)
+                .post(CREATE_INVITE_TO_JOIN_SERVICE_RESOURCE_URL)
+                .then()
+                .statusCode(422)
+                .body("errors", hasSize(4))
+                .body("errors", hasItems(
+                        "serviceExternalId must not be empty",
+                        "roleName must not be empty",
+                        "sender must not be empty",
+                        "email must not be empty"
+                ));
+    }
+
+    @Test
+    void createInvitation_shouldFail_whenInvalidEmail() throws Exception {
+        Map<Object, Object> invitationRequest = Map.of(
+                "sender", senderExternalId,
+                "email", "invalid",
+                "role_name", roleAdminName,
+                "service_external_id", service.getExternalId());
+        
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(invitationRequest))
+                .contentType(ContentType.JSON)
+                .post(CREATE_INVITE_TO_JOIN_SERVICE_RESOURCE_URL)
+                .then()
+                .statusCode(422)
+                .body("errors", hasSize(1))
+                .body("errors", hasItems("email must be a well-formed email address"));
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateSelfRegistrationInviteIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateSelfRegistrationInviteIT.java
@@ -1,0 +1,109 @@
+package uk.gov.pay.adminusers.resources;
+
+
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.adminusers.fixtures.UserDbFixture;
+
+import java.util.Locale;
+import java.util.Map;
+
+import static javax.ws.rs.core.Response.Status.CONFLICT;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.text.MatchesPattern.matchesPattern;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
+
+class InviteResourceCreateSelfRegistrationInviteIT extends IntegrationTest {
+
+    public static final String CREATE_SELF_REGISTRATION_INVITE_URL = "/v1/api/invites/create-self-registration-invite";
+
+    @Test
+    void shouldSuccess_WhenAllRequiredFieldsAreProvidedAndValid() throws Exception {
+        String email = "example@example.gov.uk";
+        Map<String, String> payload = Map.of("email", email);
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(payload))
+                .contentType(ContentType.JSON)
+                .post(CREATE_SELF_REGISTRATION_INVITE_URL)
+                .then()
+                .statusCode(CREATED.getStatusCode())
+                .body("email", is(email.toLowerCase(Locale.ENGLISH)))
+                .body("_links", hasSize(2))
+                .body("_links[0].href", matchesPattern("^https://selfservice.pymnt.localdomain/invites/[0-9a-z]{32}$"))
+                .body("_links[0].method", is("GET"))
+                .body("_links[0].rel", is("invite"));
+    }
+
+    @Test
+    void shouldFail_WhenMandatoryFieldsAreMissing() throws Exception {
+        Map<String, String> payload = Map.of();
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(payload))
+                .contentType(ContentType.JSON)
+                .post(CREATE_SELF_REGISTRATION_INVITE_URL)
+                .then()
+                .statusCode(422)
+                .body("errors", hasSize(1))
+                .body("errors", hasItems("email must not be empty"));
+    }
+
+    @Test
+    void shouldFail_WhenEmailIsInvalid() throws Exception {
+        Map<String, String> payload = Map.of("email", "invalid");
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(payload))
+                .contentType(ContentType.JSON)
+                .post(CREATE_SELF_REGISTRATION_INVITE_URL)
+                .then()
+                .statusCode(422)
+                .body("errors", hasSize(1))
+                .body("errors", hasItems("email must be a well-formed email address"));
+    }
+
+    @Test
+    void shouldFail_WhenEmailIsNotPublicSectorDomain() throws Exception {
+        String email = "example@example.com";
+        Map<String, String> payload = Map.of("email", email);
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(payload))
+                .contentType(ContentType.JSON)
+                .post(CREATE_SELF_REGISTRATION_INVITE_URL)
+                .then()
+                .statusCode(FORBIDDEN.getStatusCode())
+                .body("errors", hasSize(1))
+                .body("errors", hasItems("Email [" + email + "] is not a valid public sector email"));
+    }
+
+    @Test
+    void shouldFail_WhenEmailIsAlreadyRegistered() throws Exception {
+
+        String username = randomUuid();
+        String email = username + "@example.gov.uk";
+        UserDbFixture.userDbFixture(databaseHelper).withUsername(username).withEmail(email).insertUser();
+
+        Map<String, String> payload = Map.of("email", email);
+
+        givenSetup()
+                .when()
+                .body(mapper.writeValueAsString(payload))
+                .contentType(ContentType.JSON)
+                .post(CREATE_SELF_REGISTRATION_INVITE_URL)
+                .then()
+                .statusCode(CONFLICT.getStatusCode())
+                .body("errors", hasSize(1))
+                .body("errors", hasItems("email [" + email + "] already exists"));
+    }
+
+}


### PR DESCRIPTION
We want to change the names of these endpoints as follows:

/v1/api/invites/service → /v1/api/invites/create-self-registration-invite /v1/api/invites/user → /v1/api/invites/create-invite-to-join-service

We are adding the new endpoints so that we can later delete the old endpoints once self-service is using the new ones.

The names of some service classes and methods have been updated in line with these changes.