### PR TITLE
PP-11407: Update docker image JRE to 11.0.20 for M1.

### DIFF
--- a/m1/arm64.Dockerfile
+++ b/m1/arm64.Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre@sha256:3efc210202a0aa206aa353f7d31b36d24aa239251d6a30bdc3c25016f280c1bd
+FROM eclipse-temurin:11-jre@sha256:e12585f95f18fba9841aa3c12e6e4261f74b608cbc27b0fab61ac267b57de8f6
 
 ARG DNS_TTL=15
 


### PR DESCRIPTION
## WHAT YOU DID
Update docker image JRE to 11.0.20 for M1

## How to test

- Make sure the build succeeds
- Peer reviewed as part of pairing
- Another team member to review
- Smoke test relevant app or service

### Documentation

Refer to Jira ticket https://payments-platform.atlassian.net/browse/PP-11407 to understand reason for version upgrade.

