### PR TITLE
PP-12726 Fix flakey test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,12 +328,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy</artifactId>
-            <version>3.0.21</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
             <version>1.9.4</version>

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/InviteEntity.java
@@ -18,6 +18,7 @@ import java.util.Locale;
 import java.util.Optional;
 
 import static java.time.temporal.ChronoUnit.DAYS;
+import static java.time.temporal.ChronoUnit.MICROS;
 import static uk.gov.pay.adminusers.persistence.entity.UTCDateTimeConverter.UTC;
 
 @Entity
@@ -76,7 +77,7 @@ public class InviteEntity extends AbstractEntity {
 
     public InviteEntity(String email, String code, String otpKey, RoleEntity role) {
         super();
-        this.date = ZonedDateTime.now(ZoneId.of("UTC"));
+        this.date = ZonedDateTime.now(ZoneId.of("UTC")).truncatedTo(MICROS);
         initializeExpiry();
         this.code = code;
         this.otpKey = otpKey;

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/InviteDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/InviteDaoIT.java
@@ -79,7 +79,7 @@ class InviteDaoIT extends DaoTestBase {
         assertThat(savedInvite.get(0).get("otp_key"), is(notNullValue()));
         assertThat(savedInvite.get(0).get("otp_key"), is(invite.getOtpKey()));
         assertThat(savedInvite.get(0).get("telephone_number"), is(nullValue()));
-        assertThat(savedInvite.get(0).get("date"), is(from(invite.getDate().toInstant().truncatedTo(MICROS))));
+        assertThat(savedInvite.get(0).get("date"), is(from(invite.getDate().toInstant())));
         assertThat(savedInvite.get(0).get("disabled"), is(Boolean.FALSE));
         assertThat(savedInvite.get(0).get("login_counter"), is(0));
     }


### PR DESCRIPTION
## WHAT YOU DID
- Fixes flakey test by truncating Instant to microseconds before inserting into DB. Truncating at the time of asserting field rounds up the microsecond precision which doesn't match the DB value and causes the test (`InviteDaoIT.create_shouldCreateAnInvite`) to fail
- Also removed unused library