### PR TITLE
PP-11279: Run the connector-adminusers messaging pact test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -323,15 +323,15 @@
         </dependency>
         <dependency>
             <groupId>au.com.dius</groupId>
-            <artifactId>pact-jvm-provider-junit_2.12</artifactId>
-            <version>${pact.version}</version>
+            <artifactId>pact-jvm-provider-junit</artifactId>
+            <version>4.0.10</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>au.com.dius</groupId>
-            <artifactId>pact-jvm-consumer-junit_2.12</artifactId>
-            <version>${pact.version}</version>
-            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>xerces</groupId>
+                    <artifactId>xercesImpl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -326,12 +326,6 @@
             <artifactId>pact-jvm-provider-junit</artifactId>
             <version>4.0.10</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>xerces</groupId>
-                    <artifactId>xercesImpl</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>

--- a/src/test/java/uk/gov/pay/adminusers/pact/ConnectorQueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/pact/ConnectorQueueMessageContractTest.java
@@ -8,7 +8,7 @@ import au.com.dius.pact.provider.junit.loader.PactBrokerAuth;
 import org.junit.runner.RunWith;
 
 @RunWith(PactRunner.class)
-@Provider("connector")
+@Provider("adminusers")
 @PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker.deploy.payments.service.gov.uk}", tags = {"${PACT_CONSUMER_TAG}", "test-fargate"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"connector"})


### PR DESCRIPTION
This is safe to merge now as there is no published pact where the provider is adminusers and consumer is connector tagged with "master" and above (i.e. "test-fargate", "staging-fargate" etc). For reference the pact to be published is at https://github.com/alphagov/pay-connector/pull/4837.