### PR TITLE
PP-12570 Update GitHub action job name

### DIFF
--- a/.github/workflows/_run-tests.yml
+++ b/.github/workflows/_run-tests.yml
@@ -45,7 +45,7 @@ jobs:
 
   provider-contract-tests:
     needs: integration-tests
-    name: "App as provider contract tests"
+    name: "App as provider tests"
     uses: alphagov/pay-ci/.github/workflows/_run-app-as-provider-contract-tests.yml@master
     secrets:
       pact_broker_username: ${{ secrets.pact_broker_username }}


### PR DESCRIPTION
## WHAT
- Updated job name so in GitHub checks it appears as `PR / tests / App as provider tests / Contract tests (pull_request) ` instead of `PR / tests / App as provider contract tests / Contract tests (pull_request) `