### PR TITLE
PP-10338: Add `isInviteToJoinService` to `Invite` object

### DIFF
--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -1293,6 +1293,9 @@ components:
         inviteLink:
           type: string
           writeOnly: true
+        invite_to_join_service:
+          type: boolean
+          example: true
         otp_key:
           type: string
           example: ABC123

--- a/src/main/java/uk/gov/pay/adminusers/model/Invite.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Invite.java
@@ -23,6 +23,7 @@ public class Invite {
     private Integer attemptCounter = 0;
 
     private List<Link> links = new ArrayList<>();
+    private boolean isInviteToJoinService;
     private String type;
     private boolean userExist = false;
     private boolean expired;
@@ -35,6 +36,7 @@ public class Invite {
                   String telephoneNumber,
                   Boolean disabled,
                   Integer attemptCounter,
+                  boolean isInviteToJoinService,
                   String type,
                   String role,
                   Boolean expired,
@@ -45,6 +47,7 @@ public class Invite {
         this.telephoneNumber = telephoneNumber;
         this.disabled = disabled;
         this.attemptCounter = attemptCounter;
+        this.isInviteToJoinService = isInviteToJoinService;
         this.type = type;
         this.role = role;
         this.expired = expired;
@@ -100,6 +103,11 @@ public class Invite {
     public void setInviteLink(String targetUrl) {
         Link inviteLink = Link.from(Link.Rel.INVITE, "GET", targetUrl);
         this.links.add(inviteLink);
+    }
+    
+    @Schema(example = "true")
+    public boolean isInviteToJoinService() {
+        return isInviteToJoinService;
     }
 
     @Schema(example = "service")

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
@@ -212,17 +212,13 @@ public class InviteEntity extends AbstractEntity {
         this.type = type;
     }
 
-    public boolean isServiceType() {
-        return InviteType.SERVICE.equals(type);
-    }
-
-    public boolean isUserType() {
-        return InviteType.USER.equals(type);
+    public boolean isInviteToJoinService() {
+        return getService().isPresent();
     }
 
     public Invite toInvite() {
         String roleName = getRole().map(RoleEntity::getName).orElse(null);
-        return new Invite(code, email, telephoneNumber, disabled, loginCounter, type.getType(), roleName, isExpired(),
+        return new Invite(code, email, telephoneNumber, disabled, loginCounter, isInviteToJoinService(), type.getType(), roleName, isExpired(),
                 hasPassword(), otpKey);
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/service/InviteService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/InviteService.java
@@ -189,15 +189,4 @@ public class InviteService {
         return newUser;
     }
 
-    private static OtpNotifySmsTemplateId mapInviteTypeToOtpNotifySmsTemplateId(InviteType inviteType) {
-        switch (inviteType) {
-            case SERVICE:
-                return SELF_INITIATED_CREATE_NEW_USER_AND_SERVICE;
-            case USER:
-                return CREATE_USER_IN_RESPONSE_TO_INVITATION_TO_SERVICE;
-            default:
-                throw new IllegalArgumentException("Unrecognised InviteType: " + inviteType.name());
-        }
-    }
-
 }

--- a/src/main/java/uk/gov/pay/adminusers/service/SelfRegistrationInviteCreator.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/SelfRegistrationInviteCreator.java
@@ -72,7 +72,7 @@ public class SelfRegistrationInviteCreator {
         List<InviteEntity> exitingInvites = inviteDao.findByEmail(requestEmail);
         List<InviteEntity> existingValidServiceInvitesForSameEmail = exitingInvites.stream()
                 .filter(inviteEntity -> !inviteEntity.isDisabled() && !inviteEntity.isExpired())
-                .filter(InviteEntity::isServiceType).collect(toUnmodifiableList());
+                .filter(inviteEntity -> !inviteEntity.isInviteToJoinService()).collect(toUnmodifiableList());
 
         if (!existingValidServiceInvitesForSameEmail.isEmpty()) {
             InviteEntity foundInvite = existingValidServiceInvitesForSameEmail.get(0);

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateInviteToJoinServiceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateInviteToJoinServiceIT.java
@@ -78,6 +78,7 @@ class InviteResourceCreateInviteToJoinServiceIT extends IntegrationTest {
                 .statusCode(CREATED.getStatusCode())
                 .body("email", is(email.toLowerCase(Locale.ENGLISH)))
                 .body("telephone_number", is(nullValue()))
+                .body("invite_to_join_service", is(true))
                 .body("_links", hasSize(1))
                 .body("_links[0].href", matchesPattern("^https://selfservice.pymnt.localdomain/invites/[0-9a-z]{32}$"))
                 .body("_links[0].method", is("GET"))

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateSelfRegistrationInviteIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateSelfRegistrationInviteIT.java
@@ -34,6 +34,7 @@ class InviteResourceCreateSelfRegistrationInviteIT extends IntegrationTest {
                 .then()
                 .statusCode(CREATED.getStatusCode())
                 .body("email", is(email.toLowerCase(Locale.ENGLISH)))
+                .body("invite_to_join_service", is(false))
                 .body("_links", hasSize(2))
                 .body("_links[0].href", matchesPattern("^https://selfservice.pymnt.localdomain/invites/[0-9a-z]{32}$"))
                 .body("_links[0].method", is("GET"))

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGetIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGetIT.java
@@ -35,7 +35,8 @@ class InviteResourceGetIT extends IntegrationTest {
                 .body("user_exist", is(false))
                 .body("attempt_counter", is(0))
                 .body("password_set", is(false))
-                .body("otp_key", is(otpKey));
+                .body("otp_key", is(otpKey))
+                .body("invite_to_join_service", is(true));
     }
 
     @Test
@@ -62,7 +63,8 @@ class InviteResourceGetIT extends IntegrationTest {
                 .body("email", is(email))
                 .body("telephone_number", is(telephoneNumber))
                 .body("disabled", is(false))
-                .body("attempt_counter", is(0));
+                .body("attempt_counter", is(0))
+                .body("invite_to_join_service", is(true));
     }
 
     @Test
@@ -122,7 +124,8 @@ class InviteResourceGetIT extends IntegrationTest {
                 .body("[0].expired", is(false))
                 .body("[0].user_exist", is(false))
                 .body("[0].attempt_counter", is(0))
-                .body("[0].password_set", is(false));
+                .body("[0].password_set", is(false))
+                .body("[0].invite_to_join_service", is(true));
     }
 
 }

--- a/src/test/java/uk/gov/pay/adminusers/service/JoinServiceInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/JoinServiceInviteCreatorTest.java
@@ -10,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.adminusers.app.config.LinksConfig;
 import uk.gov.pay.adminusers.model.Invite;
 import uk.gov.pay.adminusers.model.CreateInviteToJoinServiceRequest;
+import uk.gov.pay.adminusers.model.InviteType;
 import uk.gov.pay.adminusers.model.SecondFactorMethod;
 import uk.gov.pay.adminusers.model.Service;
 import uk.gov.pay.adminusers.model.ServiceName;
@@ -101,6 +102,8 @@ class JoinServiceInviteCreatorTest {
         assertThat(savedInvite.getEmail(), is(email));
         assertThat(savedInvite.getOtpKey(), is(otpKey));
         assertThat(savedInvite.getCode(), is(notNullValue()));
+        assertThat(savedInvite.isInviteToJoinService(), is(true));
+        assertThat(savedInvite.getType(), is(InviteType.USER));
     }
 
     @Test
@@ -131,6 +134,8 @@ class JoinServiceInviteCreatorTest {
         assertThat(savedInvite.getEmail(), is(email));
         assertThat(savedInvite.getOtpKey(), is(otpKey));
         assertThat(savedInvite.getCode(), is(notNullValue()));
+        assertThat(savedInvite.isInviteToJoinService(), is(true));
+        assertThat(savedInvite.getType(), is(InviteType.USER));
     }
 
     @Test
@@ -202,6 +207,8 @@ class JoinServiceInviteCreatorTest {
         assertThat(invite.isPresent(), is(true));
         assertThat(invite.get().getCode(), is(anInvite.getCode()));
         assertThat(invite.get().getEmail(), is(anInvite.getEmail()));
+        assertThat(invite.get().isInviteToJoinService(), is(true));
+        assertThat(invite.get().getType(), is("user"));
     }
 
     @Test
@@ -230,6 +237,8 @@ class JoinServiceInviteCreatorTest {
         assertThat(invite.isPresent(), is(true));
         assertThat(invite.get().getCode(), is(anInvite.getCode()));
         assertThat(invite.get().getEmail(), is(anInvite.getEmail()));
+        assertThat(invite.get().isInviteToJoinService(), is(true));
+        assertThat(invite.get().getType(), is("user"));
     }
 
     @Test
@@ -248,6 +257,8 @@ class JoinServiceInviteCreatorTest {
         assertThat(invite.isPresent(), is(true));
         assertThat(invite.get().getCode(), is(anInvite.getCode()));
         assertThat(invite.get().getEmail(), is(anInvite.getEmail()));
+        assertThat(invite.get().isInviteToJoinService(), is(true));
+        assertThat(invite.get().getType(), is("user"));
     }
 
     @Test
@@ -283,6 +294,8 @@ class JoinServiceInviteCreatorTest {
         assertThat(invite.isPresent(), is(true));
         assertThat(invite.get().getCode(), is(validInvite.getCode()));
         assertThat(invite.get().getEmail(), is(validInvite.getEmail()));
+        assertThat(invite.get().isInviteToJoinService(), is(true));
+        assertThat(invite.get().getType(), is("user"));
     }
 
     private InviteEntity mockInviteSuccessExistingInvite() {

--- a/src/test/java/uk/gov/pay/adminusers/service/SelfRegistrationInviteCreatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/SelfRegistrationInviteCreatorTest.java
@@ -77,6 +77,7 @@ class SelfRegistrationInviteCreatorTest {
 
         verify(inviteDao, times(1)).persist(persistedInviteEntity.capture());
         assertThat(invite.getEmail(), is(request.getEmail()));
+        assertThat(invite.isInviteToJoinService(), is(false));
         assertThat(invite.getType(), is("service"));
         assertThat(invite.getLinks().get(0).getHref(), matchesPattern("^http://selfservice/invites/[0-9a-z]{32}$"));
     }
@@ -95,6 +96,7 @@ class SelfRegistrationInviteCreatorTest {
 
         verify(inviteDao, times(1)).persist(persistedInviteEntity.capture());
         assertThat(invite.getEmail(), is(request.getEmail()));
+        assertThat(invite.isInviteToJoinService(), is(false));
         assertThat(invite.getType(), is("service"));
         assertThat(invite.getLinks().get(0).getHref(), matchesPattern("^http://selfservice/invites/[0-9a-z]{32}$"));
 
@@ -105,10 +107,8 @@ class SelfRegistrationInviteCreatorTest {
         String email = "email@example.gov.uk";
         CreateSelfRegistrationInviteRequest request = new CreateSelfRegistrationInviteRequest(email);
         UserEntity sender = mock(UserEntity.class);
-        ServiceEntity service = mock(ServiceEntity.class);
         RoleEntity role = mock(RoleEntity.class);
         InviteEntity validInvite = new InviteEntity(email, "code", "otpKey", role);
-        validInvite.setService(service);
         validInvite.setSender(sender);
         validInvite.setType(InviteType.SERVICE);
 
@@ -122,6 +122,7 @@ class SelfRegistrationInviteCreatorTest {
 
         verify(inviteDao, times(1)).merge(persistedInviteEntity.capture());
         assertThat(invite.getEmail(), is(request.getEmail()));
+        assertThat(invite.isInviteToJoinService(), is(false));
         assertThat(invite.getType(), is("service"));
         assertThat(invite.getLinks().get(0).getHref(), is("http://selfservice/invites/code"));
     }
@@ -148,6 +149,7 @@ class SelfRegistrationInviteCreatorTest {
         Invite invite = selfRegistrationInviteCreator.doInvite(request);
 
         assertThat(invite.getEmail(), is(request.getEmail()));
+        assertThat(invite.isInviteToJoinService(), is(false));
         assertThat(invite.getType(), is("service"));
         assertThat(invite.getLinks().get(0).getHref().matches("^http://selfservice/invites/[0-9a-z]{32}$"), is(true));
     }


### PR DESCRIPTION
Endpoints which return an invite will now include this flag, which will soon be used instead of the `type` field, so that we can delete the latter.