### PR TITLE
PP-15686 Add GOVUK_PSP_IS_ADYEN feature to enable selecting Adyen in go live journey

### DIFF
--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -1555,10 +1555,8 @@ components:
               type: boolean
               example: false
             example:
-              test_feature:
+              govuk_psp_is_adyen:
                 enabled: true
-              test_feature_2:
-                enabled: false
           example:
             test_feature:
               enabled: true

--- a/openapi/adminusers_spec.yaml
+++ b/openapi/adminusers_spec.yaml
@@ -452,8 +452,8 @@ paths:
         | replace | archived | true |
         | replace | went_live_date | 2022-04-09T18:07:46Z |
         | replace | default_billing_address_country | GB |
-         | add | feature | test_feature |
-         | remove | feature | test_feature |
+         | add | feature | govuk_psp_is_adyen |
+         | remove | feature | govuk_psp_is_adyen |
       operationId: updateServiceAttribute
       parameters:
       - example: 7d19aff33f8948deb97ed16b2912dcd3
@@ -1558,10 +1558,8 @@ components:
               govuk_psp_is_adyen:
                 enabled: true
           example:
-            test_feature:
+            govuk_psp_is_adyen:
               enabled: true
-            test_feature_2:
-              enabled: false
         service_name:
           type: object
           additionalProperties:

--- a/src/main/java/uk/gov/pay/adminusers/model/Feature.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Feature.java
@@ -1,5 +1,8 @@
 package uk.gov.pay.adminusers.model;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 public enum Feature {
     GOVUK_PSP_IS_ADYEN("govuk_psp_is_adyen");
 
@@ -11,5 +14,11 @@ public enum Feature {
 
     public String getValue() {
         return value;
+    }
+    
+    public static String getValidValues() {
+        return Arrays.stream(Feature.values())
+                .map(Feature::getValue)
+                .collect(Collectors.joining(", "));
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/model/Feature.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Feature.java
@@ -1,8 +1,5 @@
 package uk.gov.pay.adminusers.model;
 
-import java.util.Arrays;
-import java.util.stream.Collectors;
-
 public enum Feature {
     GOVUK_PSP_IS_ADYEN("govuk_psp_is_adyen");
 
@@ -14,11 +11,5 @@ public enum Feature {
 
     public String getValue() {
         return value;
-    }
-    
-    public static String getValidValues() {
-        return Arrays.stream(Feature.values())
-                .map(Feature::getValue)
-                .collect(Collectors.joining(", "));
     }
 }

--- a/src/main/java/uk/gov/pay/adminusers/model/Feature.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Feature.java
@@ -1,8 +1,7 @@
 package uk.gov.pay.adminusers.model;
 
 public enum Feature {
-    TEST_FEATURE("test_feature"),
-    TEST_FEATURE_2("test_feature_2");
+    GOVUK_PSP_IS_ADYEN("govuk_psp_is_adyen");
 
     private final String value;
     

--- a/src/main/java/uk/gov/pay/adminusers/model/Service.java
+++ b/src/main/java/uk/gov/pay/adminusers/model/Service.java
@@ -365,11 +365,8 @@ public class Service {
 
     @Schema(example = """
             {
-              "test_feature": {
+              "govuk_psp_is_adyen": {
                 "enabled": true
-              },
-              "test_feature_2": {
-                "enabled": false
               }
             }
             """)

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceResource.java
@@ -276,8 +276,8 @@ public class ServiceResource {
                     "| replace | archived | true |\n" +
                     "| replace | went_live_date | 2022-04-09T18:07:46Z |\n" +
                     "| replace | default_billing_address_country | GB |\n " +
-                    "| add | feature | test_feature |\n " +
-                    "| remove | feature | test_feature |",
+                    "| add | feature | govuk_psp_is_adyen |\n " +
+                    "| remove | feature | govuk_psp_is_adyen |",
             requestBody = @RequestBody(content = @Content(array = @ArraySchema(schema = @Schema(implementation = ServiceUpdateRequest.class)))),
             responses = {
                     @ApiResponse(responseCode = "200", description = "OK",

--- a/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
+++ b/src/main/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidator.java
@@ -74,7 +74,7 @@ public class ServiceUpdateOperationValidator {
 
     private static final EnumSet<GoLiveStage> GO_LIVE_STAGES = EnumSet.allOf(GoLiveStage.class);
     private static final EnumSet<PspTestAccountStage> PSP_TEST_ACCOUNT_STAGES = EnumSet.allOf(PspTestAccountStage.class);
-    private static final Set<String> FEATURES = EnumSet.allOf(Feature.class)
+    public static final Set<String> FEATURES = EnumSet.allOf(Feature.class)
             .stream()
             .map(Feature::getValue)
             .collect(Collectors.toSet());

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateIT.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceResourceUpdateIT.java
@@ -108,7 +108,7 @@ class ServiceResourceUpdateIT extends IntegrationTest {
         String serviceExternalId = serviceDbFixture(databaseHelper).insertService().getExternalId();
         JsonNode payload = mapper
                 .valueToTree(List.of(
-                        patchRequest("add", "feature", "test_feature")));
+                        patchRequest("add", "feature", "govuk_psp_is_adyen")));
 
         givenSetup()
                 .when()
@@ -117,17 +117,17 @@ class ServiceResourceUpdateIT extends IntegrationTest {
                 .patch(format(SERVICE_RESOURCE, serviceExternalId))
                 .then()
                 .statusCode(200)
-                .body("service_features.test_feature.enabled", is(true));
+                .body("service_features.govuk_psp_is_adyen.enabled", is(true));
     }
 
     @Test
     void shouldRemoveFeature() {
-        Set<String> features = new HashSet<>(List.of("test_feature"));
+        Set<String> features = new HashSet<>(List.of("govuk_psp_is_adyen"));
         Service service = serviceDbFixture(databaseHelper).withFeatures(features).insertService();
         
         JsonNode payload = mapper
                 .valueToTree(List.of(
-                        patchRequest("remove", "feature", "test_feature")));
+                        patchRequest("remove", "feature", "govuk_psp_is_adyen")));
 
         givenSetup()
                 .when()
@@ -136,7 +136,7 @@ class ServiceResourceUpdateIT extends IntegrationTest {
                 .patch(format(SERVICE_RESOURCE, service.getExternalId()))
                 .then()
                 .statusCode(200)
-                .body("service_features.test_feature.enabled", is(false));
+                .body("service_features.govuk_psp_is_adyen.enabled", is(false));
     }
 
     private Map<String, Object> patchRequest(String op, String path, Object value) {

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import uk.gov.pay.adminusers.model.Feature;
 import uk.gov.pay.adminusers.validations.RequestValidations;
 
 import java.util.HashMap;
@@ -18,6 +17,7 @@ import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.adminusers.resources.ServiceUpdateOperationValidator.FEATURES;
 
 class ServiceUpdateOperationValidatorTest {
 
@@ -221,7 +221,7 @@ class ServiceUpdateOperationValidatorTest {
     
     @Test
     void addShouldFailWhenFeatureIsInvalid(){
-        var expectedErrorMessage = String.format("Field [value] must be one of [%s]", Feature.getValidValues());
+        var expectedErrorMessage = String.format("Field [value] must be one of %s", FEATURES);
         
         shouldFail("feature", "add", "invalidFeature", expectedErrorMessage);
     }

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import uk.gov.pay.adminusers.model.Feature;
 import uk.gov.pay.adminusers.validations.RequestValidations;
 
 import java.util.HashMap;
@@ -220,7 +221,9 @@ class ServiceUpdateOperationValidatorTest {
     
     @Test
     void addShouldFailWhenFeatureIsInvalid(){
-        shouldFail("feature", "add", "invalidFeature", "Field [value] must be one of [govuk_psp_is_adyen]");
+        var expectedErrorMessage = String.format("Field [value] must be one of [%s]", Feature.getValidValues());
+        
+        shouldFail("feature", "add", "invalidFeature", expectedErrorMessage);
     }
 
     private static Object[] shouldSucceedParams() {

--- a/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/resources/ServiceUpdateOperationValidatorTest.java
@@ -72,7 +72,7 @@ class ServiceUpdateOperationValidatorTest {
                 new Object[]{"add", "merchant_details/email", "any value"},
                 new Object[]{"add", "merchant_details/telephone_number", "any value"},
                 new Object[]{"add", "default_billing_address_country", "GB"},
-                new Object[]{"replace", "feature", "test_feature"},
+                new Object[]{"replace", "feature", "govuk_psp_is_adyen"},
         };
     }
 
@@ -220,7 +220,7 @@ class ServiceUpdateOperationValidatorTest {
     
     @Test
     void addShouldFailWhenFeatureIsInvalid(){
-        shouldFail("feature", "add", "invalidFeature", "Field [value] must be one of [test_feature, test_feature_2]");
+        shouldFail("feature", "add", "invalidFeature", "Field [value] must be one of [govuk_psp_is_adyen]");
     }
 
     private static Object[] shouldSucceedParams() {
@@ -252,8 +252,8 @@ class ServiceUpdateOperationValidatorTest {
                 new Object[]{"replace", "went_live_date", "2020-01-01T01:01:00Z"},
                 new Object[]{"replace", "default_billing_address_country", null},
                 new Object[]{"replace", "default_billing_address_country", "GB"},
-                new Object[]{"add", "feature", "test_feature"},
-                new Object[]{"remove", "feature", "test_feature"}
+                new Object[]{"add", "feature", "govuk_psp_is_adyen"},
+                new Object[]{"remove", "feature", "govuk_psp_is_adyen"}
         };
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceFindTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceFindTest.java
@@ -48,7 +48,7 @@ import static uk.gov.pay.adminusers.resources.ServiceUpdateOperationValidator.FE
 @ExtendWith(DropwizardExtensionsSupport.class)
 class ServiceResourceFindTest extends ServiceResourceBaseTest {
 
-    public static final int featureCount = FEATURES.size();
+    private static final int FEATURE_COUNT = FEATURES.size();
     private static ServiceDao mockedServiceDao = mock(ServiceDao.class);
     private static UserDao mockedUserDao = mock(UserDao.class);
 
@@ -101,7 +101,7 @@ class ServiceResourceFindTest extends ServiceResourceBaseTest {
         assertThat(json.get("collect_billing_address"), is(serviceEntity.isCollectBillingAddress()));
         assertThat(json.get("default_billing_address_country"), is(serviceEntity.getDefaultBillingAddressCountry()));
         assertThat(json.get("current_go_live_stage"), is(String.valueOf(serviceEntity.getCurrentGoLiveStage())));
-        assertThat(json.getMap("service_features"), aMapWithSize(featureCount));
+        assertThat(json.getMap("service_features"), aMapWithSize(FEATURE_COUNT));
         assertThat(json.get("service_features.govuk_psp_is_adyen.enabled"), is(false));
     }
 
@@ -190,7 +190,7 @@ class ServiceResourceFindTest extends ServiceResourceBaseTest {
         assertThat(json.get("sector"), is("police"));
         assertThat(json.get("internal"), is(false));
         assertThat(json.get("archived"), is(false));
-        assertThat(json.getMap("service_features"), aMapWithSize(featureCount));
+        assertThat(json.getMap("service_features"), aMapWithSize(FEATURE_COUNT));
         assertThat(json.get("service_features.govuk_psp_is_adyen.enabled"), is(true));
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceFindTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceFindTest.java
@@ -42,11 +42,13 @@ import static org.hamcrest.core.Is.is;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static uk.gov.pay.adminusers.app.util.RandomIdGenerator.randomUuid;
+import static uk.gov.pay.adminusers.resources.ServiceUpdateOperationValidator.FEATURES;
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(DropwizardExtensionsSupport.class)
 class ServiceResourceFindTest extends ServiceResourceBaseTest {
 
+    public static final int featureCount = FEATURES.size();
     private static ServiceDao mockedServiceDao = mock(ServiceDao.class);
     private static UserDao mockedUserDao = mock(UserDao.class);
 
@@ -99,7 +101,7 @@ class ServiceResourceFindTest extends ServiceResourceBaseTest {
         assertThat(json.get("collect_billing_address"), is(serviceEntity.isCollectBillingAddress()));
         assertThat(json.get("default_billing_address_country"), is(serviceEntity.getDefaultBillingAddressCountry()));
         assertThat(json.get("current_go_live_stage"), is(String.valueOf(serviceEntity.getCurrentGoLiveStage())));
-        assertThat(json.getMap("service_features"), aMapWithSize(1));
+        assertThat(json.getMap("service_features"), aMapWithSize(featureCount));
         assertThat(json.get("service_features.govuk_psp_is_adyen.enabled"), is(false));
     }
 
@@ -188,7 +190,7 @@ class ServiceResourceFindTest extends ServiceResourceBaseTest {
         assertThat(json.get("sector"), is("police"));
         assertThat(json.get("internal"), is(false));
         assertThat(json.get("archived"), is(false));
-        assertThat(json.getMap("service_features"), aMapWithSize(1));
+        assertThat(json.getMap("service_features"), aMapWithSize(featureCount));
         assertThat(json.get("service_features.govuk_psp_is_adyen.enabled"), is(true));
     }
 

--- a/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceFindTest.java
+++ b/src/test/java/uk/gov/pay/adminusers/unit/service/ServiceResourceFindTest.java
@@ -99,9 +99,8 @@ class ServiceResourceFindTest extends ServiceResourceBaseTest {
         assertThat(json.get("collect_billing_address"), is(serviceEntity.isCollectBillingAddress()));
         assertThat(json.get("default_billing_address_country"), is(serviceEntity.getDefaultBillingAddressCountry()));
         assertThat(json.get("current_go_live_stage"), is(String.valueOf(serviceEntity.getCurrentGoLiveStage())));
-        assertThat(json.getMap("service_features"), aMapWithSize(2));
-        assertThat(json.get("service_features.test_feature.enabled"), is(false));
-        assertThat(json.get("service_features.test_feature.enabled"), is(false));
+        assertThat(json.getMap("service_features"), aMapWithSize(1));
+        assertThat(json.get("service_features.govuk_psp_is_adyen.enabled"), is(false));
     }
 
     @Test
@@ -152,7 +151,7 @@ class ServiceResourceFindTest extends ServiceResourceBaseTest {
     void shouldFind_existingServiceByGatewayAccountId() {
         GatewayAccountIdEntity gatewayAccountIdEntity = new GatewayAccountIdEntity();
         String gatewayAccountId = randomUuid();
-        Set<String> features = new HashSet<>(List.of("test_feature"));
+        Set<String> features = new HashSet<>(List.of("govuk_psp_is_adyen"));
         gatewayAccountIdEntity.setGatewayAccountId(gatewayAccountId);
         ServiceEntity serviceEntity = ServiceEntityFixture.aServiceEntity()
                 .withGatewayAccounts(Collections.singletonList(gatewayAccountIdEntity))
@@ -189,9 +188,8 @@ class ServiceResourceFindTest extends ServiceResourceBaseTest {
         assertThat(json.get("sector"), is("police"));
         assertThat(json.get("internal"), is(false));
         assertThat(json.get("archived"), is(false));
-        assertThat(json.getMap("service_features"), aMapWithSize(2));
-        assertThat(json.get("service_features.test_feature.enabled"), is(true));
-        assertThat(json.get("service_features.test_feature_2.enabled"), is(false));
+        assertThat(json.getMap("service_features"), aMapWithSize(1));
+        assertThat(json.get("service_features.govuk_psp_is_adyen.enabled"), is(true));
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID
- Added `GOVUK_PSP_IS_ADYEN` to `Feature` enum and removed test features
- Added `getValidValues` to `Feature` enum and used in testing so that in the future new features only need adding to Feature enum
- Updated tests, schema and spec
