### PR TITLE
PP-12767 remove unnecessary logging

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -267,7 +263,7 @@
         "filename": "src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java",
         "hashed_secret": "1976a945a8d2733655e4b2453bd49fb59cb7ba19",
         "is_verified": false,
-        "line_number": 388
+        "line_number": 383
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/resources/ToolboxEndpointResource.java": [
@@ -299,7 +295,7 @@
         "filename": "src/main/java/uk/gov/pay/adminusers/resources/UserResource.java",
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_verified": false,
-        "line_number": 441
+        "line_number": 440
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/service/ForgottenPasswordServices.java": [
@@ -466,5 +462,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-10T06:56:20Z"
+  "generated_at": "2024-07-02T10:54:33Z"
 }

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
@@ -148,7 +148,6 @@ public class ServiceResource {
     )
     public Response findService(@Parameter(example = "7d19aff33f8948deb97ed16b2912dcd3") @PathParam("serviceExternalId")
                                 String serviceExternalId) {
-        LOGGER.info("Find Service request - [ {} ]", serviceExternalId);
         return serviceDao.findByExternalId(serviceExternalId)
                 .map(serviceEntity ->
                         Response.status(OK).entity(linksBuilder.decorate(serviceEntity.toService())).build())
@@ -169,7 +168,6 @@ public class ServiceResource {
             }
     )
     public Response findServices(@Parameter(example = "1") @QueryParam("gatewayAccountId") String gatewayAccountId) {
-        LOGGER.info("Find service by gateway account id request - [ {} ]", gatewayAccountId);
         return serviceRequestValidator.validateFindRequest(gatewayAccountId)
                 .map(errors -> Response.status(BAD_REQUEST).entity(errors).build())
                 .orElseGet(() -> serviceServicesFactory.serviceFinder().byGatewayAccountId(gatewayAccountId)
@@ -302,7 +300,6 @@ public class ServiceResource {
     public Response updateServiceAttribute(@Parameter(example = "7d19aff33f8948deb97ed16b2912dcd3")
                                            @PathParam("serviceExternalId") String serviceExternalId,
                                            JsonNode payload) {
-        LOGGER.info("Service PATCH request - [ {} ]", serviceExternalId);
         return serviceRequestValidator.validateUpdateAttributeRequest(payload)
                 .map(errors -> Response.status(BAD_REQUEST).entity(errors).build())
                 .orElseGet(() -> processUpdateServiceAttributePayload(serviceExternalId, payload));
@@ -334,7 +331,6 @@ public class ServiceResource {
                                                  @Parameter(schema = @Schema(implementation = UpdateMerchantDetailsRequest.class))
                                                  JsonNode payload)
             throws ValidationException, ServiceNotFoundException {
-        LOGGER.info("Service PUT request to update merchant details - [ {} ]", serviceExternalId);
         serviceRequestValidator.validateUpdateMerchantDetailsRequest(payload);
         Service service = serviceServicesFactory.serviceUpdater().doUpdateMerchantDetails(
                 serviceExternalId, UpdateMerchantDetailsRequest.from(payload));
@@ -355,7 +351,6 @@ public class ServiceResource {
             }
     )
     public Response findUsersByServiceId(@PathParam("serviceExternalId") String serviceExternalId) {
-        LOGGER.info("Service users GET request - [ {} ]", serviceExternalId);
         return serviceDao.findByExternalId(serviceExternalId)
                 .map(serviceEntity ->
                         Response.status(200).entity(
@@ -389,16 +384,12 @@ public class ServiceResource {
                                           @PathParam("userExternalId") String userExternalId,
                                           @Parameter(example = "d012mkldfdfnsdhqha7f0ee748ff1546", required = true, description = "User external ID to remove from service")
                                           @HeaderParam(HEADER_USER_CONTEXT) String userContext) {
-        LOGGER.info("Service users DELETE request - serviceExternalId={}, userExternalId={}", serviceExternalId, userExternalId);
         if (isBlank(userContext)) {
             return Response.status(Status.FORBIDDEN).build();
         } else if (userExternalId.equals(userContext)) {
-            LOGGER.info("Failed Service users DELETE request. User and Remover cannot be the same - " +
-                    "serviceExternalId={}, removerExternalId={}, userExternalId={}", serviceExternalId, userContext, userExternalId);
             return Response.status(CONFLICT).build();
         }
         serviceServicesFactory.serviceUserRemover().remove(userExternalId, userContext, serviceExternalId);
-        LOGGER.info("Succeeded Service users DELETE request - serviceExternalId={}, removerExternalId={}, userExternalId={}", serviceExternalId, userContext, userExternalId);
         return Response.status(NO_CONTENT).build();
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/UserResource.java
@@ -172,7 +172,6 @@ public class UserResource {
     )
     public Response getUsers(@Parameter(schema = @Schema(example = "93ba1ec4ed6a4238a59f16ad97b4fa12,1234"))
                              @QueryParam("ids") String externalIds) {
-        LOGGER.info("Users GET request - [ {} ]", externalIds);
         List<String> externalIdsList = COMMA_SEPARATOR.splitToList(externalIds);
 
         List<User> users = userServices.findUsersByExternalIds(externalIdsList);
@@ -475,7 +474,6 @@ public class UserResource {
     )
     public Response createServiceRole(@Parameter(example = "93ba1ec4ed6a4238a59f16ad97b4fa12")
                                       @PathParam("userExternalId") String userExternalId, JsonNode payload) {
-        LOGGER.info("Assign service role to a user {} request", userExternalId);
         return validator.validateAssignServiceRequest(payload)
                 .map(errors -> Response.status(BAD_REQUEST).entity(errors).build())
                 .orElseGet(() -> {


### PR DESCRIPTION
The latest IT Healthcheck identified a number of logging statements which could potentially result in unsanitised PII being logged. In several of these cases, these logging statements were found to be unnecessary as the relevant information is already logged in the API call, so they are being removed rather than spending time investigating the risk around logging PII.

- remove unnecessary logging statements