### PR TITLE
PP-11723 upgrade guice to v6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,10 +23,9 @@ updates:
         versions:
           - ">= 4"
       - dependency-name: "com.google.inject:guice-bom"
-        # Guice 6.x requires compatibility work on our side
         # Guice 7.x only works with Jakarta EE and not Java EE
         versions:
-          - ">= 6"
+          - ">= 7"
       - dependency-name: "org.eclipse.persistence:org.eclipse.persistence.jpa"
         # Version 3.x and above only works with Jakarta EE and not Java EE
         versions:

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
             <dependency>
                 <groupId>com.google.inject</groupId>
                 <artifactId>guice-bom</artifactId>
-                <version>5.1.0</version>
+                <version>6.0.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -59,10 +59,22 @@
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.inject</groupId>
+                    <artifactId>jakarta.inject-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-auth</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.inject</groupId>
+                    <artifactId>jakarta.inject-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -79,6 +91,12 @@
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.inject</groupId>
+                    <artifactId>jakarta.inject-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.inject.extensions</groupId>
@@ -244,6 +262,11 @@
             <groupId>uk.gov.service.payments</groupId>
             <artifactId>logging-dropwizard-3</artifactId>
             <version>${pay-java-commons.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <version>2.0.1.MR</version>
         </dependency>
 
         <!-- Test dependencies that are imported from one of the BOMs specified

--- a/src/main/java/uk/gov/pay/adminusers/persistence/dao/RoleDao.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/dao/RoleDao.java
@@ -3,6 +3,7 @@ package uk.gov.pay.adminusers.persistence.dao;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import com.google.inject.persist.Transactional;
 import uk.gov.pay.adminusers.persistence.entity.RoleEntity;
 
 import javax.persistence.EntityManager;
@@ -15,6 +16,7 @@ import java.util.Optional;
  * </p>
  *     @see uk.gov.pay.adminusers.persistence.entity.RoleEntity
  */
+@Transactional
 public class RoleDao {
 
     private final Provider<EntityManager> entityManager;


### PR DESCRIPTION
## WHAT YOU DID

Upgrade project to use Guice v6

Add Transactional annotation to RoleDao. It was missing and Guice 6 is a stricter implementation.
