### PR TITLE
PP-11652 Stop Dependabot trying to upgrade us to Dropwizard 4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
+  ignore:
+    - dependency-name: "dropwizard-dependencies"
+      versions:
+        - ">= 4"
   open-pull-requests-limit: 10
   labels:
   - dependencies


### PR DESCRIPTION
We’d rather Dependabot not try to upgrade Dropwizard at all unless it’s a security fix but it’s not possible to have Dependabot only open security fix pull requests for Java projects.

Dependabot 4 is a major release that switches from the deprecated Java EE to Jakarta EE. This will involve other changes to our code so we’re never going to just merge a Dependabot PR and be done with it.

So if Dependabot is going to insist on opening Dropwizard upgrade PRs, it may as well open ones we might actually merge (such as upgrading from 3.0.1 to 3.0.2 — which it would not open while it sees a ‘newer’ 4.x version is available).