### PR TITLE
PP-13991 refactor config to use dropwizard-sentry 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,11 +190,6 @@
             <version>9.0.12</version>
         </dependency>
         <dependency>
-            <groupId>org.dhatim</groupId>
-            <artifactId>dropwizard-sentry</artifactId>
-            <version>2.1.6</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.13.1</version>

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -25,7 +25,7 @@ logging:
       customFields:
         container: "adminusers"
         environment: ${ENVIRONMENT}
-    - type: pay-dropwizard-4-sentry
+    - type: sentry
       threshold: ERROR
       dsn: ${SENTRY_DSN:-https://example.com@dummy/1}
       environment: ${ENVIRONMENT}


### PR DESCRIPTION
## WHAT YOU DID

We can migrate to Sentry 4.x now we use Dropwizard 4, which would allow us to remove some custom code.

