### PR TITLE
PP-11205 Add columns to use when archiving services

### DIFF
--- a/src/main/resources/migrations/00088_alter_services_add_columns_for_archiving.sql
+++ b/src/main/resources/migrations/00088_alter_services_add_columns_for_archiving.sql
@@ -1,0 +1,10 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_services_add_column_first_checked_for_archival_date
+ALTER TABLE services ADD COLUMN first_checked_for_archival_date TIMESTAMP WITH TIME ZONE;
+
+--changeset uk.gov.pay:alter_services_add_column_skip_checking_for_archival_until_date
+ALTER TABLE services ADD COLUMN skip_checking_for_archival_until_date TIMESTAMP WITH TIME ZONE;
+
+--rollback ALTER TABLE services DROP COLUMN first_checked_for_archival_date;
+--rollback ALTER TABLE services DROP COLUMN skip_checking_for_archival_until_date;


### PR DESCRIPTION
## WHAT 
- Added below columns to use when archiving services

1. `first_checked_for_archival_date`

This date will be set when services are checked for archival and not archived

Will mainly be used to select services for archiving where `created_date is not available` and no transactions exist. Any services with `first_checked_for_archival_date` set and no transaction exists for 7 years from this date will be archived.

2. `skip_checking_for_archival_until_date`

For services taking payments, it won't be necessary to check them for archiving again in about a week's time. So this date can be set and used to skip checking services for archiving for 7 years since the last payment.
