### PR TITLE
BAU — Tell Dependabot to ignore dropwizard-testing-junit4 version 4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
         # Dropwizard 4.x only works with Jakarta EE and not Java EE
         versions:
           - ">= 4"
+      - dependency-name: "io.dropwizard.modules:dropwizard-testing-junit4"
+        # dropwizard-testing-junit4 only works with Dropwizard 4.x
+        versions:
+          - ">= 4"
       - dependency-name: "org.dhatim:dropwizard-sentry"
         # We essentially forked Dropwizard Sentry because it did not support
         # Dropwizard 3.x — there is now a Dropwizard Sentry 4.x, which supports


### PR DESCRIPTION
Tell Dependabot to ignore dropwizard-testing-junit4 version 4 because it only works with Dropwizard 4.x and we are using Dropwizard 3.x.