### PR TITLE
PP-11228: Remove graphite metrics sending and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ The [API Specification](/openapi/adminusers_spec.yaml) provides more detail on t
 | `JPA_LOG_LEVEL`                                                               | The logging level to set for JPA. Defaults to `WARNING`. |
 | `JPA_SQL_LOG_LEVEL`                                                           | The logging level to set for JPA SQL logging. Defaults to `WARNING`. |
 | `LOGIN_ATTEMPT_CAP`                                                           | The number of consecutive failed logins a user can have before their account is disabled. Defaults to `10`. |
-| `METRICS_HOST`                                                                | The hostname to send graphite metrics to. Defaults to `localhost`. |
-| `METRICS_PORT`                                                                | The port number to send graphite metrics to. Defaults to `8092`. |
 | `NOTIFY_SIGN_IN_OTP_SMS_TEMPLATE_ID`                                          | The GOV.UK Notify template ID to use for sending OTP codes via SMS for signing in. Defaults to `pay-notify-sign-in-otp-sms-template-id`. |
 | `NOTIFY_CHANGE_SIGN_IN_2FA_TO_SMS_OTP_SMS_TEMPLATE_ID`                        | The GOV.UK Notify template ID to use for sending OTP codes via SMS for changing the sign-in method to text messages. Defaults to `pay-notify-switch-sign-in-2fa-to-sms-otp-sms-template-id`. |
 | `NOTIFY_SELF_INITIATED_CREATE_USER_AND_SERVICE_OTP_SMS_TEMPLATE_ID`           | The GOV.UK Notify template ID to use for sending OTP codes via SMS for self-initiated user and service creation. Defaults to `pay-notify-self-initiated-create-user-and-service-otp-sms-template-id`. |

--- a/pom.xml
+++ b/pom.xml
@@ -85,10 +85,6 @@
             <artifactId>dropwizard-migrations</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-graphite</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.6.0</version>

--- a/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersConfig.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/AdminUsersConfig.java
@@ -20,11 +20,6 @@ public class AdminUsersConfig extends Configuration {
     private JPAConfiguration jpaConfiguration;
 
     @NotNull
-    private String graphiteHost;
-    @NotNull
-    private Integer graphitePort;
-
-    @NotNull
     private String baseUrl;
 
     @Valid
@@ -78,14 +73,6 @@ public class AdminUsersConfig extends Configuration {
 
     @JsonProperty("ecsContainerMetadataUriV4")
     private URI ecsContainerMetadataUriV4;
-
-    public String getGraphiteHost() {
-        return graphiteHost;
-    }
-
-    public Integer getGraphitePort() {
-        return graphitePort;
-    }
 
     public String getBaseUrl() {
         return baseUrl;

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -99,9 +99,6 @@ notifyDirectDebit:
 
 forgottenPasswordExpiryMinutes: ${FORGOTTEN_PASSWORD_EXPIRY_MINUTES:-90}
 
-graphiteHost: ${METRICS_HOST:-localhost}
-graphitePort: ${METRICS_PORT:-8092}
-
 links:
   selfserviceUrl: ${SELFSERVICE_URL:-https://selfservice.pymnt.localdomain}
   selfserviceInvitesUrl: ${SELFSERVICE_URL:-https://selfservice.pymnt.localdomain}/invites

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -92,9 +92,6 @@ notifyDirectDebit:
 
 forgottenPasswordExpiryMinutes: ${FORGOTTEN_PASSWORD_EXPIRY_MINUTES:-90}
 
-graphiteHost: ${METRICS_HOST:-localhost}
-graphitePort: ${METRICS_PORT:-8092}
-
 links:
   selfserviceUrl: ${SELFSERVICE_URL:-https://selfservice.pymnt.localdomain}
   selfserviceInvitesUrl: ${SELFSERVICE_URL:-https://selfservice.pymnt.localdomain}/invites


### PR DESCRIPTION
## WHAT YOU DID
1. Remove graphite metrics configuration and sending
2. Rename GRAPHITE_SENDING_PERIOD_SECONDS to METRICS_COLLECTION_PERIOD_SECONDS, and set it to the appropriate value.

## How to test

Check build passes and explicitly wait for the e2e tests to pass

## Code review checklist

### Logging

- [X] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [X] Updated README.md for any of the following ?

* ~Introduced any new environment variables~ / removed existing environment variable
* ~Added new API / updated existing API definition~
