### PR TITLE
PP-11407: Update docker image JRE to 11.0.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre-alpine@sha256:aea6ff5a31148a9dc80c65fad592d5681c61f73dab8ad2f5b8fb08de256899dc
+FROM eclipse-temurin:11-jre-alpine@sha256:77f7c2509dba2f346bf042e424d395b16b0c432ee1eabf0cbcc17922dc900c73
 
 RUN ["apk", "--no-cache", "upgrade"]
 


### PR DESCRIPTION
## WHAT YOU DID
Update docker image JRE to 11.0.20

## How to test

- Make sure the build succeeds
- Peer reviewed as part of pairing 
- Another team member to review
- Smoke test relevant app or service

### Documentation

Refer to Jira ticket https://payments-platform.atlassian.net/browse/PP-11407 to understand reason for version upgrade.
