### PR TITLE
Revert "Bump com.amazonaws:aws-java-sdk-bom from 1.12.603 to 1.12.610"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.12.610</version>
+                <version>1.12.603</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Reverts alphagov/pay-adminusers#2305.

Seems to be causing end-to-end tests to fail.