### PR TITLE
BAU add `junit-vintage-engine` test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -356,6 +356,12 @@
             </exclusions>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+            <version>5.9.3</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
## WHAT YOU DID

- added `junit-vintage-engine` test scoped depedency to resolve breaking changes in `dropwizard` 2.1.5
