### PR TITLE
PP-11265 add unique index to lower email on the users table

### DIFF
--- a/src/main/resources/migrations/00084_alter_table_users_add_unique_index_lower_email.sql
+++ b/src/main/resources/migrations/00084_alter_table_users_add_unique_index_lower_email.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter-table-users-add-lower-email-unique-index
+
+CREATE UNIQUE INDEX lower_case_email_index ON users ((LOWER(email)));
+
+--rollback DROP INDEX lower_case_email_index;


### PR DESCRIPTION
## WHAT YOU DID

The current sql unique constraint on the email column in the users table is not case insensitive. It should be.

Unique constraint lower(email) is not valid PSQL script. It was either unique index or installing citext extension and altering the column type. citext can only be installed by superuser and cannot be done through our usual liquibase script.

- Add unique index to lower(email).
