### PR TITLE
PP-11205 Archive services

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/app/config/ExpungeAndArchiveDataConfig.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/config/ExpungeAndArchiveDataConfig.java
@@ -10,11 +10,18 @@ public class ExpungeAndArchiveDataConfig {
     @NotNull
     private int expungeUserDataAfterDays;
 
+    @NotNull
+    private int archiveServicesAfterDays;
+
     public boolean isExpungeAndArchiveHistoricalDataEnabled() {
         return expungeAndArchiveHistoricalDataEnabled;
     }
 
     public int getExpungeUserDataAfterDays() {
         return expungeUserDataAfterDays;
+    }
+
+    public int getArchiveServicesAfterDays() {
+        return archiveServicesAfterDays;
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/client/ledger/model/LedgerSearchTransactionsResponse.java
+++ b/src/main/java/uk/gov/pay/adminusers/client/ledger/model/LedgerSearchTransactionsResponse.java
@@ -14,6 +14,13 @@ public class LedgerSearchTransactionsResponse {
     @JsonProperty("results")
     private List<LedgerTransaction> transactions;
 
+    public LedgerSearchTransactionsResponse(){
+        //empty constructor
+    }
+    public LedgerSearchTransactionsResponse(List<LedgerTransaction> transactions) {
+        this.transactions = transactions;
+    }
+
     public List<LedgerTransaction> getTransactions() {
         return transactions;
     }

--- a/src/main/java/uk/gov/pay/adminusers/client/ledger/model/LedgerTransaction.java
+++ b/src/main/java/uk/gov/pay/adminusers/client/ledger/model/LedgerTransaction.java
@@ -22,11 +22,11 @@ public class LedgerTransaction {
         // empty constructor
     }
 
-    public LedgerTransaction(String transactionId, String reference) {
+    public LedgerTransaction(String transactionId, String reference, ZonedDateTime createdDate) {
         this.transactionId = transactionId;
         this.reference = reference;
+        this.createdDate = createdDate;
     }
-
 
     public String getReference() {
         return reference;

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -142,3 +142,4 @@ ecsContainerMetadataUriV4: ${ECS_CONTAINER_METADATA_URI_V4:-}
 expungeAndArchiveDataConfig:
   expungeAndArchiveHistoricalDataEnabled: ${EXPUNGE_AND_ARCHIVE_HISTORICAL_DATA_ENABLED:-false}
   expungeUserDataAfterDays: ${EXPUNGE_USER_DATA_AFTER_DAYS:-1460}
+  archiveServicesAfterDays: ${EXPUNGE_ARCHIVE_SERVICES_AFTER_DAYS:-2555}

--- a/src/test/java/uk/gov/pay/adminusers/expungeandarchive/service/ExpungeAndArchiveHistoricalDataServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/expungeandarchive/service/ExpungeAndArchiveHistoricalDataServiceTest.java
@@ -6,6 +6,7 @@ import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
 import io.prometheus.client.CollectorRegistry;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -15,12 +16,20 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.adminusers.app.config.AdminUsersConfig;
 import uk.gov.pay.adminusers.app.config.ExpungeAndArchiveDataConfig;
+import uk.gov.pay.adminusers.client.ledger.model.LedgerSearchTransactionsResponse;
+import uk.gov.pay.adminusers.client.ledger.model.LedgerTransaction;
+import uk.gov.pay.adminusers.client.ledger.service.LedgerService;
+import uk.gov.pay.adminusers.fixtures.ServiceEntityFixture;
 import uk.gov.pay.adminusers.persistence.dao.ForgottenPasswordDao;
 import uk.gov.pay.adminusers.persistence.dao.InviteDao;
+import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
+import uk.gov.pay.adminusers.persistence.entity.GatewayAccountIdEntity;
+import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -29,9 +38,15 @@ import static java.time.ZoneOffset.UTC;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
+import static uk.gov.pay.adminusers.fixtures.LedgerSearchTransactionsResponseFixture.aLedgerSearchTransactionsResponseFixture;
+import static uk.gov.pay.adminusers.fixtures.LedgerTransactionFixture.aLedgerTransactionFixture;
 
 @ExtendWith(MockitoExtension.class)
 class ExpungeAndArchiveHistoricalDataServiceTest {
@@ -41,6 +56,12 @@ class ExpungeAndArchiveHistoricalDataServiceTest {
 
     @Mock
     InviteDao mockInviteDao;
+
+    @Mock
+    ServiceDao mockServiceDao;
+
+    @Mock
+    LedgerService mockLedgerService;
 
     @Mock
     ForgottenPasswordDao mockForgottenPasswordDao;
@@ -69,7 +90,7 @@ class ExpungeAndArchiveHistoricalDataServiceTest {
         clock = Clock.fixed(Instant.parse(SYSTEM_INSTANT), UTC);
         when(mockAdminUsersConfig.getExpungeAndArchiveDataConfig()).thenReturn(mockExpungeAndArchiveConfig);
         expungeAndArchiveHistoricalDataService = new ExpungeAndArchiveHistoricalDataService(mockUserDao,
-                mockInviteDao, mockForgottenPasswordDao, mockAdminUsersConfig, clock);
+                mockInviteDao, mockForgottenPasswordDao, mockServiceDao, mockLedgerService, mockAdminUsersConfig, clock);
     }
 
     @Test
@@ -84,6 +105,7 @@ class ExpungeAndArchiveHistoricalDataServiceTest {
         verifyNoInteractions(mockUserDao);
         verifyNoInteractions(mockInviteDao);
         verifyNoInteractions(mockForgottenPasswordDao);
+        verifyNoInteractions(mockServiceDao);
 
         verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
@@ -91,7 +113,7 @@ class ExpungeAndArchiveHistoricalDataServiceTest {
     }
 
     @Test
-    void shouldDeleteHistoricalDataIfFlagIsEnabled() {
+    void shouldDeleteHistoricalUserDataIfFlagIsEnabled() {
         Logger root = (Logger) LoggerFactory.getLogger(ExpungeAndArchiveHistoricalDataService.class);
         root.addAppender(mockAppender);
         root.setLevel(INFO);
@@ -117,5 +139,159 @@ class ExpungeAndArchiveHistoricalDataServiceTest {
 
         Double duration = collectorRegistry.getSampleValue("expunge_and_archive_historical_data_job_duration_seconds_sum");
         assertThat(duration, greaterThan(initialDuration));
+    }
+
+    @Nested
+    class TestArchivingServices {
+
+        ServiceEntity serviceEntity;
+        String gatewayAccountId1 = randomUuid();
+        String gatewayAccountId2 = randomUuid();
+        ZonedDateTime systemDate;
+
+        GatewayAccountIdEntity gatewayAccountIdEntity1;
+        GatewayAccountIdEntity gatewayAccountIdEntity2;
+
+        @BeforeEach
+        void setUp() {
+            when(mockExpungeAndArchiveConfig.isExpungeAndArchiveHistoricalDataEnabled()).thenReturn(true);
+            when(mockExpungeAndArchiveConfig.getArchiveServicesAfterDays()).thenReturn(7);
+
+            gatewayAccountIdEntity1 = new GatewayAccountIdEntity();
+            gatewayAccountIdEntity1.setGatewayAccountId(gatewayAccountId1);
+
+            gatewayAccountIdEntity2 = new GatewayAccountIdEntity();
+            gatewayAccountIdEntity2.setGatewayAccountId(gatewayAccountId2);
+
+            serviceEntity = ServiceEntityFixture
+                    .aServiceEntity()
+                    .withArchived(false)
+                    .withGatewayAccounts(List.of(gatewayAccountIdEntity1, gatewayAccountIdEntity2))
+                    .build();
+
+            systemDate = clock.instant().atZone(UTC);
+        }
+
+        @Test
+        void shouldArchiveService_WhenTheLastTransactionDateIsBeforeTheServicesEligibleForArchivingDate() {
+            when(mockExpungeAndArchiveConfig.getArchiveServicesAfterDays()).thenReturn(7);
+
+            LedgerTransaction ledgerTransaction1 = aLedgerTransactionFixture()
+                    .withCreatedDate(systemDate.minusDays(10))
+                    .build();
+            LedgerSearchTransactionsResponse searchTransactionsResponse1 = aLedgerSearchTransactionsResponseFixture()
+                    .withTransactionList(List.of(ledgerTransaction1))
+                    .build();
+
+            LedgerTransaction ledgerTransaction2 = aLedgerTransactionFixture()
+                    .withCreatedDate(systemDate.minusDays(20))
+                    .build();
+            LedgerSearchTransactionsResponse searchTransactionsResponse2 = aLedgerSearchTransactionsResponseFixture()
+                    .withTransactionList(List.of(ledgerTransaction2))
+                    .build();
+
+            when(mockLedgerService.searchTransactions(gatewayAccountId1, 1)).thenReturn(searchTransactionsResponse1);
+            when(mockLedgerService.searchTransactions(gatewayAccountId2, 1)).thenReturn(searchTransactionsResponse2);
+            when(mockServiceDao.findServicesToCheckForArchiving(systemDate.minusDays(7))).thenReturn(List.of(serviceEntity));
+
+            expungeAndArchiveHistoricalDataService.expungeAndArchiveHistoricalData();
+
+            assertTrue(serviceEntity.isArchived());
+            verify(mockServiceDao).merge(serviceEntity);
+        }
+
+        @Test
+        void shouldArchiveServiceWithoutTransactionsButCreatedBeforeTheServicesEligibleForArchivingDate() {
+            when(mockExpungeAndArchiveConfig.getArchiveServicesAfterDays()).thenReturn(7);
+
+            LedgerSearchTransactionsResponse searchTransactionsResponse1 = aLedgerSearchTransactionsResponseFixture()
+                    .withTransactionList(List.of())
+                    .build();
+            when(mockLedgerService.searchTransactions(gatewayAccountId1, 1)).thenReturn(searchTransactionsResponse1);
+
+            serviceEntity = ServiceEntityFixture
+                    .aServiceEntity()
+                    .withArchived(false)
+                    .withCreatedDate(systemDate.minusDays(8))
+                    .withGatewayAccounts(List.of(gatewayAccountIdEntity1))
+                    .build();
+            when(mockServiceDao.findServicesToCheckForArchiving(systemDate.minusDays(7))).thenReturn(List.of(serviceEntity));
+
+            expungeAndArchiveHistoricalDataService.expungeAndArchiveHistoricalData();
+
+            assertTrue(serviceEntity.isArchived());
+            verify(mockServiceDao).merge(serviceEntity);
+        }
+
+        @Test
+        void shouldNotArchiveService_WhenTheLastTransactionDateIsAfterTheServicesEligibleForArchivingDate() {
+            when(mockExpungeAndArchiveConfig.getArchiveServicesAfterDays()).thenReturn(7);
+
+            LedgerSearchTransactionsResponse searchTransactionsResponse1 = aLedgerSearchTransactionsResponseFixture()
+                    .withTransactionList(List.of())
+                    .build();
+
+            LedgerTransaction ledgerTransaction2 = aLedgerTransactionFixture()
+                    .withCreatedDate(systemDate.plusDays(1))
+                    .build();
+            LedgerSearchTransactionsResponse searchTransactionsResponse2 = aLedgerSearchTransactionsResponseFixture()
+                    .withTransactionList(List.of(ledgerTransaction2))
+                    .build();
+
+            when(mockLedgerService.searchTransactions(gatewayAccountId1, 1)).thenReturn(searchTransactionsResponse1);
+            when(mockLedgerService.searchTransactions(gatewayAccountId2, 1)).thenReturn(searchTransactionsResponse2);
+            when(mockServiceDao.findServicesToCheckForArchiving(systemDate.minusDays(7))).thenReturn(List.of(serviceEntity));
+
+            expungeAndArchiveHistoricalDataService.expungeAndArchiveHistoricalData();
+
+            assertFalse(serviceEntity.isArchived());
+            verifyNoMoreInteractions(mockServiceDao);
+        }
+
+        @Test
+        void shouldNotArchiveServiceWithoutTransactionsAndCreatedIsAfterTheServicesEligibleForArchivingDate() {
+            when(mockExpungeAndArchiveConfig.getArchiveServicesAfterDays()).thenReturn(7);
+
+            LedgerSearchTransactionsResponse searchTransactionsResponse1 = aLedgerSearchTransactionsResponseFixture()
+                    .withTransactionList(List.of())
+                    .build();
+            when(mockLedgerService.searchTransactions(gatewayAccountId1, 1)).thenReturn(searchTransactionsResponse1);
+
+            serviceEntity = ServiceEntityFixture
+                    .aServiceEntity()
+                    .withArchived(false)
+                    .withCreatedDate(systemDate)
+                    .withGatewayAccounts(List.of(gatewayAccountIdEntity1))
+                    .build();
+            when(mockServiceDao.findServicesToCheckForArchiving(systemDate.minusDays(7))).thenReturn(List.of(serviceEntity));
+
+            expungeAndArchiveHistoricalDataService.expungeAndArchiveHistoricalData();
+
+            assertFalse(serviceEntity.isArchived());
+            verifyNoMoreInteractions(mockServiceDao);
+        }
+
+        @Test
+        void shouldNotArchiveServiceWhenLedgerReturnsNoTransactionsAndCreatedDateIsNotAvailableOnService() {
+            when(mockExpungeAndArchiveConfig.getArchiveServicesAfterDays()).thenReturn(7);
+
+            LedgerSearchTransactionsResponse searchTransactionsResponse1 = aLedgerSearchTransactionsResponseFixture()
+                    .withTransactionList(List.of())
+                    .build();
+            when(mockLedgerService.searchTransactions(gatewayAccountId1, 1)).thenReturn(searchTransactionsResponse1);
+
+            serviceEntity = ServiceEntityFixture
+                    .aServiceEntity()
+                    .withArchived(false)
+                    .withCreatedDate(null)
+                    .withGatewayAccounts(List.of(gatewayAccountIdEntity1))
+                    .build();
+            when(mockServiceDao.findServicesToCheckForArchiving(systemDate.minusDays(7))).thenReturn(List.of(serviceEntity));
+
+            expungeAndArchiveHistoricalDataService.expungeAndArchiveHistoricalData();
+
+            assertFalse(serviceEntity.isArchived());
+            verifyNoMoreInteractions(mockServiceDao);
+        }
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/LedgerSearchTransactionsResponseFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/LedgerSearchTransactionsResponseFixture.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.adminusers.fixtures;
+
+import uk.gov.pay.adminusers.client.ledger.model.LedgerSearchTransactionsResponse;
+import uk.gov.pay.adminusers.client.ledger.model.LedgerTransaction;
+
+import java.util.List;
+
+public class LedgerSearchTransactionsResponseFixture {
+
+    List<LedgerTransaction> transactionList;
+
+    public static LedgerSearchTransactionsResponseFixture aLedgerSearchTransactionsResponseFixture() {
+        return new LedgerSearchTransactionsResponseFixture();
+    }
+
+    public LedgerSearchTransactionsResponseFixture withTransactionList(List<LedgerTransaction> transactions) {
+        this.transactionList = transactions;
+        return this;
+    }
+
+    public LedgerSearchTransactionsResponse build() {
+        return new LedgerSearchTransactionsResponse(transactionList);
+    }
+}

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/LedgerTransactionFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/LedgerTransactionFixture.java
@@ -2,10 +2,13 @@ package uk.gov.pay.adminusers.fixtures;
 
 import uk.gov.pay.adminusers.client.ledger.model.LedgerTransaction;
 
+import java.time.ZonedDateTime;
+
 public class LedgerTransactionFixture {
 
     private String transactionId;
     private String reference;
+    private ZonedDateTime createdDate;
 
     private LedgerTransactionFixture() {
     }
@@ -25,13 +28,17 @@ public class LedgerTransactionFixture {
         return this;
     }
 
+    public LedgerTransactionFixture withCreatedDate(ZonedDateTime createdDate) {
+        this.createdDate = createdDate;
+        return this;
+    }
 
     public LedgerTransaction build() {
         return new LedgerTransaction(
                 transactionId,
-                reference
+                reference,
+                createdDate
         );
     }
-    
     
 }

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -134,3 +134,4 @@ ecsContainerMetadataUriV4: ${ECS_CONTAINER_METADATA_URI_V4:-}
 expungeAndArchiveDataConfig:
   expungeAndArchiveHistoricalDataEnabled: ${EXPUNGE_AND_ARCHIVE_HISTORICAL_DATA_ENABLED:-false}
   expungeUserDataAfterDays: ${EXPUNGE_USER_DATA_AFTER_DAYS:-1460}
+  archiveServicesAfterDays: ${EXPUNGE_ARCHIVE_SERVICES_AFTER_DAYS:-2555}


### PR DESCRIPTION
## WHAT YOU DID
- Archive services without any transactions in the last 7 years (or based on config number of days).
- Criteria for archiving service is 
  - last transaction (for any linked gateway account) and is older than 7 years
  -  OR created date is older than 7 years

- It is possible that a service doesn't have any transaction and created_date is also null. These will be dealt with separately.

