### PR TITLE
PP-13026: Add stored procedure to allow safer manual sql execution

### DIFF
--- a/src/main/resources/migrations/00089_create_procedure_check_and_execute.sql
+++ b/src/main/resources/migrations/00089_create_procedure_check_and_execute.sql
@@ -1,0 +1,36 @@
+--liquibase formatted sql dbms:postgresql splitStatements:false
+
+--changeset uk.gov.pay:create_procedure_check_and_execute
+create or replace procedure check_and_execute(
+    p_dml_sql text,
+    p_table_name text,
+    p_expected_no_of_rows_to_update_or_delete numeric
+)
+language plpgsql
+as ' declare
+    rows_affected INTEGER;
+    total_rows INTEGER;
+begin
+    EXECUTE format(''SELECT COUNT(*) FROM %I'', p_table_name) INTO total_rows;
+
+    if p_expected_no_of_rows_to_update_or_delete >= total_rows then
+        raise exception ''Failed. Expected no. of rows (%) to update/delete can not be same or more than the total number of rows (%) in the table'',
+            p_expected_no_of_rows_to_update_or_delete,
+            total_rows;
+    end if;
+
+    execute p_dml_sql;
+    get diagnostics rows_affected = ROW_COUNT;
+
+    if rows_affected != p_expected_no_of_rows_to_update_or_delete then
+        raise exception ''Failed. Statement expected to update/delete % rows but updating % rows. Changes not commited.'',
+            p_expected_no_of_rows_to_update_or_delete,
+            rows_affected;
+    end if;
+
+    raise notice ''Success. Statement affected % rows. Expected to update/delete LESS THAN or EQUAL to % rows'',
+        rows_affected,
+        p_expected_no_of_rows_to_update_or_delete;
+end; '
+
+--rollback drop procedure check_and_execute;


### PR DESCRIPTION
## WHAT YOU DID
Add stored procedure check_and_execute which allows specifying SQL, the table, and expected number of rows affected. This should allow ad-hoc modifications to be done more safely since it will automatically error if the number of rows affected wasn't exactly what you had intended

This is based on the prior art in https://github.com/alphagov/pay-connector/pull/5451/ and the RFC https://github.com/alphagov/pay-architecture/discussions/147

The formatting of the liquibase migrations meant I had to slightly edit the sql and replace the $$ quoted multi line string with single `'` quotes (and change all single quotes inside it to 2 x single quotes `''` (not double quotes)

## How to test

- Locally run up pay local with this branch of adminusers `pay local up --cluster card --local adminusers`
- Once it's running run `docker exec -it adminusers_db psql -U adminusers`
- List the functions `\df` you'll see check_and_execute exists.
- Create at least 4 test payments `pay local payment`
- Run `docker exec -it adminusers_db psql -U adminusers` again and try it out:
```
adminusers=> CALL check_and_execute('DELETE FROM role_permission WHERE role_id=1 ', 'role_permission', 199);
ERROR:  Failed. Expected no. of rows (199) to update/delete can not be same or more than the total number of rows (187) in the table
CONTEXT:  PL/pgSQL function check_and_execute(text,text,numeric) line 8 at RAISE
adminusers=> BEGIN;
BEGIN
adminusers=*> CALL check_and_execute('DELETE FROM role_permission WHERE role_id=1 AND permission_id=1', 'role_permission', 1);
NOTICE:  Success. Statement affected 1 rows. Expected to update/delete LESS THAN or EQUAL to 1 rows
CALL
adminusers=*> CALL check_and_execute('DELETE FROM role_permission WHERE role_id=1 ', 'role_permission', 1);
ERROR:  Failed. Statement expected to update/delete 1 rows but updating 50 rows. Changes not commited.
CONTEXT:  PL/pgSQL function check_and_execute(text,text,numeric) line 17 at RAISE
```

## Code review checklist

### Logging

N/A

### Documentation

N/A