### PR TITLE
PP-13647 update AWS SDK to version 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,9 +37,9 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.12.782</version>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>2.31.34</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -133,8 +133,8 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-sqs</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sqs</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
@@ -226,7 +226,7 @@
         </dependency>
         <dependency>
             <groupId>uk.gov.service.payments</groupId>
-            <artifactId>queue-dropwizard-4</artifactId>
+            <artifactId>queue-dropwizard-4-aws-sdk-v2</artifactId>
             <version>${pay-java-commons.version}</version>
         </dependency>
         <dependency>

--- a/src/test/java/uk/gov/pay/adminusers/infra/AppWithPostgresAndSqsRule.java
+++ b/src/test/java/uk/gov/pay/adminusers/infra/AppWithPostgresAndSqsRule.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.adminusers.infra;
 
-import com.amazonaws.services.sqs.AmazonSQS;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.persist.PersistService;
@@ -20,6 +19,7 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.sqs.SqsClient;
 import uk.gov.pay.adminusers.app.AdminUsersApp;
 import uk.gov.pay.adminusers.app.config.AdminUsersConfig;
 import uk.gov.pay.adminusers.app.config.AdminUsersModule;
@@ -45,7 +45,7 @@ public class AppWithPostgresAndSqsRule implements TestRule {
 
     private final String configFilePath;
     private final PostgresDockerRule postgres;
-    private final AmazonSQS sqsClient;
+    private final SqsClient sqsClient;
     private final DropwizardAppRule<AdminUsersConfig> app;
     private final RuleChain rules;
     private final int wireMockPort = PortFactory.findFreePort();
@@ -115,7 +115,7 @@ public class AppWithPostgresAndSqsRule implements TestRule {
         return databaseTestHelper;
     }
 
-    public AmazonSQS getSqsClient() {
+    public SqsClient getSqsClient() {
         return sqsClient;
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/infra/AppWithPostgresExtension.java
+++ b/src/test/java/uk/gov/pay/adminusers/infra/AppWithPostgresExtension.java
@@ -61,6 +61,7 @@ public class AppWithPostgresExtension implements BeforeAllCallback {
                         config("database.user", postgres.getUsername()),
                         config("database.password", postgres.getPassword()),
                         config("sqs.connectorTasksQueueUrl", SqsTestDocker.getQueueUrl("event-queue")),
+                        config("sqs.endpoint", SqsTestDocker.getEndpoint()),
                         config("ledgerBaseURL", "http://localhost:" + wireMockPort))
                 .toArray(new ConfigOverride[0]);
 

--- a/src/test/java/uk/gov/pay/adminusers/infra/SqsTestDocker.java
+++ b/src/test/java/uk/gov/pay/adminusers/infra/SqsTestDocker.java
@@ -1,15 +1,16 @@
 package uk.gov.pay.adminusers.infra;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.CreateQueueRequest;
 
+import java.net.URI;
 import java.util.List;
 
 public class SqsTestDocker {
@@ -17,7 +18,7 @@ public class SqsTestDocker {
 
     private static GenericContainer sqsContainer;
 
-    public static AmazonSQS initialise(List<String> queueNames) {
+    public static SqsClient initialise(List<String> queueNames) {
         try {
             createContainer();
             return createQueues(queueNames);
@@ -38,9 +39,15 @@ public class SqsTestDocker {
         }
     }
 
-    private static AmazonSQS createQueues(List<String> queueNames) {
-        AmazonSQS amazonSQS = getSqsClient();
-        queueNames.forEach(amazonSQS::createQueue);
+    private static SqsClient createQueues(List<String> queueNames) {
+        SqsClient amazonSQS = getSqsClient();
+        queueNames.forEach(queueName -> {
+            CreateQueueRequest createQueueRequest = CreateQueueRequest.builder()
+                    .queueName(queueName)
+                    .build();
+
+            amazonSQS.createQueue(createQueueRequest);
+        });
 
         return amazonSQS;
     }
@@ -53,18 +60,13 @@ public class SqsTestDocker {
         return "http://localhost:" + sqsContainer.getMappedPort(9324);
     }
 
-    private static AmazonSQS getSqsClient() {
+    private static SqsClient getSqsClient() {
         // random credentials required by AWS SDK to build SQS client
-        BasicAWSCredentials awsCreds = new BasicAWSCredentials("x", "x");
-
-        return AmazonSQSClientBuilder.standard()
-                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
-                .withEndpointConfiguration(
-                        new AwsClientBuilder.EndpointConfiguration(
-                                getEndpoint(),
-                                "region-1"
-                        ))
-                .withRequestHandlers()
+        AwsBasicCredentials awsCreds = AwsBasicCredentials.create("x", "x");
+        return SqsClient.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(awsCreds))
+                .endpointOverride(URI.create(getEndpoint()))
+                .region(Region.of("region-1"))
                 .build();
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/pact/queuemessage/DisputeCreatedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/pact/queuemessage/DisputeCreatedEventQueueConsumerIT.java
@@ -13,6 +13,7 @@ import com.google.gson.GsonBuilder;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.adminusers.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.adminusers.fixtures.EventFixture;
 import uk.gov.pay.adminusers.fixtures.ServiceDbFixture;
@@ -137,7 +138,11 @@ public class DisputeCreatedEventQueueConsumerIT {
     public void test() throws Exception {
         String messageContents = new String(currentMessage);
         String snsMessage = new GsonBuilder().create().toJson(Map.of("Message", messageContents));
-        adminusersApp.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), snsMessage);
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(snsMessage)
+                .build();
+        adminusersApp.getSqsClient().sendMessage(messageRequest);
         await().atMost(2, TimeUnit.SECONDS).until(
                 () -> !wireMockRule.findAll(RequestPatternBuilder.newRequestPattern().withUrl("/v2/notifications/email")).isEmpty());
         

--- a/src/test/java/uk/gov/pay/adminusers/pact/queuemessage/DisputeEvidenceSubmittedEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/pact/queuemessage/DisputeEvidenceSubmittedEventQueueConsumerIT.java
@@ -13,6 +13,7 @@ import com.google.gson.GsonBuilder;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.adminusers.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.adminusers.fixtures.EventFixture;
 import uk.gov.pay.adminusers.fixtures.ServiceDbFixture;
@@ -132,7 +133,11 @@ public class DisputeEvidenceSubmittedEventQueueConsumerIT {
     public void test() throws Exception {
         String messageContents = new String(currentMessage);
         String snsMessage = new GsonBuilder().create().toJson(Map.of("Message", messageContents));
-        adminusersApp.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), snsMessage);
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(snsMessage)
+                .build();
+        adminusersApp.getSqsClient().sendMessage(messageRequest);
         await().atMost(2, TimeUnit.SECONDS).until(
                 () -> !wireMockRule.findAll(RequestPatternBuilder.newRequestPattern().withUrl("/v2/notifications/email")).isEmpty());
         

--- a/src/test/java/uk/gov/pay/adminusers/pact/queuemessage/DisputeLostEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/pact/queuemessage/DisputeLostEventQueueConsumerIT.java
@@ -13,6 +13,7 @@ import com.google.gson.GsonBuilder;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.adminusers.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.adminusers.fixtures.EventFixture;
 import uk.gov.pay.adminusers.fixtures.ServiceDbFixture;
@@ -132,7 +133,11 @@ public class DisputeLostEventQueueConsumerIT {
     public void test() throws Exception {
         String messageContents = new String(currentMessage);
         String snsMessage = new GsonBuilder().create().toJson(Map.of("Message", messageContents));
-        adminusersApp.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), snsMessage);
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(snsMessage)
+                .build();
+        adminusersApp.getSqsClient().sendMessage(messageRequest);
         await().atMost(2, TimeUnit.SECONDS).until(
                 () -> !wireMockRule.findAll(RequestPatternBuilder.newRequestPattern().withUrl("/v2/notifications/email")).isEmpty());
 

--- a/src/test/java/uk/gov/pay/adminusers/pact/queuemessage/DisputeWonEventQueueConsumerIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/pact/queuemessage/DisputeWonEventQueueConsumerIT.java
@@ -13,6 +13,7 @@ import com.google.gson.GsonBuilder;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.pay.adminusers.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.adminusers.fixtures.EventFixture;
 import uk.gov.pay.adminusers.fixtures.ServiceDbFixture;
@@ -132,7 +133,11 @@ public class DisputeWonEventQueueConsumerIT {
     public void test() throws Exception {
         String messageContents = new String(currentMessage);
         String snsMessage = new GsonBuilder().create().toJson(Map.of("Message", messageContents));
-        adminusersApp.getSqsClient().sendMessage(SqsTestDocker.getQueueUrl("event-queue"), snsMessage);
+        SendMessageRequest messageRequest = SendMessageRequest.builder()
+                .queueUrl(SqsTestDocker.getQueueUrl("event-queue"))
+                .messageBody(snsMessage)
+                .build();
+        adminusersApp.getSqsClient().sendMessage(messageRequest);
         await().atMost(2, TimeUnit.SECONDS).until(
                 () -> !wireMockRule.findAll(RequestPatternBuilder.newRequestPattern().withUrl("/v2/notifications/email")).isEmpty());
         

--- a/src/test/java/uk/gov/pay/adminusers/queue/event/EventSubscriberQueueTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/queue/event/EventSubscriberQueueTest.java
@@ -1,12 +1,12 @@
 package uk.gov.pay.adminusers.queue.event;
 
-import com.amazonaws.services.sqs.model.SendMessageResult;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 import uk.gov.pay.adminusers.app.config.AdminUsersConfig;
 import uk.gov.pay.adminusers.app.config.EventSubscriberQueueConfig;
 import uk.gov.pay.adminusers.app.config.SqsConfig;
@@ -59,7 +59,7 @@ class EventSubscriberQueueTest {
     void shouldRetrieveEventsForCorrectlyFormattedJSON() throws Exception {
         String message = load(DISPUTE_CREATED_SNS_MESSAGE);
 
-        var sendMessageResult = mock(SendMessageResult.class);
+        var sendMessageResult = mock(SendMessageResponse.class);
         List<QueueMessage> messages = List.of(
                 QueueMessage.of(sendMessageResult, message)
         );

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -111,7 +111,7 @@ secondFactorAuthentication:
 
 sqs:
   nonStandardServiceEndpoint: ${AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT:-true}
-  endpoint: ${AWS_SQS_ENDPOINT:-localhost}
+  endpoint: ${AWS_SQS_ENDPOINT:-http://localhost}
   region: ${AWS_SQS_REGION:-region-1}
   secretKey: ${AWS_SECRET_KEY:-x}
   accessKey: ${AWS_ACCESS_KEY:-x}


### PR DESCRIPTION
## WHAT YOU DID

The AWS SDK for Java 1.x is in maintenance mode, effective July 31, 2024. The AWS SDK for Java 1.x will no longer receive updates for new or existing services. We need to upgrade `pay-adminuers` to use the AWS SDK version 2 for SQS operations. This will involve updating dependencies, refactoring code to accommodate changes in the SDK, and ensuring the new SDK's methods and patterns are followed.
