### PR TITLE
PP-11355 allow apostrophes and hyphens when searching by service name

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
@@ -100,7 +100,7 @@ public class ServiceRequestValidator {
     }
 
     public Optional<Errors> validateSearchRequest(ServiceSearchRequest request) {
-        var allowedChars = Pattern.compile("^[0-9A-Za-z\\s]+$");
+        var allowedChars = Pattern.compile("^[0-9A-Za-z'\\-\\s]+$");
         var errorList = new ArrayList<String>();
         var values = request.toMap().values().stream()
                 .filter(value -> !isBlank(value))

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceRequestValidatorTest.java
@@ -124,6 +124,13 @@ public class ServiceRequestValidatorTest {
     }
 
     @Test
+    public void shouldAllowWellFormedRequest_whenSearchingServicesWithApostropheAndHyphen() throws JsonProcessingException {
+        var searchRequest = ServiceSearchRequest.from(mapper.readTree("{\"service_name\": \"test's test-name\"}"));
+        Optional<Errors> errors = serviceRequestValidator.validateSearchRequest(searchRequest);
+        assertThat(errors.isPresent(), is(false));
+    }
+
+    @Test
     public void shouldErrorIfSpecialCharsArePresent_whenSearchingServices() throws JsonProcessingException {
         var searchRequest = ServiceSearchRequest.from(mapper.readTree("{\"service_name\": \"!@£\"}"));
         Optional<Errors> errors = serviceRequestValidator.validateSearchRequest(searchRequest);


### PR DESCRIPTION
## WHAT YOU DID

Some services - such as King’s Academy have an apostrophe in their name.

- update regex to allow apostrophes and hyphen in service search payload
