### PR TITLE
PP-10888 Add username to forgotten password response

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -192,14 +192,14 @@
         "filename": "src/main/java/uk/gov/pay/adminusers/model/ForgottenPassword.java",
         "hashed_secret": "675fecb5af336276574d3d88a4d382d961cf7418",
         "is_verified": false,
-        "line_number": 46
+        "line_number": 49
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/main/java/uk/gov/pay/adminusers/model/ForgottenPassword.java",
         "hashed_secret": "3660e32cde5fccc8d1e4521d0c831c2012388720",
         "is_verified": false,
-        "line_number": 57
+        "line_number": 60
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/model/InviteOtpRequest.java": [
@@ -335,7 +335,7 @@
         "filename": "src/test/java/uk/gov/pay/adminusers/pact/ContractTest.java",
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_verified": false,
-        "line_number": 73
+        "line_number": 75
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/persistence/dao/GovUkPayAgreementDaoIT.java": [
@@ -484,5 +484,5 @@
       }
     ]
   },
-  "generated_at": "2022-12-19T11:54:47Z"
+  "generated_at": "2023-04-05T11:15:21Z"
 }

--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -1215,6 +1215,9 @@ components:
         user_external_id:
           type: string
           example: 12e3eccfab284ae5bc1108e9c0456ba7
+        username:
+          type: string
+          example: username@example.gov.uk
     GovUkPayAgreement:
       type: object
       properties:

--- a/src/main/java/uk/gov/pay/adminusers/model/ForgottenPassword.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/ForgottenPassword.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.service.payments.commons.api.json.ApiResponseDateTimeSerializer;
 
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 
@@ -18,25 +18,28 @@ import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
 public class ForgottenPassword {
 
     @JsonIgnore
-    private Integer id;
-    private String code;
-    private ZonedDateTime date;
-    private String userExternalId;
+    private final Integer id;
+    private final String code;
+    private final ZonedDateTime date;
+    private final String userExternalId;
+    private final String username;
     private List<Link> links;
 
-    public static ForgottenPassword forgottenPassword(String code, String userExternalId) {
-        return forgottenPassword(randomInt(), code, ZonedDateTime.now(ZoneId.of("UTC")), userExternalId);
+    public static ForgottenPassword forgottenPassword(String code, String userExternalId, String username) {
+        return forgottenPassword(randomInt(), code, ZonedDateTime.now(ZoneOffset.UTC), userExternalId, username);
     }
 
-    public static ForgottenPassword forgottenPassword(Integer id, String code, ZonedDateTime date, String userExternalId) {
-        return new ForgottenPassword(id, code, date, userExternalId);
+    public static ForgottenPassword forgottenPassword(Integer id, String code, ZonedDateTime date,
+                                                      String userExternalId, String username) {
+        return new ForgottenPassword(id, code, date, userExternalId, username);
     }
 
-    private ForgottenPassword(Integer id, String code, ZonedDateTime date, String userExternalId) {
+    private ForgottenPassword(Integer id, String code, ZonedDateTime date, String userExternalId, String username) {
         this.id = id;
         this.code = code;
         this.date = date;
         this.userExternalId = userExternalId;
+        this.username = username;
     }
 
     public Integer getId() {
@@ -57,6 +60,11 @@ public class ForgottenPassword {
     @Schema(example = "12e3eccfab284ae5bc1108e9c0456ba7")
     public String getUserExternalId() {
         return userExternalId;
+    }
+
+    @Schema(example = "username@example.gov.uk")
+    public String getUsername() {
+        return username;
     }
 
     public void setLinks(List<Link> links) {

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ForgottenPasswordEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ForgottenPasswordEntity.java
@@ -105,6 +105,6 @@ public class ForgottenPasswordEntity extends AbstractEntity {
     }
 
     public ForgottenPassword toForgottenPassword() {
-        return forgottenPassword(getId(), code, date, user.getExternalId());
+        return forgottenPassword(getId(), code, date, user.getExternalId(), user.getUsername());
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/ForgottenPasswordDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/ForgottenPasswordDbFixture.java
@@ -28,7 +28,8 @@ public class ForgottenPasswordDbFixture {
     }
 
     public String insertForgottenPassword() {
-        databaseTestHelper.add(forgottenPassword(nextInt(), forgottenPasswordCode, date, RandomIdGenerator.randomUuid()), userId);
+        databaseTestHelper.add(forgottenPassword(nextInt(), forgottenPasswordCode, date, RandomIdGenerator.randomUuid(),
+                RandomIdGenerator.randomUuid() + "@test.test"), userId);
         return forgottenPasswordCode;
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/pact/ContractTest.java
@@ -55,9 +55,11 @@ public abstract class ContractTest {
     public void aUserExistsWithAForgottenPasswordRequest() {
         String code = "avalidforgottenpasswordtoken";
         String userExternalId = randomUuid();
-        createUserWithinAService(userExternalId, randomUuid(), "password", "cp5wa");
+        String username = "username";
+        createUserWithinAService(userExternalId, username, "password", "cp5wa");
         List<Map<String, Object>> userByExternalId = dbHelper.findUserByExternalId(userExternalId);
-        dbHelper.add(ForgottenPassword.forgottenPassword(code, userExternalId), (Integer) userByExternalId.get(0).get("id"));
+        dbHelper.add(ForgottenPassword.forgottenPassword(code, userExternalId ,username),
+                (Integer) userByExternalId.get(0).get("id"));
     }
 
     @State("a user exists with max login attempts")
@@ -71,9 +73,11 @@ public abstract class ContractTest {
     public void aForgottenPasswordEntryExist() {
         String code = "existing-code";
         String existingUserExternalId = "7d19aff33f8948deb97ed16b2912dcd3";
-        createUserWithinAService(existingUserExternalId, "forgotten-password-user", "password", "cp5wa");
+        String username = "forgotten-password-user";
+        createUserWithinAService(existingUserExternalId, username, "password", "cp5wa");
         List<Map<String, Object>> userByName = dbHelper.findUserByExternalId(existingUserExternalId);
-        dbHelper.add(ForgottenPassword.forgottenPassword(code, existingUserExternalId), (Integer) userByName.get(0).get("id"));
+        dbHelper.add(ForgottenPassword.forgottenPassword(code, existingUserExternalId, username),
+                (Integer) userByName.get(0).get("id"));
     }
 
     @State("a user and user admin exists in service with the given ids before a delete operation")

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/ForgottenPasswordDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/ForgottenPasswordDaoIT.java
@@ -47,7 +47,7 @@ public class ForgottenPasswordDaoIT extends DaoTestBase {
         String userExternalId = user.getExternalId();
         UserEntity userEntity = userDao.findByExternalId(userExternalId).get();
 
-        ForgottenPassword forgottenPassword = forgottenPassword(forgottenPasswordCode, userExternalId);
+        ForgottenPassword forgottenPassword = forgottenPassword(forgottenPasswordCode, userExternalId, email);
         ForgottenPasswordEntity forgottenPasswordEntity = ForgottenPasswordEntity.from(forgottenPassword, userEntity);
 
         forgottenPasswordDao.persist(forgottenPasswordEntity);
@@ -73,7 +73,7 @@ public class ForgottenPasswordDaoIT extends DaoTestBase {
         UserEntity userEntity = userDao.findByExternalId(userExternalId).get();
 
         ZonedDateTime notExpired = ZonedDateTime.now().minusMinutes(89);
-        ForgottenPassword forgottenPassword = forgottenPassword(randomInt(), forgottenPasswordCode, notExpired, userExternalId);
+        var forgottenPassword = forgottenPassword(randomInt(), forgottenPasswordCode, notExpired, userExternalId, email);
 
         databaseHelper.add(forgottenPassword, userEntity.getId());
 
@@ -95,7 +95,7 @@ public class ForgottenPasswordDaoIT extends DaoTestBase {
         UserEntity userEntity = userDao.findByExternalId(userExternalId).get();
 
         ZonedDateTime expired = ZonedDateTime.now().minusMinutes(91);
-        ForgottenPassword forgottenPassword = forgottenPassword(randomInt(), forgottenPasswordCode, expired, userExternalId);
+        var forgottenPassword = forgottenPassword(randomInt(), forgottenPasswordCode, expired, userExternalId, email);
 
         databaseHelper.add(forgottenPassword, userEntity.getId());
 
@@ -113,7 +113,7 @@ public class ForgottenPasswordDaoIT extends DaoTestBase {
         UserEntity userEntity = userDao.findByExternalId(userExternalId).get();
 
         ZonedDateTime notExpired = ZonedDateTime.now().minusMinutes(89);
-        ForgottenPassword forgottenPassword = forgottenPassword(randomInt(), forgottenPasswordCode, notExpired, userExternalId);
+        var forgottenPassword = forgottenPassword(randomInt(), forgottenPasswordCode, notExpired, userExternalId, email);
 
         databaseHelper.add(forgottenPassword, userEntity.getId());
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/ForgottenPasswordResourceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ForgottenPasswordResourceIT.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.adminusers.resources;
 
 import org.junit.jupiter.api.Test;
+import uk.gov.pay.adminusers.model.User;
 
 import java.util.Map;
 
@@ -51,9 +52,10 @@ public class ForgottenPasswordResourceIT extends IntegrationTest {
     @Test
     public void shouldGetForgottenPassword_whenGetByCode_forAnExistingForgottenPassword() {
 
-        String username = randomUuid();
-        String email = username + "@example.com";
-        int userId = userDbFixture(databaseHelper).withUsername(username).withEmail(email).insertUser().getId();
+        String email = randomUuid() + "@example.com";
+        User user = userDbFixture(databaseHelper).withUsername(email).withEmail(email).insertUser();
+        Integer userId = user.getId();
+        String userExternalId = user.getExternalId();
         String forgottenPasswordCode = forgottenPasswordDbFixture(databaseHelper, userId).insertForgottenPassword();
 
         givenSetup()
@@ -62,7 +64,9 @@ public class ForgottenPasswordResourceIT extends IntegrationTest {
                 .get(FORGOTTEN_PASSWORDS_RESOURCE_URL + "/" + forgottenPasswordCode)
                 .then()
                 .statusCode(OK.getStatusCode())
-                .body("code", is(forgottenPasswordCode));
+                .body("code", is(forgottenPasswordCode))
+                .body("user_external_id", is(userExternalId))
+                .body("username", is(email));
 
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/service/LinksBuilderTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/LinksBuilderTest.java
@@ -41,7 +41,8 @@ class LinksBuilderTest {
 
     @Test
     void shouldConstruct_forgottenPasswordSelfLinkCorrectly() throws Exception {
-        ForgottenPassword forgottenPassword = ForgottenPassword.forgottenPassword(1, "a-code", ZonedDateTime.now(), "7d19aff33f8948deb97ed16b2912dcd3");
+        var forgottenPassword = ForgottenPassword.forgottenPassword(1, "a-code", ZonedDateTime.now(),
+                "7d19aff33f8948deb97ed16b2912dcd3", "a-username"); // pragma: allowlist secret
         ForgottenPassword decorated = linksBuilder.decorate(forgottenPassword);
 
         String linkJson = objectMapper.writeValueAsString(decorated.getLinks().get(0));


### PR DESCRIPTION
Include a `"username"` property in the JSON response to a request to `/v1/api/forgotten-passwords/{code}` because it’s useful for selfservice to know this when displaying the page that lets the user enter their new password as part of the forgotten password flow.