### PR TITLE
PP-12789 upgrade to pay-java-commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hamcrest.version>2.2</hamcrest.version>
         <pact.version>3.6.15</pact.version>
-        <pay-java-commons.version>1.0.20240603094506</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20240711152628</pay-java-commons.version>
         <prometheus.version>0.16.0</prometheus.version>
         <swaggger-version>2.2.22</swaggger-version>
         <surefire.version>3.3.0</surefire.version>

--- a/src/test/java/uk/gov/pay/adminusers/client/ledger/service/LedgerServiceConsumerTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/client/ledger/service/LedgerServiceConsumerTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.adminusers.client.ledger.service;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,8 +12,8 @@ import uk.gov.pay.adminusers.app.config.AdminUsersConfig;
 import uk.gov.pay.adminusers.app.config.RestClientConfig;
 import uk.gov.pay.adminusers.client.ledger.model.LedgerSearchTransactionsResponse;
 import uk.gov.pay.adminusers.client.ledger.model.LedgerTransaction;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import javax.ws.rs.client.Client;
 import java.util.Optional;
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.when;
 public class LedgerServiceConsumerTest {
 
     @Rule
-    public PactProviderRule ledgerRule = new PactProviderRule("ledger", this);
+    public PayPactProviderRule ledgerRule = new PayPactProviderRule("ledger", this);
 
     @Mock
     AdminUsersConfig configuration;

--- a/src/test/java/uk/gov/pay/adminusers/pact/queuemessage/DisputeCreatedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/pact/queuemessage/DisputeCreatedEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.adminusers.pact.queuemessage;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;

--- a/src/test/java/uk/gov/pay/adminusers/pact/queuemessage/DisputeEvidenceSubmittedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/pact/queuemessage/DisputeEvidenceSubmittedEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.adminusers.pact.queuemessage;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;

--- a/src/test/java/uk/gov/pay/adminusers/pact/queuemessage/DisputeLostEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/pact/queuemessage/DisputeLostEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.adminusers.pact.queuemessage;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;

--- a/src/test/java/uk/gov/pay/adminusers/pact/queuemessage/DisputeWonEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/pact/queuemessage/DisputeWonEventQueueConsumerIT.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.adminusers.pact.queuemessage;
 
 import au.com.dius.pact.consumer.MessagePactBuilder;
-import au.com.dius.pact.consumer.MessagePactProviderRule;
-import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.PactVerification;
-import au.com.dius.pact.model.v3.messaging.MessagePact;
+import au.com.dius.pact.consumer.junit.MessagePactProviderRule;
+import au.com.dius.pact.consumer.junit.PactVerification;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.messaging.MessagePact;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;

--- a/src/test/resources/pacts/adminusers-ledger-get-payment-transaction.json
+++ b/src/test/resources/pacts/adminusers-ledger-get-payment-transaction.json
@@ -34,7 +34,7 @@
         },
         "body": {
           "reference": "my reference",
-          "transaction_id": "e8eq11mi2ndmauvb51qsg8hccn",
+          "transaction_id": "e8eq11mi2ndmauvb51qsg8hccn"
         },
         "matchingRules": {
           "body": {


### PR DESCRIPTION
## WHAT YOU DID

`pay-java-commons` was upgraded to Java 21. Some of the imports needed update as they are transative dependencies.

also fix pact test (unnecessary , in json file)
