### PR TITLE
BAU Return success response when agreement exists

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -146,28 +146,28 @@
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "1976a945a8d2733655e4b2453bd49fb59cb7ba19",
         "is_verified": false,
-        "line_number": 659
+        "line_number": 663
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "a31519136d26754afeb0df49b5f066f387091f88",
         "is_verified": false,
-        "line_number": 693
+        "line_number": 697
       },
       {
         "type": "Secret Keyword",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "0ea7458942ab65e0a340cf4fd28ca00d93c494f3",
         "is_verified": false,
-        "line_number": 792
+        "line_number": 796
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "3660e32cde5fccc8d1e4521d0c831c2012388720",
         "is_verified": false,
-        "line_number": 1214
+        "line_number": 1218
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/model/CreateUserRequest.java": [
@@ -389,7 +389,7 @@
         "filename": "src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceGovUkPayAgreementResourceIT.java",
         "hashed_secret": "c3a8fcf85a56dee95cff4ce7adf0bb9a4c18f747",
         "is_verified": false,
-        "line_number": 59
+        "line_number": 77
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/resources/UserResourceAuthenticationIT.java": [
@@ -466,5 +466,5 @@
       }
     ]
   },
-  "generated_at": "2023-08-03T16:06:10Z"
+  "generated_at": "2023-09-13T11:11:05Z"
 }

--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -507,6 +507,12 @@ paths:
               required:
               - user_external_id
       responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GovUkPayAgreement'
+          description: Agreement already created - existing agreement returned
         "201":
           content:
             application/json:
@@ -517,8 +523,6 @@ paths:
           description: Invalid payload
         "404":
           description: Service with serviceExternalId not found
-        "409":
-          description: Agreement already exists for the service.
       summary: Record acceptance of GOV.UK Pay terms
       tags:
       - Services
@@ -613,10 +617,10 @@ paths:
               $ref: '#/components/schemas/StripeAgreementRequest'
         required: true
       responses:
+        "200":
+          description: Stripe agreement already created
         "201":
           description: Created
-        "409":
-          description: Conflict. Another stripe agreement already exists for the service
         "422":
           description: Invalid JSON payload or IP address
       summary: Record acceptance of Stripe terms

--- a/src/main/java/uk/gov/pay/adminusers/exception/StripeAgreementExistsException.java
+++ b/src/main/java/uk/gov/pay/adminusers/exception/StripeAgreementExistsException.java
@@ -1,7 +1,0 @@
-package uk.gov.pay.adminusers.exception;
-
-public class StripeAgreementExistsException extends ConflictException {
-    public StripeAgreementExistsException() {
-        super("Stripe agreement information is already stored for this service");
-    }
-}

--- a/src/main/java/uk/gov/pay/adminusers/service/StripeAgreementService.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/StripeAgreementService.java
@@ -4,7 +4,6 @@ import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.adminusers.exception.ServiceNotFoundException;
-import uk.gov.pay.adminusers.exception.StripeAgreementExistsException;
 import uk.gov.pay.adminusers.model.StripeAgreement;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
 import uk.gov.pay.adminusers.persistence.dao.StripeAgreementDao;
@@ -39,10 +38,6 @@ public class StripeAgreementService {
     public void doCreate(String serviceExternalId, InetAddress ipAddress) {
         ServiceEntity serviceEntity = serviceDao.findByExternalId(serviceExternalId)
                 .orElseThrow(() -> new ServiceNotFoundException(serviceExternalId));
-        
-        if (stripeAgreementDao.findByServiceExternalId(serviceExternalId).isPresent()) {
-            throw new StripeAgreementExistsException();
-        }
 
         logger.info(format("Creating stripe agreement for service %s", serviceExternalId));
         ZonedDateTime agreementTime = ZonedDateTime.now(ZoneId.of("UTC"));

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceGovUkPayAgreementResourceIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceGovUkPayAgreementResourceIT.java
@@ -50,6 +50,24 @@ class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest {
     }
 
     @Test
+    void shouldReturn_200_whenAgreementAlreadyExists() {
+        GovUkPayAgreementDbFixture.govUkPayAgreementDbFixture(databaseHelper)
+                .withServiceId(service.getId())
+                .withEmail(email)
+                .insert();
+
+        JsonNode payload = mapper.valueToTree(Map.of("user_external_id", user.getExternalId()));
+        givenSetup()
+                .when()
+                .accept(JSON)
+                .body(payload)
+                .post(format("/v1/api/services/%s/govuk-pay-agreement", service.getExternalId()))
+                .then()
+                .statusCode(200)
+                .body("email", is(email));
+    }
+
+    @Test
     void shouldReturn_404_whenServiceNotFound() {
         JsonNode payload = mapper.valueToTree(Map.of("user_external_id", user.getExternalId()));
         givenSetup()
@@ -114,24 +132,6 @@ class ServiceResourceGovUkPayAgreementResourceIT extends IntegrationTest {
                 .statusCode(400)
                 .body("errors", hasSize(1))
                 .body("errors[0]", is("Field [user_external_id] is required"));
-    }
-
-    @Test
-    void shouldReturn_409_whenAgreementAlreadyExists() {
-        GovUkPayAgreementDbFixture.govUkPayAgreementDbFixture(databaseHelper)
-                .withServiceId(service.getId())
-                .insert();
-
-        JsonNode payload = mapper.valueToTree(Map.of("user_external_id", user.getExternalId()));
-        givenSetup()
-                .when()
-                .accept(JSON)
-                .body(payload)
-                .post(format("/v1/api/services/%s/govuk-pay-agreement", service.getExternalId()))
-                .then()
-                .statusCode(409)
-                .body("errors", hasSize(1))
-                .body("errors[0]", is("GOV.UK Pay agreement information is already stored for this service"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceStripeAgreementIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceStripeAgreementIT.java
@@ -41,19 +41,7 @@ class ServiceResourceStripeAgreementIT extends IntegrationTest {
     }
 
     @Test
-    void shouldReturn_NOT_FOUND_whenServiceNotFound() {
-        JsonNode payload = mapper.valueToTree(Map.of(FIELD_IP_ADDRESS, "0.0.0.0"));
-        givenSetup()
-                .when()
-                .accept(JSON)
-                .body(payload)
-                .post(format("/v1/api/services/%s/stripe-agreement", "123"))
-                .then()
-                .statusCode(404);
-    }
-
-    @Test
-    void shouldReturn_409_whenStripeAgreementAlreadyExists() {
+    void shouldReturn_200_whenStripeAgreementAlreadyExists() {
         StripeAgreementDbFixture.stripeAgreementDbFixture(databaseHelper)
                 .withServiceId(service.getId())
                 .insert();
@@ -65,9 +53,19 @@ class ServiceResourceStripeAgreementIT extends IntegrationTest {
                 .body(payload)
                 .post(format("/v1/api/services/%s/stripe-agreement", service.getExternalId()))
                 .then()
-                .statusCode(409)
-                .body("errors", hasSize(1))
-                .body("errors[0]", is("Stripe agreement information is already stored for this service"));
+                .statusCode(200);
+    }
+
+    @Test
+    void shouldReturn_NOT_FOUND_whenServiceNotFound() {
+        JsonNode payload = mapper.valueToTree(Map.of(FIELD_IP_ADDRESS, "0.0.0.0"));
+        givenSetup()
+                .when()
+                .accept(JSON)
+                .body(payload)
+                .post(format("/v1/api/services/%s/stripe-agreement", "123"))
+                .then()
+                .statusCode(404);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/service/StripeAgreementServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/service/StripeAgreementServiceTest.java
@@ -8,7 +8,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.adminusers.exception.ServiceNotFoundException;
-import uk.gov.pay.adminusers.exception.StripeAgreementExistsException;
 import uk.gov.pay.adminusers.model.StripeAgreement;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
 import uk.gov.pay.adminusers.persistence.dao.StripeAgreementDao;
@@ -94,22 +93,5 @@ public class StripeAgreementServiceTest {
 
         assertThrows(ServiceNotFoundException.class,
                 () -> stripeAgreementService.doCreate(serviceExternalId, InetAddress.getByName("192.0.2.0")));
-    }
-
-    @Test
-    public void shouldThrowException_whenStripeAgreementAlreadyExists() throws UnknownHostException {
-        String serviceExternalId = "abc123";
-
-        ServiceEntity mockServiceEntity = mock(ServiceEntity.class);
-        when(mockedServiceDao.findByExternalId(serviceExternalId)).thenReturn(Optional.of(mockServiceEntity));
-
-        StripeAgreementEntity mockStripeAgreementEntity = mock(StripeAgreementEntity.class);
-        when(mockedStripeAgreementDao.findByServiceExternalId(serviceExternalId)).thenReturn(Optional.of(mockStripeAgreementEntity));
-
-        StripeAgreementExistsException exception = assertThrows(StripeAgreementExistsException.class,
-                () -> stripeAgreementService.doCreate(serviceExternalId, InetAddress.getByName("192.0.2.0")));
-
-        assertThat(exception.getMessage(),
-                is("Stripe agreement information is already stored for this service"));
     }
 }


### PR DESCRIPTION
When a request was made to create either a GovUkPayAgreement or StripeAgreement was made, we were returning a 409 error if one already existed.

Instead return a 200. For creating a GovUkPayAgreement, also return the agreement in the response.

This is so that we can recover from the scenario where the end user submits the admin tool page to agree to the agreement, but there is another error, which we have seen happen when trying to create the Zendesk ticket.