### PR TITLE
PP-11205 Change the order of deleting user data

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/expungeandarchive/resource/ExpungeAndArchiveHistoricalDataResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/expungeandarchive/resource/ExpungeAndArchiveHistoricalDataResource.java
@@ -27,7 +27,6 @@ public class ExpungeAndArchiveHistoricalDataResource {
     public ExpungeAndArchiveHistoricalDataResource(ExpungeAndArchiveHistoricalDataService expungeAndArchiveHistoricalDataService) {
         this.expungeAndArchiveHistoricalDataService = expungeAndArchiveHistoricalDataService;
     }
-
     @POST
     @Produces(APPLICATION_JSON)
     @Operation(

--- a/src/main/java/uk/gov/pay/adminusers/expungeandarchive/service/ExpungeAndArchiveHistoricalDataService.java
+++ b/src/main/java/uk/gov/pay/adminusers/expungeandarchive/service/ExpungeAndArchiveHistoricalDataService.java
@@ -71,9 +71,9 @@ public class ExpungeAndArchiveHistoricalDataService {
             if (expungeAndArchiveDataConfig.isExpungeAndArchiveHistoricalDataEnabled()) {
                 ZonedDateTime deleteUsersAndRelatedDataBeforeDate = getDeleteUsersAndRelatedDataBeforeDate();
 
-                int noOfUsersDeleted = userDao.deleteUsersNotAssociatedWithAnyService(deleteUsersAndRelatedDataBeforeDate.toInstant());
                 int noOfInvitesDeleted = inviteDao.deleteInvites(deleteUsersAndRelatedDataBeforeDate);
                 int noOfForgottenPasswordsDeleted = forgottenPasswordDao.deleteForgottenPasswords(deleteUsersAndRelatedDataBeforeDate);
+                int noOfUsersDeleted = userDao.deleteUsersNotAssociatedWithAnyService(deleteUsersAndRelatedDataBeforeDate.toInstant());
 
                 int noOfServicesArchived = archiveServices();
 

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/InviteDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/InviteDbFixture.java
@@ -26,6 +26,7 @@ public class InviteDbFixture {
     private Integer loginCounter = 0;
     private String externalServiceId = randomUuid();
     private Integer serviceId = randomInt();
+    private Integer senderId;
 
     private InviteDbFixture(DatabaseTestHelper databaseTestHelper) {
         this.databaseTestHelper = databaseTestHelper;
@@ -40,13 +41,13 @@ public class InviteDbFixture {
         int roleId = RoleDbFixture.roleDbFixture(databaseTestHelper).insertRole().getId();
         String userUsername = randomUuid();
         String userEmail = userUsername + "@example.com";
-        int invitingUserId =
+        senderId =
                 UserDbFixture.userDbFixture(databaseTestHelper)
                         .withEmail(userEmail)
                         .insertUser()
                         .getId();
         databaseTestHelper.addInvite(
-                nextInt(), invitingUserId, serviceId, roleId,
+                nextInt(), senderId, serviceId, roleId,
                 email, code, otpKey, date, expiryDate, telephoneNumber, password,
                 disabled, loginCounter
         );
@@ -122,6 +123,11 @@ public class InviteDbFixture {
 
     public InviteDbFixture withDate(ZonedDateTime date) {
         this.date = date;
+        return this;
+    }
+
+    public InviteDbFixture withSenderId(Integer senderId) {
+        this.senderId = senderId;
         return this;
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Delete forgotten_passwords & invites records first which have foreign key relation to the users table. 
- Delete historical users first could result in a `foreign key constraint violation` if there are references in forgotten_passwords & invites
