### PR TITLE
PP-12726 Upgrade to Java 21

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,7 +44,7 @@ updates:
     ignore:
       - dependency-name: "eclipse-temurin"
         versions:
-          - "> 11"
+          - "> 21"
     open-pull-requests-limit: 10
     labels:
       - dependencies
@@ -58,7 +58,7 @@ updates:
     ignore:
       - dependency-name: "eclipse-temurin"
         versions:
-          - "> 11"
+          - "> 21"
     open-pull-requests-limit: 10
     labels:
       - dependencies

--- a/.github/workflows/_run-tests.yml
+++ b/.github/workflows/_run-tests.yml
@@ -25,6 +25,7 @@ jobs:
     uses: alphagov/pay-ci/.github/workflows/_run-java-tests-and-publish-pacts.yml@master
     with:
       publish_pacts: true
+      java_version: "21"
     secrets:
       pact_broker_username: ${{ secrets.pact_broker_username }}
       pact_broker_password: ${{ secrets.pact_broker_password }}
@@ -39,6 +40,7 @@ jobs:
     with:
       consumer: adminusers
       provider: ${{ matrix.provider }}
+      java_version: "21"
     secrets:
       pact_broker_username: ${{ secrets.pact_broker_username }}
       pact_broker_password: ${{ secrets.pact_broker_password }}
@@ -50,3 +52,13 @@ jobs:
     secrets:
       pact_broker_username: ${{ secrets.pact_broker_username }}
       pact_broker_password: ${{ secrets.pact_broker_password }}
+    with:
+      java_version: "21"
+
+  check-docker-base-images-are-manifests:
+    uses: alphagov/pay-ci/.github/workflows/_validate_docker_image_is_manifest.yml@master
+
+  check-docker-base-images-for-m1-are-manifests:
+    uses: alphagov/pay-ci/.github/workflows/_validate_docker_image_is_manifest.yml@master
+    with:
+      dockerfile: "m1/arm64.Dockerfile"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,10 +36,10 @@ jobs:
             paths:
               - 'src/**'
 
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
         with:
-          java-version: '11'
+          java-version: '21'
           distribution: 'adopt'
 
       - name: Compile project

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -335,7 +335,7 @@
         "filename": "src/test/java/uk/gov/pay/adminusers/persistence/dao/GovUkPayAgreementDaoIT.java",
         "hashed_secret": "c3a8fcf85a56dee95cff4ce7adf0bb9a4c18f747",
         "is_verified": false,
-        "line_number": 77
+        "line_number": 78
       }
     ],
     "src/test/java/uk/gov/pay/adminusers/resources/InviteResourceOtpIT.java": [
@@ -466,5 +466,5 @@
       }
     ]
   },
-  "generated_at": "2023-11-08T10:45:43Z"
+  "generated_at": "2024-06-10T06:56:20Z"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM maven:3.9.5-eclipse-temurin-11-alpine@sha256:5b8e35bd58fc6d6d78fa7faa34c0a895f897ce90a10ab1e2c31e2eb5c62ee027 AS builder
+FROM maven:3.9.7-eclipse-temurin-21-alpine@sha256:8b762a139e07e874e3830521d97bafaf963cce6bda92afe9fb532def5d011404 AS builder
 
 WORKDIR /home/build
 COPY . .
 
 RUN ["mvn", "clean", "--no-transfer-progress", "package", "-DskipTests"]
 
-FROM eclipse-temurin:11-jre-alpine@sha256:77899ea444d0c219f3a4f500923dcae6b4b28db239b80c5214f26c1167ba74b5 AS final
+FROM eclipse-temurin:21-jre-alpine@sha256:23467b3e42617ca197f43f58bc5fb03ca4cb059d68acd49c67128bfded132d67 AS final
 
 RUN ["apk", "--no-cache", "upgrade"]
 

--- a/m1/arm64.Dockerfile
+++ b/m1/arm64.Dockerfile
@@ -1,11 +1,13 @@
-FROM maven:3.9.5-eclipse-temurin-11@sha256:d698c543af44a1a8e4b2b2f9c1cfe3e009f2398cc7125a3d1204c71ad876800f AS builder
+FROM maven:3.9.7-eclipse-temurin-21-alpine@sha256:8b762a139e07e874e3830521d97bafaf963cce6bda92afe9fb532def5d011404 AS builder
 
 WORKDIR /home/build
 COPY . .
 
 RUN ["mvn", "clean", "--no-transfer-progress", "package", "-DskipTests"]
 
-FROM eclipse-temurin:11-jre@sha256:f31717a7a4c0d7cc9e50008544d269c90d6894dd70cdcbb28da8060913fcf8ad AS final
+FROM eclipse-temurin:21-jre-alpine@sha256:23467b3e42617ca197f43f58bc5fb03ca4cb059d68acd49c67128bfded132d67 AS final
+
+RUN ["apk", "--no-cache", "upgrade"]
 
 ARG DNS_TTL=15
 
@@ -14,11 +16,10 @@ ENV LANG C.UTF-8
 
 RUN echo networkaddress.cache.ttl=$DNS_TTL >> "$JAVA_HOME/conf/security/java.security"
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y tini wget
+COPY ./import_aws_rds_cert_bundles.sh /
+RUN /import_aws_rds_cert_bundles.sh && rm /import_aws_rds_cert_bundles.sh
 
-COPY import_aws_rds_cert_bundles.sh /
-RUN /import_aws_rds_cert_bundles.sh
-RUN rm /import_aws_rds_cert_bundles.sh
+RUN ["apk", "add", "--no-cache", "bash", "tini"]
 
 ENV PORT 8080
 ENV ADMIN_PORT 8081

--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>3.0.21</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
             <version>1.9.4</version>
@@ -355,9 +361,9 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>au.com.dius</groupId>
-                <artifactId>pact-jvm-provider-maven_2.12</artifactId>
-                <version>${pact.version}</version>
+                <groupId>au.com.dius.pact.provider</groupId>
+                <artifactId>maven</artifactId>
+                <version>4.6.10</version>
                 <configuration>
                     <pactDirectory>target/pacts</pactDirectory>
                     <pactBrokerUrl>${PACT_BROKER_URL}</pactBrokerUrl>
@@ -374,7 +380,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
                 <configuration>
-                    <release>11</release>
+                    <release>21</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/GovUkPayAgreementDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/GovUkPayAgreementDaoIT.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.time.temporal.ChronoUnit.MICROS;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -37,7 +38,7 @@ public class GovUkPayAgreementDaoIT extends DaoTestBase {
         Service service = serviceDbFixture(databaseHelper)
                 .withGatewayAccountIds(randomInt().toString())
                 .insertService();
-        ZonedDateTime dateTime = ZonedDateTime.now(ZoneOffset.UTC);
+        ZonedDateTime dateTime = ZonedDateTime.now(ZoneOffset.UTC).truncatedTo(MICROS);
         GovUkPayAgreementEntity newEntity = new GovUkPayAgreementEntity("someone@example.org", dateTime);
         Optional<ServiceEntity> serviceEntity = serviceDao.findByExternalId(service.getExternalId());
         newEntity.setService(serviceEntity.get());

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/InviteDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/InviteDaoIT.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 
 import static java.sql.Timestamp.from;
 import static java.time.ZonedDateTime.parse;
+import static java.time.temporal.ChronoUnit.MICROS;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -78,7 +79,7 @@ class InviteDaoIT extends DaoTestBase {
         assertThat(savedInvite.get(0).get("otp_key"), is(notNullValue()));
         assertThat(savedInvite.get(0).get("otp_key"), is(invite.getOtpKey()));
         assertThat(savedInvite.get(0).get("telephone_number"), is(nullValue()));
-        assertThat(savedInvite.get(0).get("date"), is(from(invite.getDate().toInstant())));
+        assertThat(savedInvite.get(0).get("date"), is(from(invite.getDate().toInstant().truncatedTo(MICROS))));
         assertThat(savedInvite.get(0).get("disabled"), is(Boolean.FALSE));
         assertThat(savedInvite.get(0).get("login_counter"), is(0));
     }

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/StripeAgreementDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/StripeAgreementDaoIT.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.time.temporal.ChronoUnit.MICROS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -45,7 +46,7 @@ public class StripeAgreementDaoIT extends DaoTestBase {
         Optional<ServiceEntity> serviceEntity = serviceDao.findByExternalId(service.getExternalId());
         assertThat(serviceEntity.isPresent(), is(true));
 
-        StripeAgreementEntity stripeAgreementEntity = new StripeAgreementEntity(serviceEntity.get(), "192.0.2.0", ZonedDateTime.now(ZoneId.of("UTC")));
+        StripeAgreementEntity stripeAgreementEntity = new StripeAgreementEntity(serviceEntity.get(), "192.0.2.0", ZonedDateTime.now(ZoneId.of("UTC")).truncatedTo(MICROS));
         stripeAgreementDao.persist(stripeAgreementEntity);
 
         assertThat(stripeAgreementEntity.getId(), is(notNullValue()));
@@ -83,7 +84,7 @@ public class StripeAgreementDaoIT extends DaoTestBase {
         Service service = serviceDbFixture(databaseHelper)
                 .insertService();
 
-        ZonedDateTime agreementTime = ZonedDateTime.now(ZoneOffset.UTC);
+        ZonedDateTime agreementTime = ZonedDateTime.now(ZoneOffset.UTC).truncatedTo(MICROS);
         String ipAddress = "192.0.2.0";
         
         stripeAgreementDbFixture(databaseHelper)

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/UserDaoIT.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.valueOf;
 import static java.time.ZonedDateTime.parse;
+import static java.time.temporal.ChronoUnit.MICROS;
 import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.apache.commons.lang3.RandomUtils.nextInt;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -80,7 +81,7 @@ public class UserDaoIT extends DaoTestBase {
         userEntity.setTelephoneNumber("+447700900000");
         userEntity.setSecondFactor(SecondFactorMethod.SMS);
         userEntity.setSessionVersion(0);
-        ZonedDateTime timeNow = ZonedDateTime.now(ZoneId.of("UTC"));
+        ZonedDateTime timeNow = ZonedDateTime.now(ZoneId.of("UTC")).truncatedTo(MICROS);
         userEntity.setCreatedAt(timeNow);
         userEntity.setUpdatedAt(timeNow);
 


### PR DESCRIPTION
## WHAT
- Upgrades to Java 21
- Also upgrades pact provider plugin
- Updated some tests for datetime granularity as they were failing on Github Actions due to Instant() returning time with nano-second granularity and values from the database are at the microsecond level. nano-second granularity shouldn't be an issue as Postgres supports only up to microsecond resolution (https://www.postgresql.org/docs/15/datatype-datetime.html) and in the API we are returning date/time in milliseconds (ex: https://github.com/alphagov/pay-adminusers/blob/master/openapi/adminusers_spec.yaml#L1228)
