### PR TITLE
PP-12177 update exception mapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hamcrest.version>2.2</hamcrest.version>
         <pact.version>3.6.15</pact.version>
-        <pay-java-commons.version>1.0.20240523151942</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20240528083746</pay-java-commons.version>
         <prometheus.version>0.16.0</prometheus.version>
         <swaggger-version>2.2.22</swaggger-version>
         <surefire.version>3.2.5</surefire.version>

--- a/src/main/java/uk/gov/pay/adminusers/app/AdminUsersApp.java
+++ b/src/main/java/uk/gov/pay/adminusers/app/AdminUsersApp.java
@@ -8,6 +8,7 @@ import io.dropwizard.core.Application;
 import io.dropwizard.core.setup.Bootstrap;
 import io.dropwizard.core.setup.Environment;
 import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.jersey.jackson.JsonProcessingExceptionMapper;
 import io.dropwizard.migrations.MigrationsBundle;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.dropwizard.DropwizardExports;
@@ -100,6 +101,8 @@ public class AdminUsersApp extends Application<AdminUsersConfig> {
         environment.jersey().register(injector.getInstance(HealthCheckResource.class));
         environment.jersey().register(injector.getInstance(EmailResource.class));
         environment.jersey().register(injector.getInstance(ExpungeAndArchiveHistoricalDataResource.class));
+
+        environment.jersey().register(new JsonProcessingExceptionMapper(true));
 
         // Register the custom ExceptionMapper(s)
         environment.jersey().register(new ValidationExceptionMapper());


### PR DESCRIPTION
## WHAT YOU DID

Updating to testcontainers through pay-java-commons has triggered an unwanted error leading InviteResourceServiceCompleteIT.shouldReturn400_whenUnsupportedSecondFactorMethodSupplied failing. `JsonProcessingExceptionMapper` defaults to not showing details of the validation/processing error.

- update pay-java-commons to `1.0.20240528083746`
- register `JsonProcessingExceptionMapper` with showDetails set to true
