### PR TITLE
PP-11205 Set and use new columns when archiving services

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
@@ -108,6 +108,14 @@ public class ServiceEntity {
     @Convert(converter = UTCDateTimeConverter.class)
     private ZonedDateTime archivedDate;
 
+    @Column(name = "first_checked_for_archival_date")
+    @Convert(converter = UTCDateTimeConverter.class)
+    private ZonedDateTime firstCheckedForArchivalDate;
+
+    @Column(name = "skip_checking_for_archival_until_date")
+    @Convert(converter = UTCDateTimeConverter.class)
+    private ZonedDateTime skipCheckingForArchivalUntilDate;
+
     @Column(name = "current_psp_test_account_stage")
     @Enumerated(STRING)
     private PspTestAccountStage currentPspTestAccountStage = PspTestAccountStage.NOT_STARTED;
@@ -273,6 +281,22 @@ public class ServiceEntity {
 
     public void setArchivedDate(ZonedDateTime archivedDate) {
         this.archivedDate = archivedDate;
+    }
+
+    public ZonedDateTime getFirstCheckedForArchivalDate() {
+        return firstCheckedForArchivalDate;
+    }
+
+    public void setFirstCheckedForArchivalDate(ZonedDateTime firstCheckedForArchivalDate) {
+        this.firstCheckedForArchivalDate = firstCheckedForArchivalDate;
+    }
+
+    public ZonedDateTime getSkipCheckingForArchivalUntilDate() {
+        return skipCheckingForArchivalUntilDate;
+    }
+
+    public void setSkipCheckingForArchivalUntilDate(ZonedDateTime skipCheckingForArchivalUntilDate) {
+        this.skipCheckingForArchivalUntilDate = skipCheckingForArchivalUntilDate;
     }
 
     public PspTestAccountStage getCurrentPspTestAccountStage() {

--- a/src/test/java/uk/gov/pay/adminusers/expungeandarchive/service/ExpungeAndArchiveHistoricalDataServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/expungeandarchive/service/ExpungeAndArchiveHistoricalDataServiceTest.java
@@ -319,7 +319,7 @@ class ExpungeAndArchiveHistoricalDataServiceTest {
             expungeAndArchiveHistoricalDataService.expungeAndArchiveHistoricalData();
 
             assertFalse(serviceEntity.isArchived());
-            assertThat(serviceEntity.getFirstCheckedForArchivalDate(), is(systemDate.withZoneSameInstant(UTC)));
+            assertThat(serviceEntity.getFirstCheckedForArchivalDate(), is(systemDate));
             assertThat(serviceEntity.getSkipCheckingForArchivalUntilDate(), is(systemDate.plusDays(7)));
             verifyNoMoreInteractions(mockServiceDao);
         }

--- a/src/test/java/uk/gov/pay/adminusers/expungeandarchive/service/ExpungeAndArchiveHistoricalDataServiceTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/expungeandarchive/service/ExpungeAndArchiveHistoricalDataServiceTest.java
@@ -245,13 +245,13 @@ class ExpungeAndArchiveHistoricalDataServiceTest {
         }
 
         @Test
-        void shouldArchiveServiceWithoutCreatedDateAndFirstButFirstCheckedForArchivalDateIsBeforeTheServicesEligibleForArchivingDate() {
+        void shouldArchiveServiceWithFirstCheckedForArchivalDateBeforeServiceArchivalDate() {
             when(mockExpungeAndArchiveConfig.getArchiveServicesAfterDays()).thenReturn(7);
 
-            LedgerSearchTransactionsResponse searchTransactionsResponse1 = aLedgerSearchTransactionsResponseFixture()
+            LedgerSearchTransactionsResponse searchTransactionsResponse = aLedgerSearchTransactionsResponseFixture()
                     .withTransactionList(List.of())
                     .build();
-            when(mockLedgerService.searchTransactions(gatewayAccountId1, 1)).thenReturn(searchTransactionsResponse1);
+            when(mockLedgerService.searchTransactions(gatewayAccountId1, 1)).thenReturn(searchTransactionsResponse);
 
             serviceEntity = ServiceEntityFixture
                     .aServiceEntity()
@@ -301,7 +301,7 @@ class ExpungeAndArchiveHistoricalDataServiceTest {
         void shouldNotArchiveService_WhenTheFirstCheckedForArchivalDateIsAfterTheServicesEligibleForArchivingDate() {
             when(mockExpungeAndArchiveConfig.getArchiveServicesAfterDays()).thenReturn(7);
 
-            LedgerSearchTransactionsResponse searchTransactionsResponse1 = aLedgerSearchTransactionsResponseFixture()
+            LedgerSearchTransactionsResponse searchTransactionsResponse = aLedgerSearchTransactionsResponseFixture()
                     .withTransactionList(List.of())
                     .build();
 
@@ -313,7 +313,7 @@ class ExpungeAndArchiveHistoricalDataServiceTest {
                     .withGatewayAccounts(List.of(gatewayAccountIdEntity1))
                     .build();
 
-            when(mockLedgerService.searchTransactions(gatewayAccountId1, 1)).thenReturn(searchTransactionsResponse1);
+            when(mockLedgerService.searchTransactions(gatewayAccountId1, 1)).thenReturn(searchTransactionsResponse);
             when(mockServiceDao.findServicesToCheckForArchiving(systemDate.minusDays(7))).thenReturn(List.of(serviceEntity));
 
             expungeAndArchiveHistoricalDataService.expungeAndArchiveHistoricalData();
@@ -371,13 +371,13 @@ class ExpungeAndArchiveHistoricalDataServiceTest {
         }
 
         @Test
-        void shouldNotArchiveServiceWhenLedgerReturnsNoTransactionsAndCreatedDateOrFirstCheckedForArchivalDateAreNotAvailableOnService() {
+        void shouldNotArchiveService_WhenLedgerReturnsNoTransactions_AndCreatedDateOrFirstCheckedForArchivalDateAreNotAvailable() {
             when(mockExpungeAndArchiveConfig.getArchiveServicesAfterDays()).thenReturn(7);
 
-            LedgerSearchTransactionsResponse searchTransactionsResponse1 = aLedgerSearchTransactionsResponseFixture()
+            LedgerSearchTransactionsResponse searchTransactionsResponse = aLedgerSearchTransactionsResponseFixture()
                     .withTransactionList(List.of())
                     .build();
-            when(mockLedgerService.searchTransactions(gatewayAccountId1, 1)).thenReturn(searchTransactionsResponse1);
+            when(mockLedgerService.searchTransactions(gatewayAccountId1, 1)).thenReturn(searchTransactionsResponse);
 
             serviceEntity = ServiceEntityFixture
                     .aServiceEntity()

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/ServiceEntityFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/ServiceEntityFixture.java
@@ -39,6 +39,7 @@ public final class ServiceEntityFixture {
     private PspTestAccountStage pspTestAccountStage = PspTestAccountStage.NOT_STARTED;
     private boolean archived = false;
     private ZonedDateTime archivedDate;
+    private ZonedDateTime firstCheckedForArchivalDate;
 
     private ServiceEntityFixture() {
     }
@@ -139,6 +140,11 @@ public final class ServiceEntityFixture {
         return this;
     }
 
+    public ServiceEntityFixture withFirstCheckedForArchivalDate(ZonedDateTime firstCheckedForArchivalDate) {
+        this.firstCheckedForArchivalDate = firstCheckedForArchivalDate;
+        return this;
+    }
+
     public ServiceEntity build() {
         ServiceEntity serviceEntity = new ServiceEntity();
         serviceEntity.setId(id);
@@ -159,6 +165,7 @@ public final class ServiceEntityFixture {
         serviceEntity.setCurrentPspTestAccountStage(pspTestAccountStage);
         serviceEntity.setArchived(archived);
         serviceEntity.setArchivedDate(archivedDate);
+        serviceEntity.setFirstCheckedForArchivalDate(firstCheckedForArchivalDate);
         return serviceEntity;
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoIT.java
@@ -53,6 +53,7 @@ public class UserDaoIT extends DaoTestBase {
         userDao = env.getInstance(UserDao.class);
         serviceDao = env.getInstance(ServiceDao.class);
         roleDao = env.getInstance(RoleDao.class);
+        databaseHelper.truncateAllData();
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID
- Sets `firstCheckedForArchivalDate` when a service is NOT archived.
   - This date is used to archive service when no transactions/created_date exist.
- Also sets `skipCheckingForArchivalUntilDate`. This is used to skip checking services for archiving if there are active payments or recently created services.
   - The date is calculated in this order 
          1.  last transaction date + archiveServicesAfterDays 
          2. created_date + archiveServicesAfterDays 
          3. firstCheckedForArchivalDate + archiveServicesAfterDays

