### PR TITLE
PP-11812 Log when users are removed from service

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/persistence/dao/ServiceRoleDao.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/dao/ServiceRoleDao.java
@@ -6,6 +6,7 @@ import com.google.inject.persist.Transactional;
 import uk.gov.pay.adminusers.persistence.entity.ServiceRoleEntity;
 
 import javax.persistence.EntityManager;
+import java.util.List;
 
 @Transactional
 public class ServiceRoleDao extends JpaDao<ServiceRoleEntity> {
@@ -20,5 +21,12 @@ public class ServiceRoleDao extends JpaDao<ServiceRoleEntity> {
                 .createQuery("DELETE from ServiceRoleEntity where service.id = :serviceId")
                 .setParameter("serviceId", serviceId)
                 .executeUpdate();
+    }
+
+    public List<ServiceRoleEntity> findServiceUserRoles(Integer serviceId) {
+        return entityManager.get()
+                .createQuery("select sre from ServiceRoleEntity sre where sre.service.id = :serviceId")
+                .setParameter("serviceId", serviceId)
+                .getResultList();
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Log user IDs when users are removed from service after a service is archived. This will be useful when a service is accidentally archived and we have to reinstate users
