### PR TITLE
PP-13030: Add is_worldpay_test_service column to services table

### DIFF
--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -395,7 +395,7 @@ paths:
       - Services
   /v1/api/services/{serviceExternalId}:
     get:
-      operationId: findService
+      operationId: getService
       parameters:
       - example: 7d19aff33f8948deb97ed16b2912dcd3
         in: path

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
@@ -141,7 +141,7 @@ public class ServiceResource {
                     @ApiResponse(responseCode = "404", description = "Not found")
             }
     )
-    public Response findService(@Parameter(example = "7d19aff33f8948deb97ed16b2912dcd3") @PathParam("serviceExternalId")
+    public Response getService(@Parameter(example = "7d19aff33f8948deb97ed16b2912dcd3") @PathParam("serviceExternalId")
                                 String serviceExternalId) {
         return serviceDao.findByExternalId(serviceExternalId)
                 .map(serviceEntity ->

--- a/src/main/resources/migrations/00089_add_column_is_worldpay_test_service_to_services.sql
+++ b/src/main/resources/migrations/00089_add_column_is_worldpay_test_service_to_services.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_column_is_worldpay_test_service
+ALTER TABLE services ADD COLUMN is_worldpay_test_service BOOLEAN DEFAULT FALSE;
+
+--rollback ALTER TABLE services DROP COLUMN is_worldpay_test_service;


### PR DESCRIPTION
We want to set up a separate service specifically for worldpay testing if the service requires one. This introduces the following functionalities:
* There is a "WORLDPAY TEST SERVICE" label shown against the service name in the My Services view in the selfservice UI
* This new service is solely for testing, and will not be able to go live

To this end, introducing a is_worldpay_test_service column is the most straightforward and easy-to-understand way to enable the above functionalities easily.

This commit also sneakily changes SerivceResource.findService to getService as this method doesn't find a service by parameters, but gets a service by its unique; and it's better to follow REST naming conventions, ie. "GET" in this case.
