### PR TITLE
BAU — Small tweaks to POM and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
       - dependency-name: "io.dropwizard:dropwizard-dependencies"
         versions:
           - ">= 4"
+      - dependency-name: "com.google.inject:guice-bom"
+        versions:
+          - ">= 7"
     open-pull-requests-limit: 10
     labels:
       - dependencies

--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <dropwizard.version>3.0.2</dropwizard.version>
         <hamcrest.version>2.2</hamcrest.version>
-        <eclipselink.version>2.7.13</eclipselink.version>
-        <guice.version>5.1.0</guice.version>
         <pact.version>3.6.15</pact.version>
         <pay-java-commons.version>1.0.20231017121422</pay-java-commons.version>
         <prometheus.version>0.16.0</prometheus.version>
@@ -27,7 +26,7 @@
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-dependencies</artifactId>
-                <version>3.0.2</version>
+                <version>${dropwizard.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -42,6 +41,13 @@
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
                 <version>1.12.566</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>1.19.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -151,7 +157,7 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.jpa</artifactId>
-            <version>${eclipselink.version}</version>
+            <version>2.7.13</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -273,12 +279,17 @@
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Test dependencies that need explicit versions -->
         <dependency>
             <groupId>io.dropwizard.modules</groupId>
             <artifactId>dropwizard-testing-junit4</artifactId>
-            <version>3.0.2</version>
+            <version>${dropwizard.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -333,12 +344,6 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path-assert</artifactId>
             <version>2.8.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>1.19.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- Use Dropwizard version property so we upgrade Dropwizard and Dropwizard Testing Support for JUnit 4.x in lockstep
- Use Testcontainers BOM
- Stop using EclipseLink version property because it’s only used in one place
- Remove unused Guice version property
- Tell Dependabot not to try to upgrade us to Guice 7.0.0, which migrates from Java EE to Jakarta EE and is never going to be a just-merge-it upgrade