### PR TITLE
PP-15598-update_patch_endpoint_to_accept_add_and_remove_feature_operation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -208,7 +208,7 @@
         "filename": "src/main/java/uk/gov/pay/adminusers/model/Service.java",
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_verified": false,
-        "line_number": 31
+        "line_number": 33
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/model/User.java": [
@@ -466,5 +466,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-23T09:32:52Z"
+  "generated_at": "2026-07-23T09:49:46Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -146,28 +146,28 @@
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "1976a945a8d2733655e4b2453bd49fb59cb7ba19",
         "is_verified": false,
-        "line_number": 683
+        "line_number": 694
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "a31519136d26754afeb0df49b5f066f387091f88",
         "is_verified": false,
-        "line_number": 717
+        "line_number": 728
       },
       {
         "type": "Secret Keyword",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "0ea7458942ab65e0a340cf4fd28ca00d93c494f3",
         "is_verified": false,
-        "line_number": 816
+        "line_number": 827
       },
       {
         "type": "Hex High Entropy String",
         "filename": "openapi/adminusers_spec.yaml",
         "hashed_secret": "3660e32cde5fccc8d1e4521d0c831c2012388720",
         "is_verified": false,
-        "line_number": 1288
+        "line_number": 1299
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/model/CreateUserRequest.java": [
@@ -260,14 +260,14 @@
         "filename": "src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java",
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_verified": false,
-        "line_number": 144
+        "line_number": 143
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java",
         "hashed_secret": "1976a945a8d2733655e4b2453bd49fb59cb7ba19",
         "is_verified": false,
-        "line_number": 373
+        "line_number": 374
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/resources/ToolboxEndpointResource.java": [
@@ -466,5 +466,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-23T09:49:46Z"
+  "generated_at": "2026-07-24T11:12:46Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -260,14 +260,14 @@
         "filename": "src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java",
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_verified": false,
-        "line_number": 144
+        "line_number": 146
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java",
         "hashed_secret": "1976a945a8d2733655e4b2453bd49fb59cb7ba19",
         "is_verified": false,
-        "line_number": 373
+        "line_number": 381
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/resources/ToolboxEndpointResource.java": [
@@ -466,5 +466,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-09T12:09:33Z"
+  "generated_at": "2026-07-22T14:13:07Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -267,7 +267,7 @@
         "filename": "src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java",
         "hashed_secret": "1976a945a8d2733655e4b2453bd49fb59cb7ba19",
         "is_verified": false,
-        "line_number": 378
+        "line_number": 373
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/resources/ToolboxEndpointResource.java": [
@@ -466,5 +466,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-22T14:58:54Z"
+  "generated_at": "2026-07-23T09:32:52Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -260,14 +260,14 @@
         "filename": "src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java",
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_verified": false,
-        "line_number": 146
+        "line_number": 144
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java",
         "hashed_secret": "1976a945a8d2733655e4b2453bd49fb59cb7ba19",
         "is_verified": false,
-        "line_number": 381
+        "line_number": 378
       }
     ],
     "src/main/java/uk/gov/pay/adminusers/resources/ToolboxEndpointResource.java": [
@@ -466,5 +466,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-22T14:13:07Z"
+  "generated_at": "2026-07-22T14:58:54Z"
 }

--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -420,29 +420,40 @@ paths:
       tags:
       - Services
     patch:
-      description: "Allows patching below service attributes. Each attribute has its\
-        \ own validation depending on data type. Request can either be a single object\
-        \ or an array of objects. It’s similar to (but not 100% compliant with) [JSON\
-        \ Patch](http://jsonpatch.com/).<br>\n  | op |  field | example |\n| --- |\
-        \  --- | ----|\n| add | gateway_account_ids  | [\"1\"] |\n| replace | redirect_to_service_immediately_on_terminal_state\
-        \ | false |\n| replace | experimental_features_enabled | false |\n| replace\
-        \ | takes_payments_over_phone | false |\n| replace | agent_initiated_moto_enabled\
-        \ | false |\n| replace | collect_billing_address | true |\n| replace | current_go_live_stage\
-        \ | NOT_STARTED |\n| replace | current_psp_test_account_stage | NOT_STARTED\
-        \ |\n| replace | merchant_details/name, organisatio | name |\n| replace |\
-        \ merchant_details/address_line1, Address lin | 1 |\n| replace | merchant_details/address_line2,\
-        \ Address lin | 2  |\n| replace | merchant_details/address_city | London |\n\
-        | replace | merchant_details/address_country | GB |\n| replace | merchant_details/address_postcode\
-        \ | E6 8XX |\n| replace | merchant_detail |/email,  |\n| replace | merchant_details/email,\
-        \ email@exampl |.com |\n| replace | merchant_detail |/url,  |\n| replace |\
-        \ merchant_details/url, http://www.exampl |.org |\n| replace | merchant_detail\
-        \ |/telephone_number,  |\n| replace | merchant_details/telephone_number |\
-        \ 447700900000 |\n| replace | custom_branding | { \"css_url\": \"css url\"\
-        , \"image_url\": \"image url\"} |\n| replace | custom_branding | {} |\n| replace\
-        \ | service_name/en | Some service name |\n| replace | sector | local government\
-        \ |\n| replace | internal | true |\n| replace | archived | true |\n| replace\
-        \ | went_live_date | 2022-04-09T18:07:46Z |\n| replace | default_billing_address_country\
-        \ | GB | "
+      description: |-
+        Allows patching below service attributes. Each attribute has its own validation depending on data type. Request can either be a single object or an array of objects. It’s similar to (but not 100% compliant with) [JSON Patch](http://jsonpatch.com/).<br>
+          | op |  field | example |
+        | --- |  --- | ----|
+        | add | gateway_account_ids  | ["1"] |
+        | replace | redirect_to_service_immediately_on_terminal_state | false |
+        | replace | experimental_features_enabled | false |
+        | replace | takes_payments_over_phone | false |
+        | replace | agent_initiated_moto_enabled | false |
+        | replace | collect_billing_address | true |
+        | replace | current_go_live_stage | NOT_STARTED |
+        | replace | current_psp_test_account_stage | NOT_STARTED |
+        | replace | merchant_details/name, organisatio | name |
+        | replace | merchant_details/address_line1, Address lin | 1 |
+        | replace | merchant_details/address_line2, Address lin | 2  |
+        | replace | merchant_details/address_city | London |
+        | replace | merchant_details/address_country | GB |
+        | replace | merchant_details/address_postcode | E6 8XX |
+        | replace | merchant_detail |/email,  |
+        | replace | merchant_details/email, email@exampl |.com |
+        | replace | merchant_detail |/url,  |
+        | replace | merchant_details/url, http://www.exampl |.org |
+        | replace | merchant_detail |/telephone_number,  |
+        | replace | merchant_details/telephone_number | 447700900000 |
+        | replace | custom_branding | { "css_url": "css url", "image_url": "image url"} |
+        | replace | custom_branding | {} |
+        | replace | service_name/en | Some service name |
+        | replace | sector | local government |
+        | replace | internal | true |
+        | replace | archived | true |
+        | replace | went_live_date | 2022-04-09T18:07:46Z |
+        | replace | default_billing_address_country | GB |
+         | add | feature | test_feature |
+         | remove | feature | test_feature |
       operationId: updateServiceAttribute
       parameters:
       - example: 7d19aff33f8948deb97ed16b2912dcd3

--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -1541,6 +1541,7 @@ components:
           items:
             type: string
             example: payment_links
+          uniqueItems: true
         service_name:
           type: object
           additionalProperties:

--- a/src/main/java/uk/gov/pay/adminusers/model/Feature.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Feature.java
@@ -1,0 +1,15 @@
+package uk.gov.pay.adminusers.model;
+
+public enum Feature {
+    TEST_FEATURE("test_feature");
+
+    private final String value;
+    
+    Feature(String feature) {
+        this.value = feature;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/uk/gov/pay/adminusers/model/Service.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Service.java
@@ -12,8 +12,10 @@ import uk.gov.service.payments.commons.api.json.ApiResponseDateTimeSerializer;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
@@ -71,7 +73,7 @@ public class Service {
     @Schema(example = "2023-04-09T18:07:46.568Z")
     private ZonedDateTime archivedDate;
     
-    private List<String> serviceFeatures = new ArrayList<>();
+    private Set<String> serviceFeatures = new HashSet<>();
 
     @JsonIgnore
     private ServiceName serviceName;
@@ -350,12 +352,12 @@ public class Service {
         this.createdDate = createdDate;
     }
 
-    public void setServiceFeatures(List<String> serviceFeatures) {
+    public void setServiceFeatures(Set<String> serviceFeatures) {
         this.serviceFeatures = serviceFeatures;
     }
 
     @ArraySchema(schema = @Schema(example = "payment_links"))
-    public List<String> getServiceFeatures() {
+    public Set<String> getServiceFeatures() {
         return serviceFeatures;
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
@@ -391,4 +391,8 @@ public class ServiceEntity {
     public void addFeature(String feature) {
         this.serviceFeatures.add(new ServiceFeatureEntity(this, feature));
     }
+
+    public void removeFeature(String feature) { 
+        this.serviceFeatures.remove(new ServiceFeatureEntity(this, feature));
+    }
 }

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceEntity.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static jakarta.persistence.EnumType.STRING;
 import static java.time.ZoneOffset.UTC;
@@ -74,7 +75,7 @@ public class ServiceEntity {
     private Set<ServiceNameEntity> serviceNames = new HashSet<>();
     
     @OneToMany(mappedBy = "service", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
-    private List<ServiceFeatureEntity> serviceFeatures = new ArrayList<>();
+    private Set<ServiceFeatureEntity> serviceFeatures = new HashSet<>();
     
     @Column(name = "current_go_live_stage")
     @Enumerated(STRING)
@@ -333,7 +334,7 @@ public class ServiceEntity {
                 .toList());
         service.setServiceFeatures(serviceFeatures.stream()
                 .map(ServiceFeatureEntity::getFeature)
-                .toList());
+                .collect(Collectors.toSet()));
         service.setCustomBranding(this.customBranding);
         if (this.merchantDetailsEntity != null) {
             service.setMerchantDetails(this.merchantDetailsEntity.toMerchantDetails());

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceFeatureEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceFeatureEntity.java
@@ -16,9 +16,9 @@ import jakarta.persistence.Table;
 @SequenceGenerator(name = "service_features_seq_gen", sequenceName = "service_features_id_seq", allocationSize = 1)
 public class ServiceFeatureEntity {
     @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "services_seq_gen")
     private Long id;
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "service_features_seq_gen")
-
+    
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "service_id")
     private ServiceEntity service;

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceFeatureEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceFeatureEntity.java
@@ -11,6 +11,8 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 
+import java.util.Objects;
+
 @Entity
 @Table(name = "service_features")
 @SequenceGenerator(name = "service_features_seq_gen", sequenceName = "service_features_id_seq", allocationSize = 1)
@@ -36,5 +38,17 @@ public class ServiceFeatureEntity {
     
     public String getFeature() {
         return feature;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        ServiceFeatureEntity that = (ServiceFeatureEntity) o;
+        return Objects.equals(service, that.service) && Objects.equals(feature, that.feature);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(service, feature);
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceFeatureEntity.java
+++ b/src/main/java/uk/gov/pay/adminusers/persistence/entity/ServiceFeatureEntity.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 @SequenceGenerator(name = "service_features_seq_gen", sequenceName = "service_features_id_seq", allocationSize = 1)
 public class ServiceFeatureEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "services_seq_gen")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "service_features_seq_gen")
     private Long id;
     
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
@@ -57,7 +57,6 @@ public class ServiceRequestValidator {
         if (!errors.isEmpty()) {
             return Optional.of(Errors.from(errors));
         }
-        System.out.println("here");
         return Optional.empty();
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
@@ -57,7 +57,7 @@ public class ServiceRequestValidator {
         if (!errors.isEmpty()) {
             return Optional.of(Errors.from(errors));
         }
-
+        System.out.println("here");
         return Optional.empty();
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceRequestValidator.java
@@ -57,6 +57,7 @@ public class ServiceRequestValidator {
         if (!errors.isEmpty()) {
             return Optional.of(Errors.from(errors));
         }
+
         return Optional.empty();
     }
 

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
@@ -10,6 +10,20 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.adminusers.exception.ServiceNotFoundException;
@@ -37,20 +51,6 @@ import uk.gov.pay.adminusers.utils.Errors;
 import uk.gov.service.payments.commons.api.exception.ValidationException;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.DELETE;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.HeaderParam;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.PUT;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.WebApplicationException;
-import jakarta.ws.rs.core.Response;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.ZoneOffset;
@@ -59,7 +59,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static java.util.stream.Collectors.toUnmodifiableList;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static jakarta.ws.rs.core.Response.Status;
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
@@ -122,7 +121,7 @@ public class ServiceResource {
     )
     public Response getServices() {
         LOGGER.info("Get Services request");
-        List<Service> services = serviceDao.listAll().stream().map(ServiceEntity::toService).map(linksBuilder::decorate).collect(toUnmodifiableList());
+        List<Service> services = serviceDao.listAll().stream().map(ServiceEntity::toService).map(linksBuilder::decorate).toList();
         return Response
                 .status(OK)
                 .entity(services)
@@ -276,7 +275,9 @@ public class ServiceResource {
                     "| replace | internal | true |\n" +
                     "| replace | archived | true |\n" +
                     "| replace | went_live_date | 2022-04-09T18:07:46Z |\n" +
-                    "| replace | default_billing_address_country | GB | ",
+                    "| replace | default_billing_address_country | GB |\n " +
+                    "| add | feature | test_feature |\n " +
+                    "| remove | feature | test_feature |",
             requestBody = @RequestBody(content = @Content(array = @ArraySchema(schema = @Schema(implementation = ServiceUpdateRequest.class)))),
             responses = {
                     @ApiResponse(responseCode = "200", description = "OK",

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
@@ -293,8 +293,8 @@ public class ServiceResource {
     }
 
     private Response processUpdateServiceAttributePayload(String serviceExternalId, JsonNode payload) {
-        final List<ServiceUpdateRequest> requests = ServiceUpdateRequest.getUpdateRequests(payload);
 
+        final List<ServiceUpdateRequest> requests = ServiceUpdateRequest.getUpdateRequests(payload);
         return serviceServicesFactory.serviceUpdater().doUpdate(serviceExternalId, requests)
                 .map(service -> Response.status(OK).entity(service).build())
                 .orElseGet(() -> Response.status(NOT_FOUND).build());

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
@@ -295,11 +295,6 @@ public class ServiceResource {
     private Response processUpdateServiceAttributePayload(String serviceExternalId, JsonNode payload) {
         final List<ServiceUpdateRequest> requests = ServiceUpdateRequest.getUpdateRequests(payload);
 
-        if (requests.stream().anyMatch(request -> "feature".equals(request.getPath()))) {
-            Service service = serviceServicesFactory.serviceUpdater().doUpdateFeature(serviceExternalId, requests);
-            return Response.ok(service).build();
-        }
-        
         return serviceServicesFactory.serviceUpdater().doUpdate(serviceExternalId, requests)
                 .map(service -> Response.status(OK).entity(service).build())
                 .orElseGet(() -> Response.status(NOT_FOUND).build());

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
@@ -69,6 +69,8 @@ import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 import static jakarta.ws.rs.core.Response.Status.NO_CONTENT;
 import static jakarta.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static uk.gov.pay.adminusers.model.ServiceUpdateRequest.FIELD_OP;
+import static uk.gov.pay.adminusers.model.ServiceUpdateRequest.FIELD_PATH;
 
 @Path("/v1/api/services")
 public class ServiceResource {
@@ -293,8 +295,14 @@ public class ServiceResource {
     }
 
     private Response processUpdateServiceAttributePayload(String serviceExternalId, JsonNode payload) {
-
         final List<ServiceUpdateRequest> requests = ServiceUpdateRequest.getUpdateRequests(payload);
+
+        if (requests.stream().anyMatch(request -> "feature".equals(request.getPath()))) {
+            serviceServicesFactory.serviceUpdater().updateFeature(serviceExternalId, requests)
+                    .map(service -> Response.status(OK).entity(service).build())
+                    .orElseGet(() -> Response.status(NOT_FOUND).build());
+        }
+        
         return serviceServicesFactory.serviceUpdater().doUpdate(serviceExternalId, requests)
                 .map(service -> Response.status(OK).entity(service).build())
                 .orElseGet(() -> Response.status(NOT_FOUND).build());

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
@@ -69,8 +69,6 @@ import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 import static jakarta.ws.rs.core.Response.Status.NO_CONTENT;
 import static jakarta.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static uk.gov.pay.adminusers.model.ServiceUpdateRequest.FIELD_OP;
-import static uk.gov.pay.adminusers.model.ServiceUpdateRequest.FIELD_PATH;
 
 @Path("/v1/api/services")
 public class ServiceResource {
@@ -298,9 +296,8 @@ public class ServiceResource {
         final List<ServiceUpdateRequest> requests = ServiceUpdateRequest.getUpdateRequests(payload);
 
         if (requests.stream().anyMatch(request -> "feature".equals(request.getPath()))) {
-            serviceServicesFactory.serviceUpdater().updateFeature(serviceExternalId, requests)
-                    .map(service -> Response.status(OK).entity(service).build())
-                    .orElseGet(() -> Response.status(NOT_FOUND).build());
+            Service service = serviceServicesFactory.serviceUpdater().doUpdateFeature(serviceExternalId, requests);
+            return Response.ok(service).build();
         }
         
         return serviceServicesFactory.serviceUpdater().doUpdate(serviceExternalId, requests)

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
@@ -21,6 +21,7 @@ import static java.util.Map.entry;
 import static uk.gov.pay.adminusers.model.ServiceUpdateRequest.FIELD_OP;
 import static uk.gov.pay.adminusers.model.ServiceUpdateRequest.FIELD_PATH;
 import static uk.gov.pay.adminusers.model.ServiceUpdateRequest.FIELD_VALUE;
+import static uk.gov.pay.adminusers.service.ServiceUpdater.FEATURE;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_AGENT_INITIATED_MOTO_ENABLED;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_ARCHIVED;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_COLLECT_BILLING_ADDRESS;
@@ -95,7 +96,8 @@ public class ServiceUpdateOperationValidator {
                 entry(FIELD_MERCHANT_DETAILS_ADDRESS_POSTCODE, singletonList(REPLACE)),
                 entry(FIELD_MERCHANT_DETAILS_EMAIL, singletonList(REPLACE)),
                 entry(FIELD_MERCHANT_DETAILS_TELEPHONE_NUMBER, singletonList(REPLACE)),
-                entry(FIELD_MERCHANT_DETAILS_URL, singletonList(REPLACE))
+                entry(FIELD_MERCHANT_DETAILS_URL, singletonList(REPLACE)),
+                entry(FEATURE, singletonList(ADD))
         ));
         Arrays.stream(SupportedLanguage.values()).forEach(lang ->
                 validAttributeUpdateOperations.put(FIELD_SERVICE_NAME_PREFIX + '/' + lang.toString(), singletonList(REPLACE)));

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
@@ -1,12 +1,12 @@
 package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.inject.Inject;
 import uk.gov.pay.adminusers.model.GoLiveStage;
 import uk.gov.pay.adminusers.model.PspTestAccountStage;
 import uk.gov.pay.adminusers.validations.RequestValidations;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 
-import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -21,7 +21,6 @@ import static java.util.Map.entry;
 import static uk.gov.pay.adminusers.model.ServiceUpdateRequest.FIELD_OP;
 import static uk.gov.pay.adminusers.model.ServiceUpdateRequest.FIELD_PATH;
 import static uk.gov.pay.adminusers.model.ServiceUpdateRequest.FIELD_VALUE;
-import static uk.gov.pay.adminusers.service.ServiceUpdater.FEATURE;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_AGENT_INITIATED_MOTO_ENABLED;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_ARCHIVED;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_COLLECT_BILLING_ADDRESS;
@@ -30,7 +29,7 @@ import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_CURRENT_PSP_TES
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_CUSTOM_BRANDING;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_DEFAULT_BILLING_ADDRESS_COUNTRY;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_EXPERIMENTAL_FEATURES_ENABLED;
-import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_TAKES_PAYMENTS_OVER_PHONE;
+import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_FEATURE;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_GATEWAY_ACCOUNT_IDS;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_INTERNAL;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_MERCHANT_DETAILS_ADDRESS_CITY;
@@ -45,6 +44,7 @@ import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_MERCHANT_DETAIL
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_REDIRECT_NAME;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_SECTOR;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_SERVICE_NAME_PREFIX;
+import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_TAKES_PAYMENTS_OVER_PHONE;
 import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_WENT_LIVE_DATE;
 
 public class ServiceUpdateOperationValidator {
@@ -97,7 +97,7 @@ public class ServiceUpdateOperationValidator {
                 entry(FIELD_MERCHANT_DETAILS_EMAIL, singletonList(REPLACE)),
                 entry(FIELD_MERCHANT_DETAILS_TELEPHONE_NUMBER, singletonList(REPLACE)),
                 entry(FIELD_MERCHANT_DETAILS_URL, singletonList(REPLACE)),
-                entry(FEATURE, singletonList(ADD))
+                entry(FIELD_FEATURE, singletonList(ADD))
         ));
         Arrays.stream(SupportedLanguage.values()).forEach(lang ->
                 validAttributeUpdateOperations.put(FIELD_SERVICE_NAME_PREFIX + '/' + lang.toString(), singletonList(REPLACE)));

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
@@ -50,7 +50,8 @@ import static uk.gov.pay.adminusers.service.ServiceUpdater.FIELD_WENT_LIVE_DATE;
 public class ServiceUpdateOperationValidator {
 
     private static final String REPLACE = "replace";
-    private static final String ADD = "add";
+    public static final String ADD = "add";
+    public static final String REMOVE = "remove";
 
     private static final int SERVICE_NAME_MAX_LENGTH = 50;
 
@@ -97,7 +98,7 @@ public class ServiceUpdateOperationValidator {
                 entry(FIELD_MERCHANT_DETAILS_EMAIL, singletonList(REPLACE)),
                 entry(FIELD_MERCHANT_DETAILS_TELEPHONE_NUMBER, singletonList(REPLACE)),
                 entry(FIELD_MERCHANT_DETAILS_URL, singletonList(REPLACE)),
-                entry(FIELD_FEATURE, singletonList(ADD))
+                entry(FIELD_FEATURE, List.of(ADD, REMOVE))
         ));
         Arrays.stream(SupportedLanguage.values()).forEach(lang ->
                 validAttributeUpdateOperations.put(FIELD_SERVICE_NAME_PREFIX + '/' + lang.toString(), singletonList(REPLACE)));

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
@@ -2,6 +2,7 @@ package uk.gov.pay.adminusers.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.inject.Inject;
+import uk.gov.pay.adminusers.model.Feature;
 import uk.gov.pay.adminusers.model.GoLiveStage;
 import uk.gov.pay.adminusers.model.PspTestAccountStage;
 import uk.gov.pay.adminusers.validations.RequestValidations;
@@ -14,6 +15,8 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
@@ -71,6 +74,10 @@ public class ServiceUpdateOperationValidator {
 
     private static final EnumSet<GoLiveStage> GO_LIVE_STAGES = EnumSet.allOf(GoLiveStage.class);
     private static final EnumSet<PspTestAccountStage> PSP_TEST_ACCOUNT_STAGES = EnumSet.allOf(PspTestAccountStage.class);
+    private static final Set<String> FEATURES = EnumSet.allOf(Feature.class)
+            .stream()
+            .map(Feature::getValue)
+            .collect(Collectors.toSet());
 
     @Inject
     public ServiceUpdateOperationValidator(RequestValidations requestValidations) {
@@ -177,9 +184,18 @@ public class ServiceUpdateOperationValidator {
             return validateStringValueWithMaxLength(operation, true, FIELD_MERCHANT_DETAILS_EMAIL_MAX_LENGTH);
         } else if (FIELD_MERCHANT_DETAILS_TELEPHONE_NUMBER.equals(path)) {
             return validateStringValueWithMaxLength(operation, true, FIELD_MERCHANT_DETAILS_TELEPHONE_NUMBER_MAX_LENGTH);
+        } else if (FIELD_FEATURE.equals(path)){
+            return validateFeature(operation);
         }
 
         return Collections.emptyList();
+    }
+
+    private List<String> validateFeature(JsonNode operation) {
+        List<String> errors = new ArrayList<>();
+ 
+        requestValidations.isValidEnumValue(operation, FEATURES, FIELD_VALUE).ifPresent(errors::addAll);
+        return errors;
     }
 
     private List<String> validateCustomBrandingValue(JsonNode operation) { ;
@@ -211,7 +227,7 @@ public class ServiceUpdateOperationValidator {
                     FIELD_VALUE).ifPresent(errors::addAll);
         }
         if (errors.isEmpty()) {
-            requestValidations.isValidEnumValue(operation, GO_LIVE_STAGES, FIELD_VALUE).ifPresent(errors::addAll);
+            requestValidations.isValidEnum(operation, GO_LIVE_STAGES, FIELD_VALUE).ifPresent(errors::addAll);
         }
         return errors;
     }
@@ -226,7 +242,7 @@ public class ServiceUpdateOperationValidator {
                     FIELD_VALUE).ifPresent(errors::addAll);
         }
         if (errors.isEmpty()) {
-            requestValidations.isValidEnumValue(operation, PSP_TEST_ACCOUNT_STAGES, FIELD_VALUE).ifPresent(errors::addAll);
+            requestValidations.isValidEnum(operation, PSP_TEST_ACCOUNT_STAGES, FIELD_VALUE).ifPresent(errors::addAll);
         }
         return errors;
     }

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
@@ -140,55 +140,40 @@ public class ServiceUpdateOperationValidator {
 
     private List<String> validateValueIsValidForPath(JsonNode operation) {
         String path = operation.get(FIELD_PATH).asText();
-        if (FIELD_CUSTOM_BRANDING.equals(path)) {
-            return validateCustomBrandingValue(operation);
-        } else if (path.startsWith(FIELD_SERVICE_NAME_PREFIX)) {
+
+        if (path.startsWith(FIELD_SERVICE_NAME_PREFIX)) {
             return validateServiceNameValue(operation, path);
-        } else if (FIELD_REDIRECT_NAME.equals(path)) {
-            return validateMandatoryBooleanValue(operation);
-        } else if (FIELD_EXPERIMENTAL_FEATURES_ENABLED.equals(path)) {
-            return validateMandatoryBooleanValue(operation);
-        } else if (FIELD_TAKES_PAYMENTS_OVER_PHONE.equals(path)) {
-            return validateMandatoryBooleanValue(operation);
-        } else if (FIELD_AGENT_INITIATED_MOTO_ENABLED.equals(path)) {
-            return validateMandatoryBooleanValue(operation);
-        } else if (FIELD_COLLECT_BILLING_ADDRESS.equals(path)) {
-            return validateMandatoryBooleanValue(operation);
-        } else if (FIELD_DEFAULT_BILLING_ADDRESS_COUNTRY.equals(path)) {
-            return validateCountryCode(operation);
-        } else if (FIELD_CURRENT_GO_LIVE_STAGE.equals(path)) {
-            return validateCurrentGoLiveStageValue(operation);
-        } else if (FIELD_CURRENT_PSP_TEST_ACCOUNT_STAGE.equals(path)){
-            return validateCurrentPspTestAccountStageValue(operation);
-        } else if (FIELD_SECTOR.equals(path)) {
-            return validateStringValueWithMaxLength(operation, false, FIELD_SECTOR_MAX_LENGTH);
-        } else if (FIELD_INTERNAL.equals(path)) {
-            return validateMandatoryBooleanValue(operation);
-        } else if (FIELD_ARCHIVED.equals(path)) {
-            return validateMandatoryBooleanValue(operation);
-        } else if (FIELD_WENT_LIVE_DATE.equals(path)) {
-            return validateZonedDateTimeValue(operation);
-        } else if (FIELD_MERCHANT_DETAILS_NAME.equals(path)) {
-            return validateStringValueWithMaxLength(operation, false, FIELD_MERCHANT_DETAILS_NAME_MAX_LENGTH);
-        } else if (FIELD_MERCHANT_DETAILS_ADDRESS_LINE_1.equals(path)) {
-            return validateStringValueWithMaxLength(operation, false, FIELD_MERCHANT_DETAILS_ADDRESS_LINE_1_MAX_LENGTH);
-        } else if (FIELD_MERCHANT_DETAILS_ADDRESS_LINE_2.equals(path)) {
-            return validateStringValueWithMaxLength(operation, true, FIELD_MERCHANT_DETAILS_ADDRESS_LINE_2_MAX_LENGTH);
-        } else if (FIELD_MERCHANT_DETAILS_ADDRESS_CITY.equals(path)) {
-            return validateStringValueWithMaxLength(operation, false, FIELD_MERCHANT_DETAILS_ADDRESS_CITY_MAX_LENGTH);
-        } else if (FIELD_MERCHANT_DETAILS_ADDRESS_COUNRTY.equals(path)) {
-            return validateStringValueWithMaxLength(operation, false, FIELD_MERCHANT_DETAILS_ADDRESS_COUNTRY_CODE_MAX_LENGTH);
-        } else if (FIELD_MERCHANT_DETAILS_ADDRESS_POSTCODE.equals(path)) {
-            return validateStringValueWithMaxLength(operation, false, FIELD_MERCHANT_DETAILS_ADDRESS_POSTCODE_MAX_LENGTH);
-        } else if (FIELD_MERCHANT_DETAILS_EMAIL.equals(path)) {
-            return validateStringValueWithMaxLength(operation, true, FIELD_MERCHANT_DETAILS_EMAIL_MAX_LENGTH);
-        } else if (FIELD_MERCHANT_DETAILS_TELEPHONE_NUMBER.equals(path)) {
-            return validateStringValueWithMaxLength(operation, true, FIELD_MERCHANT_DETAILS_TELEPHONE_NUMBER_MAX_LENGTH);
-        } else if (FIELD_FEATURE.equals(path)){
-            return validateFeature(operation);
         }
 
-        return Collections.emptyList();
+        return switch (path) {
+            case FIELD_REDIRECT_NAME, FIELD_EXPERIMENTAL_FEATURES_ENABLED, FIELD_TAKES_PAYMENTS_OVER_PHONE,
+                 FIELD_AGENT_INITIATED_MOTO_ENABLED, FIELD_COLLECT_BILLING_ADDRESS, FIELD_INTERNAL, FIELD_ARCHIVED -> validateMandatoryBooleanValue(operation);
+
+            case FIELD_CUSTOM_BRANDING -> validateCustomBrandingValue(operation);
+            case FIELD_DEFAULT_BILLING_ADDRESS_COUNTRY -> validateCountryCode(operation);
+            case FIELD_CURRENT_GO_LIVE_STAGE -> validateCurrentGoLiveStageValue(operation);
+            case FIELD_CURRENT_PSP_TEST_ACCOUNT_STAGE -> validateCurrentPspTestAccountStageValue(operation);
+            case FIELD_SECTOR -> validateStringValueWithMaxLength(operation, false, FIELD_SECTOR_MAX_LENGTH);
+            case FIELD_WENT_LIVE_DATE -> validateZonedDateTimeValue(operation);
+            case FIELD_MERCHANT_DETAILS_NAME ->
+                    validateStringValueWithMaxLength(operation, false, FIELD_MERCHANT_DETAILS_NAME_MAX_LENGTH);
+            case FIELD_MERCHANT_DETAILS_ADDRESS_LINE_1 ->
+                    validateStringValueWithMaxLength(operation, false, FIELD_MERCHANT_DETAILS_ADDRESS_LINE_1_MAX_LENGTH);
+            case FIELD_MERCHANT_DETAILS_ADDRESS_LINE_2 ->
+                    validateStringValueWithMaxLength(operation, true, FIELD_MERCHANT_DETAILS_ADDRESS_LINE_2_MAX_LENGTH);
+            case FIELD_MERCHANT_DETAILS_ADDRESS_CITY ->
+                    validateStringValueWithMaxLength(operation, false, FIELD_MERCHANT_DETAILS_ADDRESS_CITY_MAX_LENGTH);
+            case FIELD_MERCHANT_DETAILS_ADDRESS_COUNRTY ->
+                    validateStringValueWithMaxLength(operation, false, FIELD_MERCHANT_DETAILS_ADDRESS_COUNTRY_CODE_MAX_LENGTH);
+            case FIELD_MERCHANT_DETAILS_ADDRESS_POSTCODE ->
+                    validateStringValueWithMaxLength(operation, false, FIELD_MERCHANT_DETAILS_ADDRESS_POSTCODE_MAX_LENGTH);
+            case FIELD_MERCHANT_DETAILS_EMAIL ->
+                    validateStringValueWithMaxLength(operation, true, FIELD_MERCHANT_DETAILS_EMAIL_MAX_LENGTH);
+            case FIELD_MERCHANT_DETAILS_TELEPHONE_NUMBER ->
+                    validateStringValueWithMaxLength(operation, true, FIELD_MERCHANT_DETAILS_TELEPHONE_NUMBER_MAX_LENGTH);
+            case FIELD_FEATURE -> validateFeature(operation);
+            default -> Collections.emptyList();
+        };
     }
 
     private List<String> validateFeature(JsonNode operation) {
@@ -198,7 +183,7 @@ public class ServiceUpdateOperationValidator {
         return errors;
     }
 
-    private List<String> validateCustomBrandingValue(JsonNode operation) { ;
+    private List<String> validateCustomBrandingValue(JsonNode operation) {
         return requestValidations.checkExists(operation, FIELD_VALUE)
                 .orElseGet(() -> checkIfValidJson(operation.get(FIELD_VALUE), FIELD_CUSTOM_BRANDING));
     }

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
@@ -24,6 +24,8 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 
 import static java.util.Map.entry;
+import static uk.gov.pay.adminusers.resources.ServiceUpdateOperationValidator.ADD;
+import static uk.gov.pay.adminusers.resources.ServiceUpdateOperationValidator.REMOVE;
 import static uk.gov.pay.adminusers.service.AdminUsersExceptions.conflictingServiceGatewayAccounts;
 
 public class ServiceUpdater {
@@ -126,7 +128,11 @@ public class ServiceUpdater {
     @Transactional
     public BiConsumer<ServiceUpdateRequest, ServiceEntity> updateFeature() {
         return (serviceUpdateRequest, serviceEntity) -> {
-            serviceEntity.addFeature(serviceUpdateRequest.valueAsString());
+            if (serviceUpdateRequest.getOp().equals(ADD)) {
+                serviceEntity.addFeature(serviceUpdateRequest.valueAsString());
+            } else if (serviceUpdateRequest.getOp().equals(REMOVE)) {
+                serviceEntity.removeFeature(serviceUpdateRequest.valueAsString());
+            }
         };
     }
     

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
@@ -52,7 +52,7 @@ public class ServiceUpdater {
     public static final String FIELD_MERCHANT_DETAILS_EMAIL = "merchant_details/email";
     public static final String FIELD_MERCHANT_DETAILS_TELEPHONE_NUMBER = "merchant_details/telephone_number";
     public static final String FIELD_MERCHANT_DETAILS_URL = "merchant_details/url";
-    public static final String FEATURE = "feature";
+    public static final String FIELD_FEATURE = "feature";
     private final ServiceDao serviceDao;
     private final Map<String, BiConsumer<ServiceUpdateRequest, ServiceEntity>> attributeUpdaters;
 
@@ -83,7 +83,8 @@ public class ServiceUpdater {
                 entry(FIELD_MERCHANT_DETAILS_ADDRESS_POSTCODE, updateMerchantDetailsAddressPostcode()),
                 entry(FIELD_MERCHANT_DETAILS_EMAIL, updateMerchantDetailsEmail()),
                 entry(FIELD_MERCHANT_DETAILS_TELEPHONE_NUMBER, updateMerchantDetailsPhone()),
-                entry(FIELD_MERCHANT_DETAILS_URL, updateMerchantDetailsUrl())
+                entry(FIELD_MERCHANT_DETAILS_URL, updateMerchantDetailsUrl()),
+                entry(FIELD_FEATURE, updateFeature())
         ));
 
         Arrays.stream(SupportedLanguage.values())
@@ -123,14 +124,10 @@ public class ServiceUpdater {
     }
     
     @Transactional
-    public Service doUpdateFeature(String serviceExternalId, List<ServiceUpdateRequest> requests) {
-        var serviceEntity = serviceDao.findByExternalId(serviceExternalId).get();
-        
-        if (requests.get(0).getOp().equals("add")){
-            serviceEntity.addFeature(requests.get(0).getValue());
-        }
-        
-        return serviceDao.merge(serviceEntity).toService();
+    public BiConsumer<ServiceUpdateRequest, ServiceEntity> updateFeature() {
+        return (serviceUpdateRequest, serviceEntity) -> {
+            serviceEntity.addFeature(serviceUpdateRequest.valueAsString());
+        };
     }
     
 

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
@@ -52,6 +52,7 @@ public class ServiceUpdater {
     public static final String FIELD_MERCHANT_DETAILS_EMAIL = "merchant_details/email";
     public static final String FIELD_MERCHANT_DETAILS_TELEPHONE_NUMBER = "merchant_details/telephone_number";
     public static final String FIELD_MERCHANT_DETAILS_URL = "merchant_details/url";
+    public static final String FEATURE = "feature";
     private final ServiceDao serviceDao;
     private final Map<String, BiConsumer<ServiceUpdateRequest, ServiceEntity>> attributeUpdaters;
 
@@ -109,7 +110,7 @@ public class ServiceUpdater {
                     return serviceEntity.toService();
                 });
     }
-
+    
     @Transactional
     public Service doUpdateMerchantDetails(String serviceExternalId, UpdateMerchantDetailsRequest updateMerchantDetailsRequest) throws ServiceNotFoundException {
         return serviceDao.findByExternalId(serviceExternalId)

--- a/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
+++ b/src/main/java/uk/gov/pay/adminusers/service/ServiceUpdater.java
@@ -121,6 +121,18 @@ public class ServiceUpdater {
                     return serviceEntity.toService();
                 }).orElseThrow(() -> new ServiceNotFoundException(serviceExternalId));
     }
+    
+    @Transactional
+    public Service doUpdateFeature(String serviceExternalId, List<ServiceUpdateRequest> requests) {
+        var serviceEntity = serviceDao.findByExternalId(serviceExternalId).get();
+        
+        if (requests.get(0).getOp().equals("add")){
+            serviceEntity.addFeature(requests.get(0).getValue());
+        }
+        
+        return serviceDao.merge(serviceEntity).toService();
+    }
+    
 
     private BiConsumer<ServiceUpdateRequest, ServiceEntity> assignGatewayAccounts() {
         return (serviceUpdateRequest, serviceEntity) -> {

--- a/src/main/java/uk/gov/pay/adminusers/validations/RequestValidations.java
+++ b/src/main/java/uk/gov/pay/adminusers/validations/RequestValidations.java
@@ -13,6 +13,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 
 import static java.lang.String.format;
@@ -76,7 +77,7 @@ public class RequestValidations {
         return errors.isEmpty() ? Optional.empty() : Optional.of(errors);
     }
 
-    public Optional<List<String>> isValidEnumValue(JsonNode payload, EnumSet<?> enumSet, String field) {
+    public Optional<List<String>> isValidEnum(JsonNode payload, EnumSet<?> enumSet, String field) {
         String value = payload.get(field).asText();
         if (enumSet.stream().noneMatch(constant -> constant.name().equals(value))) {
             return Optional.of(singletonList(format("Field [%s] must be one of %s", field, enumSet)));
@@ -163,5 +164,13 @@ public class RequestValidations {
                 jsonNode -> !EmailValidator.isValid(jsonNode.asText()),
                 fieldNames,
                 "Field [email] must be a valid email address");
+    }
+
+    public Optional<List<String>> isValidEnumValue(JsonNode payload, Set<String> validValues, String field) {
+        String value = payload.get(field).asText();
+        if (validValues.stream().noneMatch(validValue -> validValue.equals(value))) {
+            return Optional.of(singletonList(format("Field [%s] must be one of %s", field, validValues)));
+        }
+        return Optional.empty();
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/ServiceDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/ServiceDbFixture.java
@@ -11,6 +11,7 @@ import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static java.lang.String.valueOf;
 import static java.time.ZoneOffset.UTC;
@@ -37,6 +38,7 @@ public class ServiceDbFixture {
     private Map<String, Object> customBranding;
     private PspTestAccountStage currentPspTestAccountStage = PspTestAccountStage.NOT_STARTED;
     private ZonedDateTime createdDate = now(UTC);
+    private Set<String> features;
 
     private ServiceDbFixture(DatabaseTestHelper databaseHelper) {
         this.databaseHelper = databaseHelper;
@@ -112,9 +114,10 @@ public class ServiceDbFixture {
         service.setTakesPaymentsOverPhone(takesPaymentsOverPhone);
         service.setCurrentPspTestAccountStage(currentPspTestAccountStage);
         service.setCreatedDate(createdDate);
-        databaseHelper.addService(service, gatewayAccountIds.toArray(new String[0]));
+        databaseHelper.addService(service, features, gatewayAccountIds.toArray(new String[0]));
 
         service.setGatewayAccountIds(gatewayAccountIds);
+        service.setServiceFeatures(features);
         return service;
     }
 
@@ -125,6 +128,11 @@ public class ServiceDbFixture {
 
     public ServiceDbFixture withExternalId(String externalId) {
         this.externalId = externalId;
+        return this;
+    }
+    
+    public ServiceDbFixture withFeatures(Set<String> features) {
+        this.features = features;
         return this;
     }
 }

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/ServiceDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/ServiceDbFixture.java
@@ -9,6 +9,7 @@ import uk.gov.pay.adminusers.utils.DatabaseTestHelper;
 
 import java.time.ZonedDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -38,7 +39,7 @@ public class ServiceDbFixture {
     private Map<String, Object> customBranding;
     private PspTestAccountStage currentPspTestAccountStage = PspTestAccountStage.NOT_STARTED;
     private ZonedDateTime createdDate = now(UTC);
-    private Set<String> features;
+    private Set<String> features = Collections.emptySet();
 
     private ServiceDbFixture(DatabaseTestHelper databaseHelper) {
         this.databaseHelper = databaseHelper;

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/ServiceDbFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/ServiceDbFixture.java
@@ -118,7 +118,6 @@ public class ServiceDbFixture {
         databaseHelper.addService(service, features, gatewayAccountIds.toArray(new String[0]));
 
         service.setGatewayAccountIds(gatewayAccountIds);
-        service.setServiceFeatures(features);
         return service;
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/fixtures/ServiceEntityFixture.java
+++ b/src/test/java/uk/gov/pay/adminusers/fixtures/ServiceEntityFixture.java
@@ -41,7 +41,7 @@ public final class ServiceEntityFixture {
     private ZonedDateTime archivedDate;
     private ZonedDateTime firstCheckedForArchivalDate;
     private ZonedDateTime skipCheckingForArchivalUntilDate;
-    private List<String> serviceFeatures = new ArrayList<>();
+    private Set<String> serviceFeatures = new HashSet<>();
 
     private ServiceEntityFixture() {
     }
@@ -152,7 +152,7 @@ public final class ServiceEntityFixture {
         return this;
     }
 
-    public ServiceEntityFixture withServiceFeatures(List<String> features) {
+    public ServiceEntityFixture withServiceFeatures(Set<String> features) {
         this.serviceFeatures = features;
         return this;
     }

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoIT.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 import static java.time.ZoneOffset.UTC;
 import static java.time.ZonedDateTime.now;
 import static java.time.ZonedDateTime.parse;
+import static java.util.Collections.emptySet;
 import static java.util.Comparator.comparing;
 import static java.util.stream.IntStream.range;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -507,7 +508,7 @@ class ServiceDaoIT extends DaoTestBase {
     private void setupUsersForServiceAndRole(String externalId, Role role, int noOfUsers) {
         String gatewayAccountId1 = randomInt().toString();
         Service service1 = Service.from(randomInt(), externalId, new ServiceName(Service.DEFAULT_NAME_VALUE));
-        databaseHelper.addService(service1, gatewayAccountId1);
+        databaseHelper.addService(service1, emptySet(), gatewayAccountId1);
 
         range(0, noOfUsers - 1).forEach(i -> {
             String username = randomUuid();
@@ -520,7 +521,7 @@ class ServiceDaoIT extends DaoTestBase {
         Integer serviceId2 = randomInt();
         String externalId2 = randomUuid();
         Service service2 = Service.from(serviceId2, externalId2, new ServiceName(Service.DEFAULT_NAME_VALUE));
-        databaseHelper.addService(service2, gatewayAccountId2);
+        databaseHelper.addService(service2, emptySet(), gatewayAccountId2);
 
         //same user 2 diff services - should count only once
         String username3 = randomUuid();

--- a/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/persistence/dao/ServiceDaoIT.java
@@ -14,7 +14,6 @@ import uk.gov.pay.adminusers.model.PspTestAccountStage;
 import uk.gov.pay.adminusers.model.Role;
 import uk.gov.pay.adminusers.model.RoleName;
 import uk.gov.pay.adminusers.model.Service;
-import uk.gov.pay.adminusers.model.ServiceName;
 import uk.gov.pay.adminusers.model.User;
 import uk.gov.pay.adminusers.persistence.entity.CustomBrandingConverter;
 import uk.gov.pay.adminusers.persistence.entity.GatewayAccountIdEntity;
@@ -31,12 +30,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static java.time.ZoneOffset.UTC;
 import static java.time.ZonedDateTime.now;
 import static java.time.ZonedDateTime.parse;
-import static java.util.Collections.emptySet;
 import static java.util.Comparator.comparing;
 import static java.util.stream.IntStream.range;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -49,8 +46,8 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
+import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 
 class ServiceDaoIT extends DaoTestBase {
 
@@ -168,7 +165,6 @@ class ServiceDaoIT extends DaoTestBase {
 
     @Test
     void shouldFindByServiceExternalId() {
-        ZonedDateTime now = now(UTC);
         ServiceEntity insertedServiceEntity = ServiceEntityFixture.aServiceEntity()
                 .withExperimentalFeaturesEnabled(true)
                 .build();
@@ -210,7 +206,7 @@ class ServiceDaoIT extends DaoTestBase {
                 .stream()
                 .map(ServiceEntity::toService)
                 .map(Service::getName)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
         assertThat(foundServiceNames, contains("register a birth"));
 
         List<ServiceEntity> shouldNotHaveServiceEntities = serviceDao.findByENServiceName("random");
@@ -247,7 +243,7 @@ class ServiceDaoIT extends DaoTestBase {
                 .stream()
                 .map(ServiceEntity::toService)
                 .map(Service::getName)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
         assertThat(foundServiceNames, containsInAnyOrder("register a birth", "bulky waste collection"));
 
         List<ServiceEntity> shouldNotHaveServiceEntities = serviceDao.findByServiceMerchantName("of");
@@ -506,23 +502,17 @@ class ServiceDaoIT extends DaoTestBase {
     }
 
     private void setupUsersForServiceAndRole(String externalId, Role role, int noOfUsers) {
-        String gatewayAccountId1 = randomInt().toString();
-        Service service1 = Service.from(randomInt(), externalId, new ServiceName(Service.DEFAULT_NAME_VALUE));
-        databaseHelper.addService(service1, emptySet(), gatewayAccountId1);
+        var service1 = serviceDbFixture(databaseHelper).withExternalId(externalId).insertService();
 
-        range(0, noOfUsers - 1).forEach(i -> {
+        range(0, noOfUsers - 1).forEach(_ -> {
             String username = randomUuid();
             String email = username + "@example.com";
             UserDbFixture.userDbFixture(databaseHelper).withServiceRole(service1, adminRole).withEmail(email).insertUser();
         });
 
         //unmatching service
-        String gatewayAccountId2 = randomInt().toString();
-        Integer serviceId2 = randomInt();
-        String externalId2 = randomUuid();
-        Service service2 = Service.from(serviceId2, externalId2, new ServiceName(Service.DEFAULT_NAME_VALUE));
-        databaseHelper.addService(service2, emptySet(), gatewayAccountId2);
-
+        var serviceId2 = serviceDbFixture(databaseHelper).insertService().getId();
+        
         //same user 2 diff services - should count only once
         String username3 = randomUuid();
         String email3 = username3 + "@example.com";

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateCustomBrandingIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateCustomBrandingIT.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
@@ -21,7 +22,7 @@ public class ServiceResourceUpdateCustomBrandingIT extends IntegrationTest {
 
         String serviceExternalId = randomUuid();
         Service service = Service.from(randomInt(), serviceExternalId, new ServiceName("existing-name"));
-        databaseHelper.addService(service, randomInt().toString());
+        databaseHelper.addService(service, emptySet(), randomInt().toString());
 
         Map<String, Object> payload = Map.of("path", "custom_branding", "op", "replace", "value", Map.of("image_url","image url","css_url","css url"));
 
@@ -46,7 +47,7 @@ public class ServiceResourceUpdateCustomBrandingIT extends IntegrationTest {
         service.setCustomBranding(existingBranding);
 
         Map<String, Object> payloadWithEmptyBranding = Map.of("path", "custom_branding", "op", "replace", "value", emptyMap());
-        databaseHelper.addService(service, randomInt().toString());
+        databaseHelper.addService(service, emptySet(), randomInt().toString());
 
 
         givenSetup()
@@ -68,7 +69,7 @@ public class ServiceResourceUpdateCustomBrandingIT extends IntegrationTest {
         Service service = Service.from(randomInt(), serviceExternalId, new ServiceName("existing-name"));
         Map<String, Object> customBranding = Map.of("css_url","existing css", "image_url","existing image");
         service.setCustomBranding(customBranding);
-        databaseHelper.addService(service, randomInt().toString());
+        databaseHelper.addService(service, emptySet(), randomInt().toString());
 
         Map<String, Object> payload = Map.of("path", "custom_branding", "op", "replace", "value", "blah");
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateCustomBrandingIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateCustomBrandingIT.java
@@ -1,28 +1,21 @@
 package uk.gov.pay.adminusers.resources;
 
 import org.junit.jupiter.api.Test;
-import uk.gov.pay.adminusers.model.Service;
-import uk.gov.pay.adminusers.model.ServiceName;
 
 import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
-import static java.util.Collections.emptySet;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
-import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
-import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
+import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 
-public class ServiceResourceUpdateCustomBrandingIT extends IntegrationTest {
+class ServiceResourceUpdateCustomBrandingIT extends IntegrationTest {
 
     @Test
-    public void shouldSuccess_whenUpdatingCustomBranding() throws Exception {
-
-        String serviceExternalId = randomUuid();
-        Service service = Service.from(randomInt(), serviceExternalId, new ServiceName("existing-name"));
-        databaseHelper.addService(service, emptySet(), randomInt().toString());
+    void shouldSuccess_whenUpdatingCustomBranding() throws Exception {
+        var serviceExternalId = serviceDbFixture(databaseHelper).insertService().getExternalId();
 
         Map<String, Object> payload = Map.of("path", "custom_branding", "op", "replace", "value", Map.of("image_url","image url","css_url","css url"));
 
@@ -40,22 +33,19 @@ public class ServiceResourceUpdateCustomBrandingIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldReplaceWithEmpty_whenUpdatingCustomBranding_withEmptyObject() throws Exception {
-        String serviceExternalId = randomUuid();
+    void shouldReplaceWithEmpty_whenUpdatingCustomBranding_withEmptyObject() throws Exception {
+        var service = serviceDbFixture(databaseHelper).insertService();
         Map<String, Object> existingBranding = Map.of("css_url","existing css", "image_url","existing image");
-        Service service = Service.from(randomInt(), serviceExternalId, new ServiceName("existing-name"));
         service.setCustomBranding(existingBranding);
 
         Map<String, Object> payloadWithEmptyBranding = Map.of("path", "custom_branding", "op", "replace", "value", emptyMap());
-        databaseHelper.addService(service, emptySet(), randomInt().toString());
-
-
+        
         givenSetup()
                 .when()
                 .contentType(JSON)
                 .accept(JSON)
                 .body(mapper.writeValueAsString(payloadWithEmptyBranding))
-                .patch(format(SERVICE_RESOURCE, serviceExternalId))
+                .patch(format(SERVICE_RESOURCE, service.getExternalId()))
                 .then()
                 .statusCode(200)
                 .body("custom_branding", is(nullValue()));
@@ -63,13 +53,10 @@ public class ServiceResourceUpdateCustomBrandingIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldReturn400_whenUpdatingServiceCustomisations_ifPayloadNotJson() throws Exception {
-
-        String serviceExternalId = randomUuid();
-        Service service = Service.from(randomInt(), serviceExternalId, new ServiceName("existing-name"));
+    void shouldReturn400_whenUpdatingServiceCustomisations_ifPayloadNotJson() throws Exception {
+        var service = serviceDbFixture(databaseHelper).insertService();
         Map<String, Object> customBranding = Map.of("css_url","existing css", "image_url","existing image");
         service.setCustomBranding(customBranding);
-        databaseHelper.addService(service, emptySet(), randomInt().toString());
 
         Map<String, Object> payload = Map.of("path", "custom_branding", "op", "replace", "value", "blah");
 
@@ -78,13 +65,13 @@ public class ServiceResourceUpdateCustomBrandingIT extends IntegrationTest {
                 .contentType(JSON)
                 .accept(JSON)
                 .body(mapper.writeValueAsString(payload))
-                .patch(format(SERVICE_RESOURCE, serviceExternalId))
+                .patch(format(SERVICE_RESOURCE, service.getExternalId()))
                 .then()
                 .statusCode(400);
     }
 
     @Test
-    public void shouldReturn404_whenUpdatingServiceCustomisations_ifNotFound() throws Exception {
+    void shouldReturn404_whenUpdatingServiceCustomisations_ifNotFound() throws Exception {
 
         Map<String, Object> payload = Map.of("path", "custom_branding", "op", "replace", "value", Map.of("image_url","image url","css_url","css url"));
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateIT.java
@@ -16,7 +16,7 @@ import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static java.lang.String.valueOf;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
@@ -129,7 +129,6 @@ public class ServiceResourceUpdateIT extends IntegrationTest {
         Set<String> features = new HashSet<>(List.of("test_feature"));
         Service service = serviceDbFixture(databaseHelper).withFeatures(features).insertService();
         
-        
         JsonNode payload = mapper
                 .valueToTree(List.of(
                         patchRequest("remove", "feature", "test_feature")));
@@ -141,7 +140,7 @@ public class ServiceResourceUpdateIT extends IntegrationTest {
                 .patch(format(SERVICE_RESOURCE, service.getExternalId()))
                 .then()
                 .statusCode(200)
-                .body("service_features", is(emptyArray()));
+                .body("service_features", is(empty()));
     }
 
     private Map<String, Object> patchRequest(String op, String path, Object value) {

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateIT.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static java.lang.String.valueOf;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
@@ -98,6 +99,24 @@ public class ServiceResourceUpdateIT extends IntegrationTest {
                 .then()
                 .statusCode(200)
                 .body("merchant_details.url", is("https://merchant.example.com"));
+    }
+    
+    @Test
+    public void shouldAddFeature() {
+        String serviceExternalId = serviceDbFixture(databaseHelper).insertService().getExternalId();
+        JsonNode payload = mapper
+                .valueToTree(List.of(
+                        patchRequest("add", "feature", "test_feature")));
+
+        givenSetup()
+                .when()
+                .contentType(JSON)
+                .body(payload)
+                .patch(format(SERVICE_RESOURCE, serviceExternalId))
+                .then()
+                .statusCode(200)
+                .body("features", contains("test_feature"));
+        
     }
 
     private Map<String, Object> patchRequest(String op, String path, Object value) {

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateIT.java
@@ -13,6 +13,7 @@ import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static java.lang.String.valueOf;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
@@ -115,8 +116,8 @@ public class ServiceResourceUpdateIT extends IntegrationTest {
                 .patch(format(SERVICE_RESOURCE, serviceExternalId))
                 .then()
                 .statusCode(200)
-                .body("features", contains("test_feature"));
-        
+                .body("service_features", hasSize(1))
+                .body("service_features", contains("test_feature"));
     }
 
     private Map<String, Object> patchRequest(String op, String path, Object value) {

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateIT.java
@@ -4,15 +4,19 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.adminusers.model.GoLiveStage;
 import uk.gov.pay.adminusers.model.MerchantDetails;
+import uk.gov.pay.adminusers.model.Service;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static java.lang.String.valueOf;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
@@ -118,6 +122,26 @@ public class ServiceResourceUpdateIT extends IntegrationTest {
                 .statusCode(200)
                 .body("service_features", hasSize(1))
                 .body("service_features", contains("test_feature"));
+    }
+
+    @Test
+    public void shouldRemoveFeature() {
+        Set<String> features = new HashSet<>(List.of("test_feature"));
+        Service service = serviceDbFixture(databaseHelper).withFeatures(features).insertService();
+        
+        
+        JsonNode payload = mapper
+                .valueToTree(List.of(
+                        patchRequest("remove", "feature", "test_feature")));
+
+        givenSetup()
+                .when()
+                .contentType(JSON)
+                .body(payload)
+                .patch(format(SERVICE_RESOURCE, service.getExternalId()))
+                .then()
+                .statusCode(200)
+                .body("service_features", is(emptyArray()));
     }
 
     private Map<String, Object> patchRequest(String op, String path, Object value) {

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateMerchantDetailsIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateMerchantDetailsIT.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
+import static java.util.Collections.emptySet;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasKey;
@@ -25,7 +26,7 @@ public class ServiceResourceUpdateMerchantDetailsIT extends IntegrationTest {
     public void shouldSuccess_whenUpdatingMerchantDetails() throws Exception {
         String serviceExternalId = randomUuid();
         Service service = Service.from(randomInt(), serviceExternalId, new ServiceName("existing-name"));
-        databaseHelper.addService(service, randomInt().toString());
+        databaseHelper.addService(service, emptySet(), randomInt().toString());
         Map<String, Object> payload = Map.of(
                 "name", "somename",
                 "telephone_number", "03069990000",
@@ -60,7 +61,7 @@ public class ServiceResourceUpdateMerchantDetailsIT extends IntegrationTest {
     public void shouldSuccess_whenUpdatingMerchantDetails_withoutOptionalFields() throws Exception {
         String serviceExternalId = randomUuid();
         Service service = Service.from(randomInt(), serviceExternalId, new ServiceName("existing-name"));
-        databaseHelper.addService(service, randomInt().toString());
+        databaseHelper.addService(service, emptySet(), randomInt().toString());
         Map<String, Object> payload = Map.of(
                 "name", "somename",
                 "address_line1", "line1",
@@ -91,7 +92,7 @@ public class ServiceResourceUpdateMerchantDetailsIT extends IntegrationTest {
     public void shouldFail_whenUpdatingMerchantDetails_withMissingMandatoryFieldName() throws Exception {
         String serviceExternalId = randomUuid();
         Service service = Service.from(randomInt(), serviceExternalId, new ServiceName("existing-name"));
-        databaseHelper.addService(service, randomInt().toString());
+        databaseHelper.addService(service, emptySet(), randomInt().toString());
         Map<String, Object> payload = Map.of(
                 "telephone_number", "03069990000",
                 "address_line1", "line1",

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateMerchantDetailsIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateMerchantDetailsIT.java
@@ -3,30 +3,24 @@ package uk.gov.pay.adminusers.resources;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.junit.jupiter.api.Test;
-import uk.gov.pay.adminusers.model.Service;
-import uk.gov.pay.adminusers.model.ServiceName;
 
 import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
-import static java.util.Collections.emptySet;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
-import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomInt;
-import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
 import static uk.gov.pay.adminusers.fixtures.ServiceDbFixture.serviceDbFixture;
 
-public class ServiceResourceUpdateMerchantDetailsIT extends IntegrationTest {
+class ServiceResourceUpdateMerchantDetailsIT extends IntegrationTest {
 
     @Test
-    public void shouldSuccess_whenUpdatingMerchantDetails() throws Exception {
-        String serviceExternalId = randomUuid();
-        Service service = Service.from(randomInt(), serviceExternalId, new ServiceName("existing-name"));
-        databaseHelper.addService(service, emptySet(), randomInt().toString());
+    void shouldSuccess_whenUpdatingMerchantDetails() throws Exception {
+        var serviceExternalId = serviceDbFixture(databaseHelper).insertService().getExternalId();
+        
         Map<String, Object> payload = Map.of(
                 "name", "somename",
                 "telephone_number", "03069990000",
@@ -58,10 +52,9 @@ public class ServiceResourceUpdateMerchantDetailsIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldSuccess_whenUpdatingMerchantDetails_withoutOptionalFields() throws Exception {
-        String serviceExternalId = randomUuid();
-        Service service = Service.from(randomInt(), serviceExternalId, new ServiceName("existing-name"));
-        databaseHelper.addService(service, emptySet(), randomInt().toString());
+    void shouldSuccess_whenUpdatingMerchantDetails_withoutOptionalFields() throws Exception {
+        var serviceExternalId = serviceDbFixture(databaseHelper).insertService().getExternalId();
+        
         Map<String, Object> payload = Map.of(
                 "name", "somename",
                 "address_line1", "line1",
@@ -89,10 +82,9 @@ public class ServiceResourceUpdateMerchantDetailsIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldFail_whenUpdatingMerchantDetails_withMissingMandatoryFieldName() throws Exception {
-        String serviceExternalId = randomUuid();
-        Service service = Service.from(randomInt(), serviceExternalId, new ServiceName("existing-name"));
-        databaseHelper.addService(service, emptySet(), randomInt().toString());
+    void shouldFail_whenUpdatingMerchantDetails_withMissingMandatoryFieldName() throws Exception {
+        var serviceExternalId = serviceDbFixture(databaseHelper).insertService().getExternalId();
+        
         Map<String, Object> payload = Map.of(
                 "telephone_number", "03069990000",
                 "address_line1", "line1",
@@ -114,7 +106,7 @@ public class ServiceResourceUpdateMerchantDetailsIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldSucceed_whenPatchUpdatingMultipleMerchantDetails() {
+    void shouldSucceed_whenPatchUpdatingMultipleMerchantDetails() {
         String serviceExternalId = serviceDbFixture(databaseHelper).insertService().getExternalId();
         String addressLine1 = "1 Spider Lane";
         String addressCountry = "Somewhere";
@@ -142,7 +134,7 @@ public class ServiceResourceUpdateMerchantDetailsIT extends IntegrationTest {
     }
 
     @Test
-    public void shouldSucceed_whenPatchUpdatingAddressLine1AndMerchantDetailsIsNull() {
+    void shouldSucceed_whenPatchUpdatingAddressLine1AndMerchantDetailsIsNull() {
         String serviceExternalId = serviceDbFixture(databaseHelper)
                 .withMerchantDetails(null)
                 .insertService()

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
@@ -72,7 +72,7 @@ public class ServiceUpdateOperationValidatorTest {
                 new Object[]{"add", "merchant_details/email", "any value"},
                 new Object[]{"add", "merchant_details/telephone_number", "any value"},
                 new Object[]{"add", "default_billing_address_country", "GB"},
-                new Object[]{"replace", "feature", "any value"},
+                new Object[]{"replace", "feature", "test_feature"},
         };
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
@@ -71,7 +71,8 @@ public class ServiceUpdateOperationValidatorTest {
                 new Object[]{"add", "merchant_details/address_postcode", "any value"},
                 new Object[]{"add", "merchant_details/email", "any value"},
                 new Object[]{"add", "merchant_details/telephone_number", "any value"},
-                new Object[]{"add", "default_billing_address_country", "GB"}
+                new Object[]{"add", "default_billing_address_country", "GB"},
+                new Object[]{"replace", "feature", "any value"},
         };
     }
 
@@ -215,6 +216,11 @@ public class ServiceUpdateOperationValidatorTest {
     @MethodSource("shouldFailWhenStringValueIsTooLongParameters")
     public void replaceShouldFailWhenStringValueIsTooLong(String path, int expectedMaxLength) {
         shouldFail(path, "replace", randomAlphanumeric(expectedMaxLength + 1), String.format("Field [value] must have a maximum length of %s characters", expectedMaxLength));
+    }
+    
+    @Test 
+    public void addShouldFailWhenFeatureIsInvalid(){
+        shouldFail("feature", "add", "invalidFeature", "Field [value] must be one of [test_feature]");
     }
 
     private static Object[] shouldSucceedParams() {

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
@@ -18,7 +18,7 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-public class ServiceUpdateOperationValidatorTest {
+class ServiceUpdateOperationValidatorTest {
 
     private static final String GO_LIVE_STAGE_INVALID_ERROR_MESSAGE = "Field [value] must be one of [NOT_STARTED, ENTERED_ORGANISATION_NAME, ENTERED_ORGANISATION_ADDRESS, CHOSEN_PSP_ADYEN, CHOSEN_PSP_STRIPE, CHOSEN_PSP_GOV_BANKING_WORLDPAY, GOV_BANKING_MOTO_OPTION_COMPLETED, TERMS_AGREED_ADYEN, TERMS_AGREED_STRIPE, TERMS_AGREED_GOV_BANKING_WORLDPAY, DENIED, LIVE]";
     private static final String PSP_TEST_ACCOUNT_STAGE_INVALID_ERROR_MESSAGE = "Field [value] must be one of [NOT_STARTED, REQUEST_SUBMITTED, CREATED]";
@@ -27,7 +27,7 @@ public class ServiceUpdateOperationValidatorTest {
     private final ServiceUpdateOperationValidator serviceUpdateOperationValidator = new ServiceUpdateOperationValidator(new RequestValidations());
 
     @Test
-    public void shouldFail_whenUpdate_whenMissingRequiredField() {
+    void shouldFail_whenUpdate_whenMissingRequiredField() {
         Map<String, String> payload = Map.of("value", "example-name");
 
         List<String> errors = serviceUpdateOperationValidator.validate(mapper.valueToTree(payload));
@@ -38,12 +38,12 @@ public class ServiceUpdateOperationValidatorTest {
     }
 
     @Test
-    public void shouldFail_whenUpdate_whenInvalidPath() {
+    void shouldFail_whenUpdate_whenInvalidPath() {
         shouldFail("xyz", "replace", "any value", "Path [xyz] is invalid");
     }
 
     @Test
-    public void shouldFail_whenUpdateServiceName_whenPathContainsUnsupportedLanguage() {
+    void shouldFail_whenUpdateServiceName_whenPathContainsUnsupportedLanguage() {
         shouldFail("service_name/xx", "replace", "example name", "Path [service_name/xx] is invalid");
     }
 
@@ -78,7 +78,7 @@ public class ServiceUpdateOperationValidatorTest {
 
     @ParameterizedTest
     @MethodSource("shouldFailForOperationParams")
-    public void shouldFailForOperation(String operation, String path, Object value) {
+    void shouldFailForOperation(String operation, String path, Object value) {
         String expectedErrorMessage = String.format("Operation [%s] is invalid for path [%s]", operation, path);
         shouldFail(path, operation, value, expectedErrorMessage);
     }
@@ -115,7 +115,7 @@ public class ServiceUpdateOperationValidatorTest {
 
     @ParameterizedTest
     @MethodSource("replaceShouldFailWhenValueInvalidValueParameters")
-    public void replaceShouldFailWhenInvalidValue(String path, Object value, String expectedErrorMessage) {
+    void replaceShouldFailWhenInvalidValue(String path, Object value, String expectedErrorMessage) {
         shouldFail(path, "replace", value, expectedErrorMessage);
     }
 
@@ -141,7 +141,7 @@ public class ServiceUpdateOperationValidatorTest {
             "archived",
             "went_live_date"
     })
-    public void replaceShouldFailWhenValueMissing(String path) {
+    void replaceShouldFailWhenValueMissing(String path) {
         ObjectNode payload = mapper.createObjectNode();
         payload.put("path", path);
         payload.put("op", "replace");
@@ -172,7 +172,7 @@ public class ServiceUpdateOperationValidatorTest {
             "archived",
             "went_live_date"
     })
-    public void replaceShouldFailWhenValueIsNull(String path) {
+    void replaceShouldFailWhenValueIsNull(String path) {
         ObjectNode payload = mapper.createObjectNode();
         payload.put("path", path);
         payload.put("op", "replace");
@@ -193,7 +193,7 @@ public class ServiceUpdateOperationValidatorTest {
             "merchant_details/address_country",
             "merchant_details/address_postcode",
     })
-    public void replaceShouldFailWhenValueIsEmptyString(String path) {
+    void replaceShouldFailWhenValueIsEmptyString(String path) {
         shouldFail(path, "replace", "", "Field [value] is required");
     }
 
@@ -214,12 +214,12 @@ public class ServiceUpdateOperationValidatorTest {
 
     @ParameterizedTest
     @MethodSource("shouldFailWhenStringValueIsTooLongParameters")
-    public void replaceShouldFailWhenStringValueIsTooLong(String path, int expectedMaxLength) {
+    void replaceShouldFailWhenStringValueIsTooLong(String path, int expectedMaxLength) {
         shouldFail(path, "replace", randomAlphanumeric(expectedMaxLength + 1), String.format("Field [value] must have a maximum length of %s characters", expectedMaxLength));
     }
     
-    @Test 
-    public void addShouldFailWhenFeatureIsInvalid(){
+    @Test
+    void addShouldFailWhenFeatureIsInvalid(){
         shouldFail("feature", "add", "invalidFeature", "Field [value] must be one of [test_feature]");
     }
 
@@ -259,7 +259,7 @@ public class ServiceUpdateOperationValidatorTest {
 
     @ParameterizedTest
     @MethodSource("shouldSucceedParams")
-    public void shouldSucceed(String operation, String path, Object value) {
+    void shouldSucceed(String operation, String path, Object value) {
         Map<String, Object> payload = new HashMap<>();
         payload.put("path", path);
         payload.put("op", operation);

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
@@ -251,7 +251,9 @@ public class ServiceUpdateOperationValidatorTest {
                 new Object[]{"replace", "archived", true},
                 new Object[]{"replace", "went_live_date", "2020-01-01T01:01:00Z"},
                 new Object[]{"replace", "default_billing_address_country", null},
-                new Object[]{"replace", "default_billing_address_country", "GB"}
+                new Object[]{"replace", "default_billing_address_country", "GB"},
+                new Object[]{"add", "feature", "test_feature"},
+                new Object[]{"remove", "feature", "test_feature"}
         };
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceFindTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceFindTest.java
@@ -3,16 +3,17 @@ package uk.gov.pay.adminusers.unit.service;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.testing.junit5.ResourceExtension;
 import io.restassured.path.json.JsonPath;
+import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.adminusers.fixtures.ServiceEntityFixture;
 import uk.gov.pay.adminusers.persistence.dao.ServiceDao;
 import uk.gov.pay.adminusers.persistence.dao.UserDao;
 import uk.gov.pay.adminusers.persistence.entity.GatewayAccountIdEntity;
 import uk.gov.pay.adminusers.persistence.entity.MerchantDetailsEntity;
 import uk.gov.pay.adminusers.persistence.entity.ServiceEntity;
-import uk.gov.pay.adminusers.fixtures.ServiceEntityFixture;
 import uk.gov.pay.adminusers.resources.GovUkPayAgreementRequestValidator;
 import uk.gov.pay.adminusers.resources.ServiceRequestValidator;
 import uk.gov.pay.adminusers.resources.ServiceResource;
@@ -24,11 +25,12 @@ import uk.gov.pay.adminusers.service.StripeAgreementService;
 import uk.gov.pay.adminusers.validations.RequestValidations;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 
-import jakarta.ws.rs.core.Response;
 import java.time.ZonedDateTime;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.not;
@@ -149,6 +151,7 @@ class ServiceResourceFindTest extends ServiceResourceBaseTest {
     void shouldFind_existingServiceByGatewayAccountId() {
         GatewayAccountIdEntity gatewayAccountIdEntity = new GatewayAccountIdEntity();
         String gatewayAccountId = randomUuid();
+        Set<String> features = new HashSet<>(List.of("apple_pay", "payment_links"));
         gatewayAccountIdEntity.setGatewayAccountId(gatewayAccountId);
         ServiceEntity serviceEntity = ServiceEntityFixture.aServiceEntity()
                 .withGatewayAccounts(Collections.singletonList(gatewayAccountIdEntity))
@@ -157,7 +160,7 @@ class ServiceResourceFindTest extends ServiceResourceBaseTest {
                 .withWentLiveDate(ZonedDateTime.parse("2020-02-01T09:00:00Z"))
                 .withArchivedDate(ZonedDateTime.parse("2021-02-01T09:00:00Z"))
                 .withSector("police")
-                .withServiceFeatures(List.of("apple_pay", "payment_links"))
+                .withServiceFeatures(features)
                 .build();
         gatewayAccountIdEntity.setService(serviceEntity);
 

--- a/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/adminusers/utils/DatabaseTestHelper.java
@@ -19,6 +19,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static java.sql.Timestamp.from;
 import static java.sql.Types.OTHER;
@@ -199,7 +200,7 @@ public class DatabaseTestHelper {
                         .mapToMap().list());
     }
 
-    public DatabaseTestHelper addService(Service service, String... gatewayAccountIds) {
+    public DatabaseTestHelper addService(Service service, Set<String> features, String... gatewayAccountIds) {
         jdbi.withHandle(handle ->
         {
             PGobject customBranding = service.getCustomBranding() == null ? null :
@@ -239,6 +240,15 @@ public class DatabaseTestHelper {
                     handle.createUpdate("INSERT INTO service_gateway_accounts(service_id, gateway_account_id) VALUES (:serviceId, :gatewayAccountId)")
                             .bind("serviceId", service.getId())
                             .bind("gatewayAccountId", gatewayAccountId)
+                            .execute()
+            );
+        }
+
+        for (String feature : features) {
+            jdbi.withHandle(handle ->
+                    handle.createUpdate("INSERT INTO service_features(service_id, feature) VALUES (:serviceId, :feature)")
+                            .bind("serviceId", service.getId())
+                            .bind("feature", feature)
                             .execute()
             );
         }


### PR DESCRIPTION
## WHAT YOU DID

- Integration tests added for both adding and removing a feature
- Added to existing parameterised validator unit tests to include validation/error handling for feature patch body 
- Amended `ServiceFeatures` to HashSet from List to ensure no duplicate features are added 
- Add `updateFeature` method to cater for both add and remove operations
- Updated `addService` to also take a Set so features can be passed to method and inserted as a separate SQL query. This led to updating all existing calls of addService to take an `emptySet()`.
- Refactored clunky if/else block in `ServiceUpdateOperationValidator` to use switch statement 
- Introduce `isValidEnumValue` to validate values on Feature enum and rename existing method to `isValidEnum` 
- Add features to `serviceDBFixture` 
- Updated openAPI spec 