### PR TITLE
BAU — Tell Dependabot to ignore Guice 6 and Dropwizard Sentry 4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,21 @@ updates:
       time: "03:00"
     ignore:
       - dependency-name: "io.dropwizard:dropwizard-dependencies"
+        # Dropwizard 4.x only works with Jakarta EE and not Java EE
+        versions:
+          - ">= 4"
+      - dependency-name: "org.dhatim:dropwizard-sentry"
+        # We essentially forked Dropwizard Sentry because it did not support
+        # Dropwizard 3.x — there is now a Dropwizard Sentry 4.x, which supports
+        # Dropwizard 4.x (and maybe Dropwizard 3.x), but we’d need to do work
+        # to go back to using an unmodified version
         versions:
           - ">= 4"
       - dependency-name: "com.google.inject:guice-bom"
+        # Guice 6.x requires compatibility work on our side
+        # Guice 7.x only works with Jakarta EE and not Java EE
         versions:
-          - ">= 7"
+          - ">= 6"
     open-pull-requests-limit: 10
     labels:
       - dependencies


### PR DESCRIPTION
Tell Dependabot to ignore Guice 6.x and Dropwizard Sentry 4.x because neither of these are going to be just-merge-the-Dependabot-PR upgrades:

- Guice 6.x requires compatibility work on our side while Guice 7.x only works with Jakarta EE and not Java EE
- We essentially forked Dropwizard Sentry because it did not support Dropwizard 3.x — there is now a Dropwizard Sentry 4.x, which supports Dropwizard 4.x (and maybe Dropwizard 3.x), but we’d need to do work to go back to using an unmodified version

Also add comments explaining why we’re ignoring upgrades for certain Maven dependencies.