### PR TITLE
PP-11327 switch using email to find a user

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -292,14 +292,14 @@
         "filename": "src/main/java/uk/gov/pay/adminusers/resources/UserResource.java",
         "hashed_secret": "a31519136d26754afeb0df49b5f066f387091f88",
         "is_verified": false,
-        "line_number": 121
+        "line_number": 122
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/main/java/uk/gov/pay/adminusers/resources/UserResource.java",
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_verified": false,
-        "line_number": 440
+        "line_number": 441
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/service/ForgottenPasswordServices.java": [
@@ -466,5 +466,5 @@
       }
     ]
   },
-  "generated_at": "2023-08-03T11:57:12Z"
+  "generated_at": "2023-08-03T16:06:10Z"
 }

--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -813,7 +813,7 @@ paths:
             schema:
               type: string
               example:
-                username: user@somegovernmentdept.gov.uk
+                email: user@somegovernmentdept.gov.uk
       responses:
         "200":
           content:
@@ -825,7 +825,7 @@ paths:
           description: Invalid search params
         "404":
           description: Not found
-      summary: Find user by username
+      summary: Find user by email
       tags:
       - Users
   /v1/api/users/{userExternalId}:

--- a/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
@@ -43,6 +43,7 @@ import static javax.ws.rs.core.Response.Status.CREATED;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
+import static uk.gov.pay.adminusers.model.User.FIELD_EMAIL;
 import static uk.gov.pay.adminusers.model.User.FIELD_USERNAME;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.conflictingEmail;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.internalServerError;
@@ -83,10 +84,10 @@ public class UserResource {
     @Produces(APPLICATION_JSON)
     @Operation(
             tags = "Users",
-            summary = "Find user by username",
+            summary = "Find user by email",
             requestBody = @RequestBody(
                     content = @Content(schema = @Schema(example = "{" +
-                            "    \"username\": \"user@somegovernmentdept.gov.uk\"" +
+                            "    \"email\": \"user@somegovernmentdept.gov.uk\"" +
                             "}"))
             ),
             responses = {
@@ -100,7 +101,7 @@ public class UserResource {
         LOGGER.info("User FIND request");
         return validator.validateFindRequest(payload)
                 .map(errors -> Response.status(BAD_REQUEST).entity(errors).build())
-                .orElseGet(() -> userServices.findUserByEmail(payload.get(FIELD_USERNAME).asText())
+                .orElseGet(() -> userServices.findUserByEmail(payload.get(FIELD_EMAIL).asText())
                         .map(user -> Response.status(OK).type(APPLICATION_JSON).entity(user).build())
                         .orElseGet(() -> Response.status(NOT_FOUND).build()));
     }


### PR DESCRIPTION
## WHAT YOU DID

Adminusers is searching by email.
It makes sense to rename the payload's field to email instead of username.

- rename username to email in findUser
