### PR TITLE
BAU fix dropwizard versioning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,6 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dropwizard.version>3.0.2</dropwizard.version>
         <hamcrest.version>2.2</hamcrest.version>
         <pact.version>3.6.15</pact.version>
         <pay-java-commons.version>1.0.20231023150042</pay-java-commons.version>
@@ -26,7 +25,7 @@
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-dependencies</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>3.0.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -289,7 +288,7 @@
         <dependency>
             <groupId>io.dropwizard.modules</groupId>
             <artifactId>dropwizard-testing-junit4</artifactId>
-            <version>${dropwizard.version}</version>
+            <version>3.0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## WHAT YOU DID

dependabot will not update dropwizard dependecies because it uses ${dropwizard.version}. dropwizard-testing-junit4 is also using ${drowizard.version} but it's a different module and its version numbering is out of sync with the main dropwizard dependencies. We need the updates for dropwizard dependencies not to rely on io.dropwizard.modules versions for security updates.

- separate the 2 dependencies that each of them have their own versiong.
