### PR TITLE
PP-13030: Use CreateServiceRequest pojo instead of JsonNode

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -139,35 +135,35 @@
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_verified": false,
-        "line_number": 398
+        "line_number": 400
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "1976a945a8d2733655e4b2453bd49fb59cb7ba19",
         "is_verified": false,
-        "line_number": 663
+        "line_number": 665
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "a31519136d26754afeb0df49b5f066f387091f88",
         "is_verified": false,
-        "line_number": 697
+        "line_number": 699
       },
       {
         "type": "Secret Keyword",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "0ea7458942ab65e0a340cf4fd28ca00d93c494f3",
         "is_verified": false,
-        "line_number": 796
+        "line_number": 798
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "3660e32cde5fccc8d1e4521d0c831c2012388720",
         "is_verified": false,
-        "line_number": 1231
+        "line_number": 1244
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/model/CreateUserRequest.java": [
@@ -260,14 +256,14 @@
         "filename": "src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java",
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_verified": false,
-        "line_number": 149
+        "line_number": 142
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java",
         "hashed_secret": "1976a945a8d2733655e4b2453bd49fb59cb7ba19",
         "is_verified": false,
-        "line_number": 383
+        "line_number": 369
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/resources/ToolboxEndpointResource.java": [
@@ -466,5 +462,5 @@
       }
     ]
   },
-  "generated_at": "2024-09-06T15:07:58Z"
+  "generated_at": "2024-09-09T09:33:48Z"
 }

--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -343,6 +343,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/Service'
           description: Created
+        "400":
+          description: Service names must be one of 'en' (English) or 'cy' (Welsh)
         "409":
           description: Gateway account IDs provided has already been assigned to another
             service
@@ -1184,6 +1186,17 @@ components:
           example: example@example.gov.uk
       required:
       - email
+    CreateServiceRequest:
+      type: object
+      properties:
+        gateway_account_ids:
+          type: array
+          items:
+            type: string
+        service_name:
+          type: object
+          additionalProperties:
+            type: string
     CreateUserRequest:
       type: object
       properties:

--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -344,7 +344,7 @@ paths:
                 $ref: '#/components/schemas/Service'
           description: Created
         "400":
-          description: Service names must be one of 'en' (English) or 'cy' (Welsh)
+          description: Service name keys must be one of 'en' (English) or 'cy' (Welsh)
         "409":
           description: Gateway account IDs provided has already been assigned to another
             service

--- a/src/main/java/uk/gov/pay/adminusers/model/CreateServiceRequest.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/CreateServiceRequest.java
@@ -1,0 +1,16 @@
+package uk.gov.pay.adminusers.model;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
+
+import java.util.List;
+import java.util.Map;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record CreateServiceRequest(
+        List<String> gatewayAccountIds,
+        @JsonDeserialize(using = ServiceNamesDeserializer.class) Map<SupportedLanguage, String> serviceName) {
+}
+

--- a/src/main/java/uk/gov/pay/adminusers/model/ServiceNamesDeserializer.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/ServiceNamesDeserializer.java
@@ -7,17 +7,15 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
+
+import static java.util.stream.Collectors.toUnmodifiableMap;
 
 public class ServiceNamesDeserializer extends JsonDeserializer<Map<SupportedLanguage, String>> {
     @Override
     public Map<SupportedLanguage, String> deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
-        Map<SupportedLanguage, String> supportedLanguageToServiceName = new HashMap<>();
-        jsonParser.getCodec().readValue(jsonParser, new TypeReference<Map<String, String>>() {})
-                .forEach((key, value) -> 
-                        supportedLanguageToServiceName.put(SupportedLanguage.fromIso639AlphaTwoCode(key), value));
-        return Collections.unmodifiableMap(supportedLanguageToServiceName);
+        return jsonParser.getCodec().readValue(jsonParser, new TypeReference<Map<String, String>>() {})
+                .entrySet().stream()
+                .collect(toUnmodifiableMap(entry -> SupportedLanguage.fromIso639AlphaTwoCode(entry.getKey()), Map.Entry::getValue));
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/model/ServiceNamesDeserializer.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/ServiceNamesDeserializer.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.adminusers.model;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ServiceNamesDeserializer extends JsonDeserializer<Map<SupportedLanguage, String>> {
+    @Override
+    public Map<SupportedLanguage, String> deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+        Map<SupportedLanguage, String> supportedLanguageToServiceName = new HashMap<>();
+        jsonParser.getCodec().readValue(jsonParser, new TypeReference<Map<String, String>>() {})
+                .forEach((key, value) -> 
+                        supportedLanguageToServiceName.put(SupportedLanguage.fromIso639AlphaTwoCode(key), value));
+        return Collections.unmodifiableMap(supportedLanguageToServiceName);
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
@@ -220,7 +220,7 @@ public class ServiceResource {
                     @ApiResponse(responseCode = "201", description = "Created",
                             content = @Content(schema = @Schema(implementation = Service.class))),
                     @ApiResponse(responseCode = "409", description = "Gateway account IDs provided has already been assigned to another service"),
-                    @ApiResponse(responseCode = "400", description = "Service names must be one of 'en' (English) or 'cy' (Welsh)"),
+                    @ApiResponse(responseCode = "400", description = "Service name keys must be one of 'en' (English) or 'cy' (Welsh)"),
                     @ApiResponse(responseCode = "500", description = "Invalid JSON payload")
             }
     )

--- a/src/main/java/uk/gov/pay/adminusers/service/LinksBuilder.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/LinksBuilder.java
@@ -12,7 +12,6 @@ import java.util.List;
 
 import static javax.ws.rs.core.UriBuilder.fromUri;
 import static uk.gov.pay.adminusers.resources.ForgottenPasswordResource.FORGOTTEN_PASSWORDS_RESOURCE;
-import static uk.gov.pay.adminusers.resources.ServiceResource.SERVICES_RESOURCE;
 import static uk.gov.pay.adminusers.resources.UserResource.USERS_RESOURCE;
 
 public class LinksBuilder {
@@ -32,7 +31,7 @@ public class LinksBuilder {
     }
 
     public Service decorate(Service service) {
-        URI uri = fromUri(baseUrl).path(SERVICES_RESOURCE).path(String.valueOf(service.getExternalId()))
+        URI uri = fromUri(baseUrl).path("/v1/api/services").path(String.valueOf(service.getExternalId()))
                 .build();
         Link selfLink = Link.from(Rel.SELF, "GET", uri.toString());
         service.setLinks(List.of(selfLink));

--- a/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/IntegrationTest.java
@@ -83,6 +83,7 @@ public class IntegrationTest {
     @BeforeEach
     public void initialise() {
         databaseHelper = APP.getDatabaseTestHelper();
+        databaseHelper.truncateAllData();
     }
 
     protected RequestSpecification givenSetup() {

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceCreateIT.java
@@ -37,20 +37,6 @@ class ServiceResourceCreateIT extends IntegrationTest {
         assertStandardFields(validatableResponse);
     }
 
-    private void assertStandardFields(ValidatableResponse validatableResponse) {
-        validatableResponse
-                .body("current_psp_test_account_stage", is("NOT_STARTED"))
-                .body("current_go_live_stage", is("NOT_STARTED"))
-                .body("default_billing_address_country", is("GB"))
-                .body("agent_initiated_moto_enabled", is(false))
-                .body("takes_payments_over_phone", is(false))
-                .body("experimental_features_enabled", is(false))
-                .body("internal", is(false))
-                .body("archived", is(false))
-                .body("redirect_to_service_immediately_on_terminal_state", is(false))
-                .body("collect_billing_address", is(true));
-    }
-
     @Test
     void can_create_default_service_with_empty_request_body() {
         var validatableResponse = givenSetup()
@@ -100,6 +86,20 @@ class ServiceResourceCreateIT extends IntegrationTest {
                 .body("name", is("Service name"));
 
         assertStandardFields(validatableResponse);
+    }
+
+    private void assertStandardFields(ValidatableResponse validatableResponse) {
+        validatableResponse
+                .body("current_psp_test_account_stage", is("NOT_STARTED"))
+                .body("current_go_live_stage", is("NOT_STARTED"))
+                .body("default_billing_address_country", is("GB"))
+                .body("agent_initiated_moto_enabled", is(false))
+                .body("takes_payments_over_phone", is(false))
+                .body("experimental_features_enabled", is(false))
+                .body("internal", is(false))
+                .body("archived", is(false))
+                .body("redirect_to_service_immediately_on_terminal_state", is(false))
+                .body("collect_billing_address", is(true));
     }
     
     @Test

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceCreateIT.java
@@ -1,37 +1,117 @@
 package uk.gov.pay.adminusers.resources;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import io.restassured.response.ValidatableResponse;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
-import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import java.util.List;
 import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
+import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static uk.gov.service.payments.commons.model.SupportedLanguage.ENGLISH;
+import static uk.gov.service.payments.commons.model.SupportedLanguage.WELSH;
 
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class ServiceResourceCreateIT extends IntegrationTest {
 
     @Test
-    void shouldCreateService() {
-        JsonNode payload = mapper
-                .valueToTree(Map.of(
-                        "service_name", Map.of(SupportedLanguage.ENGLISH.toString(), "Service name"),
-                        "gateway_account_ids", List.of("1")
-                ));
-        
-        givenSetup()
+    void create_service_with_all_parameters_successfully() {
+        var validatableResponse = givenSetup()
                 .when()
                 .contentType(JSON)
-                .body(payload)
+                .body(Map.of("service_name", Map.of(ENGLISH.toString(), "Service name"),
+                        "gateway_account_ids", List.of("1")))
                 .post("v1/api/services")
                 .then()
                 .statusCode(201)
                 .body("created_date", is(not(nullValue())))
                 .body("gateway_account_ids", is(List.of("1")))
                 .body("service_name", hasEntry("en", "Service name"));
+        
+        assertStandardFields(validatableResponse);
+    }
+
+    private void assertStandardFields(ValidatableResponse validatableResponse) {
+        validatableResponse
+                .body("current_psp_test_account_stage", is("NOT_STARTED"))
+                .body("current_go_live_stage", is("NOT_STARTED"))
+                .body("default_billing_address_country", is("GB"))
+                .body("agent_initiated_moto_enabled", is(false))
+                .body("takes_payments_over_phone", is(false))
+                .body("experimental_features_enabled", is(false))
+                .body("internal", is(false))
+                .body("archived", is(false))
+                .body("redirect_to_service_immediately_on_terminal_state", is(false))
+                .body("collect_billing_address", is(true));
+    }
+
+    @Test
+    void can_create_default_service_with_empty_request_body() {
+        var validatableResponse = givenSetup()
+                .when()
+                .contentType(JSON)
+                .post("v1/api/services")
+                .then()
+                .statusCode(201)
+                .body("created_date", is(not(nullValue())))
+                .body("gateway_account_ids", is(emptyIterable()))
+                .body("service_name", hasEntry("en", "System Generated"))
+                .body("name", is("System Generated"));
+        
+        assertStandardFields(validatableResponse);
+    }
+    
+    @Test
+    void can_create_default_service_with_gateway_account_ids_only() {
+        var validatableResponse = givenSetup()
+                .when()
+                .contentType(JSON)
+                .body(Map.of("gateway_account_ids", List.of("1", "2")))
+                .post("v1/api/services")
+                .then()
+                .statusCode(201)
+                .body("created_date", is(not(nullValue())))
+                .body("gateway_account_ids", is(List.of("1", "2")))
+                .body("service_name", hasEntry("en", "System Generated"))
+                .body("name", is("System Generated"));
+
+        assertStandardFields(validatableResponse);
+    }
+
+    @Test
+    void can_create_default_service_with_service_name_only() {
+        var validatableResponse = givenSetup()
+                .when()
+                .contentType(JSON)
+                .body(Map.of("service_name", Map.of(ENGLISH.toString(), "Service name", WELSH.toString(), "Welsh name")))
+                .post("v1/api/services")
+                .then()
+                .statusCode(201)
+                .body("created_date", is(not(nullValue())))
+                .body("gateway_account_ids", is(emptyIterable()))
+                .body("service_name", hasEntry("en", "Service name"))
+                .body("service_name", hasEntry("cy", "Welsh name"))
+                .body("name", is("Service name"));
+
+        assertStandardFields(validatableResponse);
+    }
+    
+    @Test
+    void return_bad_request_when_invalid_supported_language_provided() {
+        givenSetup()
+                .when()
+                .contentType(JSON)
+                .body(Map.of("service_name", Map.of("fr", "Service name")))
+                .post("v1/api/services")
+                .then()
+                .statusCode(400)
+                .body("message", is("Unable to process JSON"))
+                .body("details", is("fr is not a supported ISO 639-1 code"));
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceCreateTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceCreateTest.java
@@ -48,7 +48,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static uk.gov.pay.adminusers.resources.ServiceResource.FIELD_NAME;
-import static uk.gov.pay.adminusers.resources.ServiceResource.SERVICES_RESOURCE;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_GATEWAY_ACCOUNT_IDS;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
@@ -103,7 +102,7 @@ public class ServiceResourceCreateTest extends ServiceResourceBaseTest {
         Service service = buildService(Collections.emptyList(), Collections.emptyMap());
         given(mockedServiceCreator.doCreate(Collections.emptyList(), Collections.emptyMap()))
                 .willReturn(service);
-        Response response = RESOURCES.target(SERVICES_RESOURCE)
+        Response response = RESOURCES.target("/v1/api/services")
                 .request(MediaType.APPLICATION_JSON)
                 .post(Entity.json(PAYLOAD_MAP), Response.class);
 
@@ -129,7 +128,7 @@ public class ServiceResourceCreateTest extends ServiceResourceBaseTest {
         Service service = buildService(Collections.emptyList(), Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME));
         given(mockedServiceCreator.doCreate(Collections.emptyList(), Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME)))
                 .willReturn(service);
-        Response response = RESOURCES.target(SERVICES_RESOURCE)
+        Response response = RESOURCES.target("/v1/api/services")
                 .request(MediaType.APPLICATION_JSON)
                 .post(Entity.json(PAYLOAD_MAP), Response.class);
 
@@ -152,7 +151,7 @@ public class ServiceResourceCreateTest extends ServiceResourceBaseTest {
         Service service = buildService(Collections.emptyList(), Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME));
         given(mockedServiceCreator.doCreate(Collections.emptyList(), Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME)))
                 .willReturn(service);
-        Response response = RESOURCES.target(SERVICES_RESOURCE)
+        Response response = RESOURCES.target("/v1/api/services")
                 .request(MediaType.APPLICATION_JSON)
                 .post(Entity.json(PAYLOAD_MAP), Response.class);
 
@@ -179,7 +178,7 @@ public class ServiceResourceCreateTest extends ServiceResourceBaseTest {
         given(mockedServiceCreator.doCreate(gatewayAccounts, Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME)))
                 .willReturn(service);
 
-        Response response = RESOURCES.target(SERVICES_RESOURCE)
+        Response response = RESOURCES.target("/v1/api/services")
                 .request(MediaType.APPLICATION_JSON)
                 .post(Entity.json(PAYLOAD_MAP), Response.class);
         assertThat(response.getStatus(), is(201));
@@ -205,7 +204,7 @@ public class ServiceResourceCreateTest extends ServiceResourceBaseTest {
         given(mockedServiceCreator.doCreate(gatewayAccounts, Map.of(SupportedLanguage.ENGLISH, EN_SERVICE_NAME)))
                 .willReturn(service);
 
-        Response response = RESOURCES.target(SERVICES_RESOURCE)
+        Response response = RESOURCES.target("/v1/api/services")
                 .request(MediaType.APPLICATION_JSON)
                 .post(Entity.json(PAYLOAD_MAP), Response.class);
         assertThat(response.getStatus(), is(201));
@@ -235,7 +234,7 @@ public class ServiceResourceCreateTest extends ServiceResourceBaseTest {
         given(mockedServiceCreator.doCreate(gatewayAccounts, serviceName))
                 .willReturn(service);
 
-        Response response = RESOURCES.target(SERVICES_RESOURCE)
+        Response response = RESOURCES.target("/v1/api/services")
                 .request(MediaType.APPLICATION_JSON)
                 .post(Entity.json(PAYLOAD_MAP), Response.class);
 
@@ -260,7 +259,7 @@ public class ServiceResourceCreateTest extends ServiceResourceBaseTest {
 
         given(mockedServicesFactory.serviceCreator()).willReturn(serviceCreator);
         given(mockedServiceDao.checkIfGatewayAccountsUsed(anyList())).willReturn(true);
-        Response response = RESOURCES.target(SERVICES_RESOURCE)
+        Response response = RESOURCES.target("/v1/api/services")
                 .request(MediaType.APPLICATION_JSON)
                 .post(Entity.json(PAYLOAD_MAP), Response.class);
         assertThat(response.getStatus(), is(409));


### PR DESCRIPTION
Following the general pattern in most of our Dropwizard codebases, we want to avoid JsonNode as the POST request body where possible so we can advantage of using javax Validation constraints.

It is also generally agreed that using hard coded URL strings makes for easier-to-read code.

Added a few more test cases in ServiceResourceCreateIT to reflect the pact tests between selfservice and adminusers:
* [a valid create service request with empty object](https://github.com/alphagov/pay-selfservice/blob/b2053a1049bc28813e8e7363245ad546ef19b675/test/pact/adminusers-client/service/create-service.pact.test.js#L50)
* [a valid create service request with gateway account ids](https://github.com/alphagov/pay-selfservice/blob/b2053a1049bc28813e8e7363245ad546ef19b675/test/pact/adminusers-client/service/create-service.pact.test.js#L85C31-L85C86)
* [a valid create service request with service name](https://github.com/alphagov/pay-selfservice/blob/b2053a1049bc28813e8e7363245ad546ef19b675/test/pact/adminusers-client/service/create-service.pact.test.js#L124)