### PR TITLE
PP-10338: Rename invite_to_join_service flag

### DIFF
--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -1248,7 +1248,7 @@ components:
         inviteLink:
           type: string
           writeOnly: true
-        invite_to_join_service:
+        is_invite_to_join_service:
           type: boolean
           example: true
         otp_key:

--- a/src/main/java/uk/gov/pay/adminusers/model/Invite.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Invite.java
@@ -106,6 +106,7 @@ public class Invite {
     }
     
     @Schema(example = "true")
+    @JsonProperty("is_invite_to_join_service")
     public boolean isInviteToJoinService() {
         return isInviteToJoinService;
     }

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateInviteToJoinServiceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateInviteToJoinServiceIT.java
@@ -78,7 +78,7 @@ class InviteResourceCreateInviteToJoinServiceIT extends IntegrationTest {
                 .statusCode(CREATED.getStatusCode())
                 .body("email", is(email.toLowerCase(Locale.ENGLISH)))
                 .body("telephone_number", is(nullValue()))
-                .body("invite_to_join_service", is(true))
+                .body("is_invite_to_join_service", is(true))
                 .body("_links", hasSize(1))
                 .body("_links[0].href", matchesPattern("^https://selfservice.pymnt.localdomain/invites/[0-9a-z]{32}$"))
                 .body("_links[0].method", is("GET"))

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateSelfRegistrationInviteIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceCreateSelfRegistrationInviteIT.java
@@ -34,7 +34,7 @@ class InviteResourceCreateSelfRegistrationInviteIT extends IntegrationTest {
                 .then()
                 .statusCode(CREATED.getStatusCode())
                 .body("email", is(email.toLowerCase(Locale.ENGLISH)))
-                .body("invite_to_join_service", is(false))
+                .body("is_invite_to_join_service", is(false))
                 .body("_links", hasSize(2))
                 .body("_links[0].href", matchesPattern("^https://selfservice.pymnt.localdomain/invites/[0-9a-z]{32}$"))
                 .body("_links[0].method", is("GET"))

--- a/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGetIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/InviteResourceGetIT.java
@@ -36,7 +36,7 @@ class InviteResourceGetIT extends IntegrationTest {
                 .body("attempt_counter", is(0))
                 .body("password_set", is(false))
                 .body("otp_key", is(otpKey))
-                .body("invite_to_join_service", is(true));
+                .body("is_invite_to_join_service", is(true));
     }
 
     @Test
@@ -64,7 +64,7 @@ class InviteResourceGetIT extends IntegrationTest {
                 .body("telephone_number", is(telephoneNumber))
                 .body("disabled", is(false))
                 .body("attempt_counter", is(0))
-                .body("invite_to_join_service", is(true));
+                .body("is_invite_to_join_service", is(true));
     }
 
     @Test
@@ -125,7 +125,7 @@ class InviteResourceGetIT extends IntegrationTest {
                 .body("[0].user_exist", is(false))
                 .body("[0].attempt_counter", is(0))
                 .body("[0].password_set", is(false))
-                .body("[0].invite_to_join_service", is(true));
+                .body("[0].is_invite_to_join_service", is(true));
     }
 
 }


### PR DESCRIPTION
`Invite#isInviteToJoinService` was getting exported as `invite_to_join_service`, which reads a bit strangely as 'invite' sounds like a verb; export it as `is_invite_to_join_service` instead.