### PR TITLE
PP-12520 Dependabot: fix comment about dropwizard-testing-junit4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
         versions:
           - ">= 4"
       - dependency-name: "io.dropwizard.modules:dropwizard-testing-junit4"
-        # dropwizard-testing-junit4 only works with Dropwizard 4.x
+        # dropwizard-testing-junit4 4.x only works with Dropwizard 4.x
         versions:
           - ">= 4"
       - dependency-name: "org.dhatim:dropwizard-sentry"


### PR DESCRIPTION
Include a version in the comment about dropwizard-testing-junit4 in the Dependabot configuration.