### PR TITLE
PP-11283 drop not null constraint

### DIFF
--- a/src/main/resources/migrations/00085_alter_table_users_remove_username_not_null_constraint.sql
+++ b/src/main/resources/migrations/00085_alter_table_users_remove_username_not_null_constraint.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter-table-users-remove-username-not-null-constraint
+ALTER TABLE users ALTER COLUMN username DROP NOT NULL;
+
+--rollback ALTER TABLE users ALTER COLUMN username SET NOT NULL;


### PR DESCRIPTION
## WHAT YOU DID
We are removing username column. Before we can drop the column, we need to refactor the code, and that's not possible without dropping the not null constraint

- drop not null constrain for username in users table
