### PR TITLE
BAU — Replace switch statement with switch expression with patterns

### DIFF
--- a/src/main/java/uk/gov/pay/adminusers/utils/dispute/DisputeReasonMapper.java
+++ b/src/main/java/uk/gov/pay/adminusers/utils/dispute/DisputeReasonMapper.java
@@ -1,30 +1,18 @@
 package uk.gov.pay.adminusers.utils.dispute;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
-
 public class DisputeReasonMapper {
 
     public static String mapToNotifyEmail(String stripeReason) {
-        if (isBlank(stripeReason)) {
-            return "unknown";
-        }
-        switch (stripeReason) {
-            case "duplicate":
-            case "fraudulent":
-            case "general":
-                return stripeReason;
-            case "credit_not_processed":
-                return "credit not processed";
-            case "product_not_received":
-                return "product not received";
-            case "product_unacceptable":
-                return "product unacceptable";
-            case "subscription_canceled":
-                return "subscription cancelled";
-            case "unrecognized":
-                return "unrecognised";
-            default:
-                return "other";
-        }
+        return switch (stripeReason) {
+            case null -> "unknown";
+            case String reason when reason.isBlank() -> "unknown";
+            case "duplicate", "fraudulent", "general" -> stripeReason;
+            case "credit_not_processed" -> "credit not processed";
+            case "product_not_received" -> "product not received";
+            case "product_unacceptable" -> "product unacceptable";
+            case "subscription_canceled" -> "subscription cancelled";
+            case "unrecognized" -> "unrecognised";
+            default -> "other";
+        };
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/utils/dispute/DisputeReasonMapperTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/dispute/DisputeReasonMapperTest.java
@@ -1,12 +1,44 @@
 package uk.gov.pay.adminusers.utils.dispute;
 
-
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class DisputeReasonMapperTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"duplicate", "fraudulent", "general"})
+    void shouldReturnPassedThroughUnmodifiedValues(String stripeReason) {
+        String mappedValue = DisputeReasonMapper.mapToNotifyEmail(stripeReason);
+        assertThat(mappedValue, is(stripeReason));
+    }
+
+    @Test
+    void shouldReturnCreditNotProcessed() {
+        String mappedValue = DisputeReasonMapper.mapToNotifyEmail("credit_not_processed");
+        assertThat(mappedValue, is("credit not processed"));
+    }
+
+    @Test
+    void shouldReturnProductNotReceived() {
+        String mappedValue = DisputeReasonMapper.mapToNotifyEmail("product_not_received");
+        assertThat(mappedValue, is("product not received"));
+    }
+
+    @Test
+    void shouldReturnProductUnacceptable() {
+        String mappedValue = DisputeReasonMapper.mapToNotifyEmail("product_unacceptable");
+        assertThat(mappedValue, is("product unacceptable"));
+    }
+
+    @Test
+    void shouldReturnProductSubscriptionCancelled() {
+        String mappedValue = DisputeReasonMapper.mapToNotifyEmail("subscription_canceled");
+        assertThat(mappedValue, is("subscription cancelled"));
+    }
 
     @Test
     void shouldReturnUnrecognised() {
@@ -31,4 +63,11 @@ class DisputeReasonMapperTest {
         String mappedValue = DisputeReasonMapper.mapToNotifyEmail("");
         assertThat(mappedValue, is("unknown"));
     }
+
+    @Test
+    void shouldHandleAllWhitespaceValue() {
+        String mappedValue = DisputeReasonMapper.mapToNotifyEmail(" ");
+        assertThat(mappedValue, is("unknown"));
+    }
+
 }


### PR DESCRIPTION
Replace a switch statement with a switch expression (with pattern matching!) just because we can now we’re using Java 21.

Add some more tests (which pass with both the old code and the new code to ensure we’re not changing any behaviour).

(The old code used Apache Commons’ `StringUtils.isBlank(…)`, which uses `Character.isWhitespace(char)`, which does not support supplementary characters. The new code uses `String.isBlank(…)`, which uses `Character.isWhitespace(int)`, which does support supplementary characters. It is my understanding that all whitespace characters belong to the basic multilingual plane, so this should not change any behaviour. If I am wrong, the behaviour change is likely to be inconsequential: some `"other"` outputs may become `"unknown"` — but it seems extremely unlikely Stripe would send us reasons containing less common whitespace characters in the first place.)