### PR TITLE
PP-11205 Add DAO method to delete users

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -317,7 +317,7 @@
         "filename": "src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java",
         "hashed_secret": "95578813f8acdd659caf14acd19b09c875addbb6",
         "is_verified": false,
-        "line_number": 26
+        "line_number": 27
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/pact/ContractTest.java": [
@@ -466,5 +466,5 @@
       }
     ]
   },
-  "generated_at": "2023-09-13T11:11:05Z"
+  "generated_at": "2023-10-26T09:06:36Z"
 }

--- a/src/main/java/uk/gov/pay/adminusers/model/User.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/User.java
@@ -50,6 +50,8 @@ public class User {
     @Schema(example = "2022-04-06T23:03:41.665Z")
     @JsonSerialize(using = ApiResponseDateTimeSerializer.class)
     private ZonedDateTime lastLoggedInAt;
+    @JsonIgnore
+    private ZonedDateTime createdAt;
     private List<Link> links = new ArrayList<>();
     private Integer sessionVersion = 0;
 
@@ -58,7 +60,15 @@ public class User {
                             SecondFactorMethod secondFactor, String provisionalOtpKey,
                             ZonedDateTime provisionalOtpKeyCreatedAt, ZonedDateTime lastLoggedInAt) {
         return new User(id, externalId, password, email, otpKey, telephoneNumber, serviceRoles, features,
-                secondFactor, provisionalOtpKey, provisionalOtpKeyCreatedAt, lastLoggedInAt);
+                secondFactor, provisionalOtpKey, provisionalOtpKeyCreatedAt, lastLoggedInAt, null);
+    }
+
+    public static User from(Integer id, String externalId, String password, String email, String otpKey,
+                            String telephoneNumber, List<ServiceRole> serviceRoles, String features,
+                            SecondFactorMethod secondFactor, String provisionalOtpKey,
+                            ZonedDateTime provisionalOtpKeyCreatedAt, ZonedDateTime lastLoggedInAt, ZonedDateTime createdAt) {
+        return new User(id, externalId, password, email, otpKey, telephoneNumber, serviceRoles, features,
+                secondFactor, provisionalOtpKey, provisionalOtpKeyCreatedAt, lastLoggedInAt, createdAt);
     }
 
     private User(Integer id, @JsonProperty("external_id") String externalId, @JsonProperty("password") String password, @JsonProperty("email") String email,
@@ -67,7 +77,9 @@ public class User {
                  @JsonProperty("second_factor") SecondFactorMethod secondFactor,
                  @JsonProperty("provisional_otp_key") String provisionalOtpKey,
                  @JsonProperty("provisional_otp_key_created_at") ZonedDateTime provisionalOtpKeyCreatedAt,
-                 @JsonProperty("last_logged_in_at") ZonedDateTime lastLoggedInAt) {
+                 @JsonProperty("last_logged_in_at") ZonedDateTime lastLoggedInAt,
+                ZonedDateTime createdAt
+                 ) {
         this.id = id;
         this.externalId = externalId;
         this.password = password;
@@ -80,6 +92,7 @@ public class User {
         this.provisionalOtpKey = provisionalOtpKey;
         this.provisionalOtpKeyCreatedAt = provisionalOtpKeyCreatedAt;
         this.lastLoggedInAt = lastLoggedInAt;
+        this.createdAt = createdAt;
     }
 
     @JsonIgnore
@@ -171,6 +184,10 @@ public class User {
 
     public void setLastLoggedInAt(ZonedDateTime lastLoggedInAt) {
         this.lastLoggedInAt = lastLoggedInAt;
+    }
+
+    public ZonedDateTime getCreatedAt() {
+        return createdAt;
     }
 
     @JsonProperty("_links")

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/UserDbFixture.java
@@ -10,6 +10,7 @@ import uk.gov.pay.adminusers.model.ServiceRole;
 import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.utils.DatabaseTestHelper;
 
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,6 +30,8 @@ public class UserDbFixture {
     private String features = "FEATURE_1, FEATURE_2";
     private String provisionalOtpKey;
     private SecondFactorMethod secondFactorMethod = SecondFactorMethod.SMS;
+    private ZonedDateTime createdAt;
+    private ZonedDateTime lastLoggedInAt;
 
     private UserDbFixture(DatabaseTestHelper databaseTestHelper) {
         this.databaseTestHelper = databaseTestHelper;
@@ -44,7 +47,7 @@ public class UserDbFixture {
                 .collect(toUnmodifiableList());
 
         User user = User.from(randomInt(), externalId, password, email, otpKey, telephoneNumber,
-                serviceRoles, features, secondFactorMethod, provisionalOtpKey, null, null);
+                serviceRoles, features, secondFactorMethod, provisionalOtpKey, null, lastLoggedInAt, createdAt);
 
         databaseTestHelper.add(user);
         serviceRoles.forEach(serviceRole -> 
@@ -101,6 +104,16 @@ public class UserDbFixture {
 
     public UserDbFixture withSecondFactorMethod(SecondFactorMethod secondFactorMethod) {
         this.secondFactorMethod = secondFactorMethod;
+        return this;
+    }
+
+    public UserDbFixture withCreatedAt(ZonedDateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+
+    public UserDbFixture withLastLoggedInAt(ZonedDateTime lastLoggedInAt) {
+        this.lastLoggedInAt = lastLoggedInAt;
         return this;
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoIT.java
@@ -409,7 +409,7 @@ public class UserDaoIT extends DaoTestBase {
         }
 
         @Test
-        void shouldDeleteUsersWithOutLastLoggedInAtDateCorrectlyButCreatedDateBeforeTheExpungeDate() {
+        void shouldDeleteUsersWithoutLastLoggedInAtDateCorrectlyButCreatedDateBeforeTheExpungeDate() {
             ZonedDateTime deleteUsersUpToDate = parse("2023-01-31T00:00:00Z");
             Integer userId = userDbFixture(databaseHelper)
                     .withLastLoggedInAt(null)

--- a/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
@@ -117,9 +117,9 @@ public class DatabaseTestHelper {
                         .createUpdate("INSERT INTO users(" +
                                 "id, external_id, password, email, otp_key, telephone_number, " +
                                 "second_factor, disabled, login_counter, version, " +
-                                "\"createdAt\", \"updatedAt\", session_version, provisional_otp_key) " +
+                                "\"createdAt\", \"updatedAt\", session_version, provisional_otp_key, last_logged_in_at) " +
                                 "VALUES (:id, :externalId, :password, :email, :otpKey, :telephoneNumber, " +
-                                ":secondFactor, :disabled, :loginCounter, :version, :createdAt, :updatedAt, :session_version, :provisionalOtpKey)")
+                                ":secondFactor, :disabled, :loginCounter, :version, :createdAt, :updatedAt, :session_version, :provisionalOtpKey, :lastLoggedInAt)")
                         .bind("id", user.getId())
                         .bind("externalId", user.getExternalId())
                         .bind("password", user.getPassword())
@@ -131,9 +131,10 @@ public class DatabaseTestHelper {
                         .bind("loginCounter", user.getLoginCounter())
                         .bind("version", 0)
                         .bind("session_version", user.getSessionVersion())
-                        .bind("createdAt", now)
+                        .bind("createdAt", user.getCreatedAt() == null ? now : user.getCreatedAt())
                         .bind("updatedAt", now)
                         .bind("provisionalOtpKey", user.getProvisionalOtpKey())
+                        .bind("lastLoggedInAt", user.getLastLoggedInAt())
                         .execute()
         );
         return this;


### PR DESCRIPTION
## WHAT YOU DID
- Added DAO method to delete historic users not associated with any service
- Updated User model for the new field (createdAt) required for tests, as tests and API resources use the same class. To refactor in a separate PR so that tests use separate fixtures.
