### PR TITLE
PP-11327 remove username from create user

### DIFF
--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -744,7 +744,7 @@ paths:
         "400":
           description: Invalid payload
         "409":
-          description: User with username already exists
+          description: User with email already exists
         "500":
           description: Internal server error
       summary: Create new user

--- a/src/main/java/uk/gov/pay/adminusers/resources/UserRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/UserRequestValidator.java
@@ -26,7 +26,7 @@ import static uk.gov.pay.adminusers.validations.UserPatchValidations.isPathAllow
 
 public class UserRequestValidator {
 
-    private static final int MAX_LENGTH_FIELD_USERNAME = 255;
+    private static final int MAX_LENGTH_FIELD_USER_EMAIL = 254;
     private final RequestValidations requestValidations;
 
     @Inject
@@ -40,7 +40,7 @@ public class UserRequestValidator {
     }
 
     public Optional<Errors> validateCreateRequest(JsonNode payload) {
-        Optional<List<String>> missingMandatoryFields = requestValidations.checkExistsAndNotEmpty(payload, FIELD_USERNAME, FIELD_EMAIL, FIELD_TELEPHONE_NUMBER, FIELD_ROLE_NAME);
+        Optional<List<String>> missingMandatoryFields = requestValidations.checkExistsAndNotEmpty(payload, FIELD_EMAIL, FIELD_TELEPHONE_NUMBER, FIELD_ROLE_NAME);
         if (missingMandatoryFields.isPresent()) {
             return Optional.of(Errors.from(missingMandatoryFields.get()));
         }
@@ -48,7 +48,7 @@ public class UserRequestValidator {
         if (invalidData.isPresent()) {
             return Optional.of(Errors.from(invalidData.get()));
         }
-        Optional<List<String>> invalidLength = requestValidations.checkMaxLength(payload, MAX_LENGTH_FIELD_USERNAME, FIELD_USERNAME);
+        Optional<List<String>> invalidLength = requestValidations.checkMaxLength(payload, MAX_LENGTH_FIELD_USER_EMAIL, FIELD_EMAIL);
         return invalidLength.map(Errors::from);
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
@@ -44,7 +44,7 @@ import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static uk.gov.pay.adminusers.model.User.FIELD_USERNAME;
-import static uk.gov.pay.adminusers.service.AdminUsersExceptions.conflictingUsername;
+import static uk.gov.pay.adminusers.service.AdminUsersExceptions.conflictingEmail;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.internalServerError;
 
 @Path(UserResource.USERS_RESOURCE)
@@ -190,7 +190,7 @@ public class UserResource {
                     @ApiResponse(responseCode = "201", description = "Created",
                             content = @Content(schema = @Schema(implementation = User.class))),
                     @ApiResponse(responseCode = "400", description = "Invalid payload"),
-                    @ApiResponse(responseCode = "409", description = "User with username already exists"),
+                    @ApiResponse(responseCode = "409", description = "User with email already exists"),
                     @ApiResponse(responseCode = "500", description = "Internal server error")
             }
     )
@@ -486,13 +486,13 @@ public class UserResource {
                 });
     }
 
-    private Response handleCreateUserException(String userName, Exception e) {
+    private Response handleCreateUserException(String email, Exception e) {
         if (e.getMessage().contains(CONSTRAINT_VIOLATION_MESSAGE)) {
-            throw conflictingUsername(userName);
+            throw conflictingEmail(email);
         } else if (e instanceof WebApplicationException) {
             throw (WebApplicationException) e;
         } else {
-            LOGGER.error("unknown database error during user creation for user [{}]", userName, e);
+            LOGGER.error("unknown database error during user creation for user [{}]", email, e);
             throw internalServerError("unable to create user at this moment");
         }
     }

--- a/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/AdminUsersExceptions.java
@@ -32,11 +32,6 @@ public class AdminUsersExceptions {
         return buildWebApplicationException(error, PRECONDITION_FAILED.getStatusCode());
     }
 
-    public static WebApplicationException conflictingUsername(String username) {
-        String error = format("username [%s] already exists", username);
-        return buildWebApplicationException(error, CONFLICT.getStatusCode());
-    }
-
     public static WebApplicationException conflictingEmail(String email) {
         String error = format("email [%s] already exists", email);
         return buildWebApplicationException(error, CONFLICT.getStatusCode());

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserRequestValidatorTest.java
@@ -40,9 +40,8 @@ class UserRequestValidatorTest {
         assertTrue(optionalErrors.isPresent());
         Errors errors = optionalErrors.get();
 
-        assertThat(errors.getErrors().size(), is(4));
+        assertThat(errors.getErrors().size(), is(3));
         assertThat(errors.getErrors(), hasItems(
-                "Field [username] is required",
                 "Field [email] is required",
                 "Field [telephone_number] is required",
                 "Field [role_name] is required"));
@@ -51,7 +50,6 @@ class UserRequestValidatorTest {
     @Test
     void shouldError_ifSomeMandatoryFieldsAreMissing() throws Exception {
         String invalidPayload = "{" +
-                "\"username\": \"a-username\"," +
                 "\"email\": \"email@example.com\"," +
                 "\"otp_key\": \"12345\"" +
                 "}";
@@ -211,7 +209,6 @@ class UserRequestValidatorTest {
     @Test
     void shouldError_ifTelephoneNumberFieldIsInvalid() throws Exception {
         String invalidPayload = "{" +
-                "\"username\": \"a-username\"," +
                 "\"password\": \"a-password\"," +
                 "\"email\": \"email@example.com\"," +
                 "\"gateway_account_ids\": [\"1\"]," +
@@ -234,9 +231,8 @@ class UserRequestValidatorTest {
     @Test
     void shouldError_ifFieldsAreBiggerThanMaxLength() throws Exception {
         String invalidPayload = "{" +
-                "\"username\": \"" + RandomStringUtils.randomAlphanumeric(256) + "\"," +
                 "\"password\": \"" + RandomStringUtils.randomAlphanumeric(256) + "\"," +
-                "\"email\": \"email@example.com\"," +
+                "\"email\": \"" + RandomStringUtils.randomAlphanumeric(255) + "\"," +
                 "\"gateway_account_ids\": [\"1\"]," +
                 "\"telephone_number\": \"07990000000\"," +
                 "\"otp_key\": \"12345\"," +
@@ -250,14 +246,13 @@ class UserRequestValidatorTest {
 
         assertThat(errors.getErrors().size(), is(1));
         assertThat(errors.getErrors(), hasItems(
-                "Field [username] must have a maximum length of 255 characters"));
+                "Field [email] must have a maximum length of 254 characters"));
 
     }
 
     @Test
     void shouldReturnEmpty_ifAllValidationsArePassed() throws Exception {
         String validPayload = "{" +
-                "\"username\": \"a-username\"," +
                 "\"password\": \"a-password\"," +
                 "\"email\": \"email@example.com\"," +
                 "\"gateway_account_ids\": [\"1\"]," +

--- a/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/UserResourceCreateIT.java
@@ -28,7 +28,6 @@ public class UserResourceCreateIT extends IntegrationTest {
     public void shouldCreateAUser_Successfully() throws Exception {
         String userEmail = "user-" + randomUuid() + "@example.com";
         Map<Object, Object> userPayload = Map.of(
-                "username", userEmail,
                 "email", userEmail,
                 "telephone_number", "+441134960000",
                 "otp_key", "34f34",
@@ -77,7 +76,6 @@ public class UserResourceCreateIT extends IntegrationTest {
         String userEmail = "user-" + randomUuid() + "@example.com";
 
         Map<Object, Object> userPayload = Map.of(
-                "username", userEmail,
                 "email", userEmail,
                 "service_external_ids", new String[]{valueOf(serviceExternalId)},
                 "telephone_number", "+441134960000",
@@ -125,10 +123,9 @@ public class UserResourceCreateIT extends IntegrationTest {
 
     @Test
     public void shouldError400_IfRoleDoesNotExist() throws Exception {
-        String username = randomUuid();
+        String email = "user-" + randomUuid() + "@example.com";
         Map<Object, Object> userPayload = Map.of(
-                "username", username,
-                "email", "user-" + username + "@example.com",
+                "email", email,
                 "gateway_account_ids", new String[]{"1", "2"},
                 "telephone_number", "01134960000",
                 "otp_key", "34f34",
@@ -158,24 +155,21 @@ public class UserResourceCreateIT extends IntegrationTest {
                 .post(USERS_RESOURCE_URL)
                 .then()
                 .statusCode(400)
-                .body("errors", hasSize(4))
+                .body("errors", hasSize(3))
                 .body("errors", hasItems(
-                        "Field [username] is required",
                         "Field [email] is required",
                         "Field [telephone_number] is required",
                         "Field [role_name] is required"));
     }
 
     @Test
-    public void shouldError409_IfUsernameAlreadyExists() throws Exception {
+    public void shouldError409_IfEmailAlreadyExists() throws Exception {
         String gatewayAccount = valueOf(nextInt());
         serviceDbFixture(databaseHelper).withGatewayAccountIds(gatewayAccount).insertService();
-        String username = randomUuid();
-        String email = username + "@example.com";
+        String email = randomUuid() + "@example.com";
         userDbFixture(databaseHelper).withEmail(email).insertUser();
 
         Map<Object, Object> userPayload = Map.of(
-                "username", username,
                 "email", email,
                 "gateway_account_ids", new String[]{gatewayAccount},
                 "telephone_number", "01134960000",
@@ -190,7 +184,7 @@ public class UserResourceCreateIT extends IntegrationTest {
                 .then()
                 .statusCode(409)
                 .body("errors", hasSize(1))
-                .body("errors[0]", is(format("username [%s] already exists", email)));
+                .body("errors[0]", is(format("email [%s] already exists", email)));
     }
 
 }

--- a/src/test/java/uk/gov/pay/adminusers/service/AdminUsersExceptionsTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/AdminUsersExceptionsTest.java
@@ -21,10 +21,10 @@ public class AdminUsersExceptionsTest {
 
     @Test
     public void shouldCreateAConflictingUsernameException() {
-        WebApplicationException undefinedRoleException = AdminUsersExceptions.conflictingUsername("existing-user");
+        WebApplicationException undefinedRoleException = AdminUsersExceptions.conflictingEmail("existing-user@example.com");
         assertThat(undefinedRoleException.getResponse().getStatus(), is(409));
         Map<String, List<String>> entity = (Map<String, List<String>>) undefinedRoleException.getResponse().getEntity();
-        assertThat(entity.get("errors").get(0), is("username [existing-user] already exists"));
+        assertThat(entity.get("errors").get(0), is("email [existing-user@example.com] already exists"));
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID

We no longer store username, we rely on the user's email. It'd be silly to expect username when creating a new user.

- remove username from user creation requests
- refactor code accordingly
- refactor tests accordingly
