### PR TITLE
BAU: Pin Java base image to v11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
+  ignore:
+  - dependency-name: "eclipse-temurin"
+    versions:
+    - "> 11"
   open-pull-requests-limit: 10
   labels:
   - dependencies
@@ -25,11 +29,15 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
+  ignore:
+  - dependency-name: "eclipse-temurin"
+    versions:
+    - "> 11"
   open-pull-requests-limit: 10
   labels:
   - dependencies
   - govuk-pay
-  - docker  
+  - docker
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
## WHAT YOU DID
Dependabot is keen to update to `eclipse-temurin:20-jre` - we're happy with `11-jre` for the moment.
